### PR TITLE
feat: Convert mcp-tasks-run to workflow-native orchestration

### DIFF
--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -189,7 +189,7 @@
     (some #(when (= sid (:psi.extension.workflow/id %)) %) (mcp-run-workflows))))
 
 (defn- active-running-workflow []
-  (first (filter :psi.extension.workflow/running? (mcp-run-workflows))))
+  (first (filter #(= :running (phase-of %)) (mcp-run-workflows))))
 
 (defn- run-id->n [run-id]
   (some->> (re-find #"run-(\\d+)$" (str run-id)) second parse-int))

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -1223,6 +1223,7 @@
                (some-> data (get-in [:_event :data :status]))
                :error)))
 
+(defn- result-running? [_ data] (= :running (ev-status data)))
 (defn- result-done? [_ data] (= :done (ev-status data)))
 (defn- result-paused? [_ data] (= :paused (ev-status data)))
 (defn- result-cancelled? [_ data] (= :cancelled (ev-status data)))
@@ -1351,6 +1352,10 @@
                            :type   :future
                            :params invoke-params
                            :src    run-loop-job})
+              (ele/transition {:event :done.invoke.runner
+                               :target :running
+                               :cond   result-running?}
+                              (ele/script {:expr apply-result-script}))
               (ele/transition {:event :done.invoke.runner
                                :target :done
                                :cond   result-done?}

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -1516,12 +1516,12 @@
 
 (defn- resume-run!
   [run-id merge? answer]
-  (if (active-running-workflow)
-    (println "Another run is currently running. Pause/cancel it before resuming another.")
-    (if-let [wf (workflow-by-id run-id)]
-      (let [phase      (phase-of wf)
-            data       (or (:psi.extension.workflow/data wf) {})
-            pause-rsn  (:run/pause-reason data)]
+  (if-let [wf (workflow-by-id run-id)]
+    (let [phase      (phase-of wf)
+          data       (or (:psi.extension.workflow/data wf) {})
+          pause-rsn  (:run/pause-reason data)]
+      (if (= phase :running)
+        (println (str run-id " is already running."))
         (if (not= phase :paused)
           (println (str run-id " is not paused."))
           (cond
@@ -1550,8 +1550,8 @@
                                 "."))
                   (refresh-widgets-later!))
                 (println (str "Failed to resume " run-id ": "
-                              (or (:psi.extension.workflow/error r) "unknown error"))))))))
-      (println (str "Run not found: " run-id)))))
+                              (or (:psi.extension.workflow/error r) "unknown error")))))))))
+    (println (str "Run not found: " run-id))))
 
 (defn- cancel-run!
   [run-id]
@@ -1583,22 +1583,26 @@
 
 (defn- retry-run!
   [run-id]
-  (if (active-running-workflow)
-    (println "Another run is currently running. Pause/cancel it before retrying another.")
-    (if-let [wf (workflow-by-id run-id)]
-      (if (not= :error (phase-of wf))
-        (println (str run-id " is not in error phase."))
-        (let [r (mutate! 'psi.extension.workflow/send-event
-                         {:id    (str run-id)
-                          :event :run/retry
-                          :data  {}})]
-          (if (:psi.extension.workflow/event-accepted? r)
-            (do
-              (println (str "Retrying " run-id " from current derived state."))
-              (refresh-widgets-later!))
-            (println (str "Failed to retry " run-id ": "
-                          (or (:psi.extension.workflow/error r) "unknown error"))))))
-      (println (str "Run not found: " run-id)))))
+  (if-let [wf (workflow-by-id run-id)]
+    (cond
+      (= :running (phase-of wf))
+      (println (str run-id " is already running."))
+
+      (not= :error (phase-of wf))
+      (println (str run-id " is not in error phase."))
+
+      :else
+      (let [r (mutate! 'psi.extension.workflow/send-event
+                       {:id    (str run-id)
+                        :event :run/retry
+                        :data  {}})]
+        (if (:psi.extension.workflow/event-accepted? r)
+          (do
+            (println (str "Retrying " run-id " from current derived state."))
+            (refresh-widgets-later!))
+          (println (str "Failed to retry " run-id ": "
+                        (or (:psi.extension.workflow/error r) "unknown error"))))))
+    (println (str "Run not found: " run-id))))
 
 (defn- remove-run-workflows!
   []

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -664,11 +664,11 @@
 (defn- run-step-subagent!
   [{:keys [run-id step-name prompt-body task-id entity-type
            project-dir worktree-dir task children state
-           user-confirmation user-answer]}]
+           user-confirmation user-answer get-api-key-fn]}]
   (let [started (now-ms)
         model   (resolve-active-model)
-        api-key (when-let [f (some-> @state :api :get-api-key)]
-                  (f (:provider model)))
+        api-key (when (fn? get-api-key-fn)
+                  (get-api-key-fn (:provider model)))
         req     (build-step-request {:step-name step-name
                                      :prompt-body prompt-body
                                      :task-id task-id
@@ -895,7 +895,8 @@
 
 (defn- run-loop-job
   [{:keys [run-id task-id project-dir worktree-dir control max-steps
-           current-state steps history user-confirmation user-answer]}]
+           current-state steps history user-confirmation user-answer
+           get-api-key-fn]}]
   (let [started-ms (now-ms)
         max-steps* (long (or max-steps max-steps-default))
         steps      (long (or steps 0))
@@ -1047,7 +1048,8 @@
                                        :children children
                                        :state step-state
                                        :user-confirmation user-confirmation
-                                       :user-answer user-answer})
+                                       :user-answer user-answer
+                                       :get-api-key-fn get-api-key-fn})
                         step-elapsed (- (now-ms) step-start)
                         base-entry   {:state      step-state
                                       :step       prompt-name
@@ -1216,7 +1218,8 @@
    :steps          (:run/steps-completed data)
    :history        (:run/history data)
    :user-confirmation (:run/user-confirmation data)
-   :user-answer    (:run/user-answer data)})
+   :user-answer    (:run/user-answer data)
+   :get-api-key-fn (:run/get-api-key-fn data)})
 
 (defn- ev-status [data]
   (keyword (or (some-> data (get-in [:_event :data :status]) name)
@@ -1403,6 +1406,7 @@
                                           :run/task-id        (long (:task-id input))
                                           :run/project-dir    (:project-dir input)
                                           :run/worktree-dir   (:worktree-dir input)
+                                          :run/get-api-key-fn (some-> @state :api :get-api-key)
                                           :run/entity-type    nil
                                           :run/current-state  :idle
                                           :run/pause-reason   nil

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -613,7 +613,7 @@
      "You are executing ONE mcp-tasks workflow step as a sub-agent.\n\n"
      "Step: " step-name "\n"
      "Entity: " (name entity-type) " #" task-id "\n"
-     "Current derived state: " (name derived-state) "\n"
+     "Current derived state: " (name state) "\n"
      "Project root: " project-dir "\n"
      "Worktree dir: " worktree-dir "\n\n"
 
@@ -686,7 +686,7 @@
     (set-live-progress!
      run-id
      {:status  :running
-      :state   derived-state
+      :state   state
       :step    step-name
       :message (str "Executing step " step-name)})
     (try
@@ -704,7 +704,7 @@
         (set-live-progress!
          run-id
          {:status  (if ok? :running :error)
-          :state   derived-state
+          :state   state
           :step    step-name
           :message (task-preview (or (some-> text str/split-lines last) "") 100)})
         {:ok?           ok?
@@ -715,7 +715,7 @@
         (set-live-progress!
          run-id
          {:status  :error
-          :state   derived-state
+          :state   state
           :step    step-name
           :message (str "Error: " (ex-message e))})
         {:ok?           false
@@ -773,17 +773,17 @@
   [{:keys [status run-id task-id entity-type worktree-dir current-state
            steps history last-step last-output final-state pause-reason
            user-confirmation user-answer started-ms error-message]}]
-  (let [elapsed  (- (now-ms) started-ms)
-        entity*  (or entity-type :task)
-        summary  (summarize-run {:status status
-                                 :run-id run-id
-                                 :task-id task-id
-                                 :entity-type entity*
-                                 :steps steps
-                                 :elapsed-ms elapsed
-                                 :final-state final-state
-                                 :pause-reason pause-reason
-                                 :error-message error-message})]
+  (let [elapsed (- (now-ms) started-ms)
+        entity* (or entity-type :task)
+        summary (summarize-run {:status        status
+                                :run-id        run-id
+                                :task-id       task-id
+                                :entity-type   entity*
+                                :steps         steps
+                                :elapsed-ms    elapsed
+                                :final-state   final-state
+                                :pause-reason  pause-reason
+                                :error-message error-message})]
     (cond-> {:status          status
              :run-id          run-id
              :task-id         task-id
@@ -802,290 +802,61 @@
       user-answer       (assoc :user-answer user-answer)
       error-message     (assoc :error-message error-message))))
 
-(defn- run-loop-job-legacy
-  [{:keys [run-id task-id project-dir worktree-dir control max-steps]}]
-  (let [started-ms (now-ms)
-        max-steps* (long (or max-steps max-steps-default))
-        ctrl0      (or (control-for run-id)
-                       (ensure-control! run-id))
-        ctrl       (if (instance? clojure.lang.IAtom ctrl0)
-                     ctrl0
-                     (atom {:pause? false :cancel? false :merge? false}))]
-    (try
-      (let [{wt :worktree-dir wt-error :error}
-            (if (seq worktree-dir)
-              {:worktree-dir worktree-dir}
-              (ensure-worktree! project-dir task-id))]
-        (if wt-error
-          (run-result {:status        :error
-                       :run-id        run-id
-                       :task-id       task-id
-                       :entity-type   :task
-                       :worktree-dir  worktree-dir
-                       :current-state :unknown
-                       :steps         0
-                       :history       []
-                       :started-ms    started-ms
-                       :error-message wt-error})
-
-          (loop [steps   0
-                 history []
-                 wt      wt]
-            (cond
-              (>= steps max-steps*)
-              (run-result {:status        :error
-                           :run-id        run-id
-                           :task-id       task-id
-                           :entity-type   :task
-                           :worktree-dir  wt
-                           :current-state (or (:next-state (last history)) :unknown)
-                           :steps         steps
-                           :history       history
-                           :started-ms    started-ms
-                           :error-message (str "Reached max steps (" max-steps* ")")})
-
-              (:cancel? @ctrl)
-              (run-result {:status        :cancelled
-                           :run-id        run-id
-                           :task-id       task-id
-                           :entity-type   :task
-                           :worktree-dir  wt
-                           :current-state (or (:next-state (last history)) :unknown)
-                           :steps         steps
-                           :history       history
-                           :started-ms    started-ms
-                           :final-state   :cancelled})
-
-              (:pause? @ctrl)
-              (run-result {:status        :paused
-                           :run-id        run-id
-                           :task-id       task-id
-                           :entity-type   :task
-                           :worktree-dir  wt
-                           :current-state (or (:next-state (last history)) :unknown)
-                           :steps         steps
-                           :history       history
-                           :started-ms    started-ms
-                           :pause-reason  :user-paused})
-
-              :else
-              (let [derived (derive-current! project-dir wt task-id)]
-                (if-let [err (:error derived)]
-                  (run-result {:status        :error
-                               :run-id        run-id
-                               :task-id       task-id
-                               :entity-type   :task
-                               :worktree-dir  wt
-                               :current-state :unknown
-                               :steps         steps
-                               :history       history
-                               :started-ms    started-ms
-                               :error-message err})
-
-                  (let [{:keys [task children entity-type state completed-count]} derived
-                        merge?     (:merge? @ctrl)
-                        step-state (if (and (= state :wait-pr-merge) merge?)
-                                     :merging-pr
-                                     state)]
-                    (cond
-                      (= state :terminated)
-                      (run-result {:status        :done
-                                   :run-id        run-id
-                                   :task-id       task-id
-                                   :entity-type   entity-type
-                                   :worktree-dir  wt
-                                   :current-state :terminated
-                                   :steps         steps
-                                   :history       history
-                                   :started-ms    started-ms
-                                   :final-state   :terminated})
-
-                      (and (= state :wait-pr-merge) (not merge?))
-                      (run-result {:status        :paused
-                                   :run-id        run-id
-                                   :task-id       task-id
-                                   :entity-type   entity-type
-                                   :worktree-dir  wt
-                                   :current-state state
-                                   :steps         steps
-                                   :history       history
-                                   :started-ms    started-ms
-                                   :pause-reason  :wait-pr-merge})
-
-                      :else
-                      (if-let [prompt-name (step-prompt-name entity-type step-state)]
-                        (let [prompt-body  (resolve-step-prompt project-dir prompt-name)
-                              step-start   (now-ms)
-                              _            (set-live-progress!
-                                            run-id
-                                            {:status  :running
-                                             :state   step-state
-                                             :step    prompt-name
-                                             :message (str "Executing " prompt-name)})
-                              step-result  (run-step-subagent!
-                                            {:run-id run-id
-                                             :step-name prompt-name
-                                             :prompt-body prompt-body
-                                             :task-id task-id
-                                             :entity-type entity-type
-                                             :project-dir project-dir
-                                             :worktree-dir wt
-                                             :task task
-                                             :children children
-                                             :derived-state step-state})
-                              step-elapsed (- (now-ms) step-start)
-                              base-entry   {:state      step-state
-                                            :step       prompt-name
-                                            :elapsed-ms step-elapsed
-                                            :output     (task-preview (:text step-result) 500)}]
-
-                          (if-not (:ok? step-result)
-                            (let [history' (conj history (assoc base-entry :ok? false))]
-                              (run-result {:status        :error
-                                           :run-id        run-id
-                                           :task-id       task-id
-                                           :entity-type   entity-type
-                                           :worktree-dir  wt
-                                           :current-state step-state
-                                           :steps         steps
-                                           :history       history'
-                                           :last-step     prompt-name
-                                           :last-output   (task-preview (:text step-result) 500)
-                                           :started-ms    started-ms
-                                           :error-message (or (:error-message step-result)
-                                                              (:text step-result)
-                                                              "Step failed")}))
-
-                            (do
-                              (when (= step-state :merging-pr)
-                                (swap! ctrl assoc :merge? false))
-                              (let [derived2 (derive-current! project-dir wt task-id)]
-                                (if-let [err2 (:error derived2)]
-                                  (let [history' (conj history (assoc base-entry :ok? true))]
-                                    (run-result {:status        :error
-                                                 :run-id        run-id
-                                                 :task-id       task-id
-                                                 :entity-type   entity-type
-                                                 :worktree-dir  wt
-                                                 :current-state step-state
-                                                 :steps         steps
-                                                 :history       history'
-                                                 :last-step     prompt-name
-                                                 :last-output   (task-preview (:text step-result) 500)
-                                                 :started-ms    started-ms
-                                                 :error-message err2}))
-
-                                  (let [next-state      (:state derived2)
-                                        next-completed  (:completed-count derived2)
-                                        progress?       (not (no-progress? state next-state
-                                                                           completed-count
-                                                                           next-completed))
-                                        history-entry   (assoc base-entry
-                                                               :ok? true
-                                                               :next-state next-state
-                                                               :completed-count next-completed)
-                                        history'        (conj history history-entry)]
-                                    (if-not progress?
-                                      (run-result {:status        :error
-                                                   :run-id        run-id
-                                                   :task-id       task-id
-                                                   :entity-type   entity-type
-                                                   :worktree-dir  wt
-                                                   :current-state next-state
-                                                   :steps         (inc steps)
-                                                   :history       history'
-                                                   :last-step     prompt-name
-                                                   :last-output   (task-preview (:text step-result) 500)
-                                                   :started-ms    started-ms
-                                                   :error-message (str "No progress after step " prompt-name
-                                                                       ", state remained " (name next-state))})
-
-                                      (do
-                                        (set-live-progress!
-                                         run-id
-                                         {:status  :running
-                                          :state   next-state
-                                          :step    prompt-name
-                                          :message (str "Advanced to " (name next-state))})
-                                        (recur (inc steps) history' wt)))))))))
-
-                        (run-result {:status        :error
-                                     :run-id        run-id
-                                     :task-id       task-id
-                                     :entity-type   entity-type
-                                     :worktree-dir  wt
-                                     :current-state step-state
-                                     :steps         steps
-                                     :history       history
-                                     :started-ms    started-ms
-                                     :error-message (str "No prompt mapping for state " (name step-state))}))))))))))
-      (catch Exception e
-        (run-result {:status        :error
-                     :run-id        run-id
-                     :task-id       task-id
-                     :entity-type   :task
-                     :worktree-dir  worktree-dir
-                     :current-state :unknown
-                     :steps         0
-                     :history       []
-                     :started-ms    started-ms
-                     :error-message (or (ex-message e) "Unexpected run failure")})))))
-
 ;; ---------------------------------------------------------------------------
 ;; UI refresh
 ;; ---------------------------------------------------------------------------
 
 (defn- widget-lines
   [wf]
-  (let [id         (:psi.extension.workflow/id wf)
-        phase      (phase-of wf)
-        data       (or (:psi.extension.workflow/data wf) {})
-        live       (get @(:live-progress @state) (str id))
-        task-id    (or (:run/task-id data)
-                       (get-in wf [:psi.extension.workflow/input :task-id]))
-        entity     (or (:run/entity-type data) :task)
-        cur-state  (or (:state live)
-                       (:run/current-state data)
-                       :unknown)
-        cur-step   (or (:step live)
-                       (:run/last-step data)
-                       "-")
-        message    (or (:message live)
-                       (:run/last-output data)
-                       (:psi.extension.workflow/error-message wf)
-                       "")
-        elapsed    (elapsed-seconds wf)
-        pause-rsn  (:run/pause-reason data)
-        top        (str (status-icon phase)
-                        " mcp-run " id
-                        " [" (phase-label phase) "]"
-                        " · " (name entity) " #" task-id
-                        " · state " (name (or cur-state :unknown))
-                        " · step " cur-step
-                        " · " elapsed "s")
-        detail     (when (seq (str/trim (str message)))
-                     (str "  " (task-preview (str/trim (str message)) 100)))
-        actions    (cond
-                     (= phase :running)
-                     (str "  /mcp-tasks-run pause " id " · /mcp-tasks-run cancel " id)
+  (let [id        (:psi.extension.workflow/id wf)
+        phase     (phase-of wf)
+        data      (or (:psi.extension.workflow/data wf) {})
+        live      (get @(:live-progress @state) (str id))
+        task-id   (or (:run/task-id data)
+                      (get-in wf [:psi.extension.workflow/input :task-id]))
+        entity    (or (:run/entity-type data) :task)
+        cur-state (or (:state live)
+                      (:run/current-state data)
+                      :unknown)
+        cur-step  (or (:step live)
+                      (:run/last-step data)
+                      "-")
+        message   (or (:message live)
+                      (:run/last-output data)
+                      (:psi.extension.workflow/error-message wf)
+                      "")
+        elapsed   (elapsed-seconds wf)
+        pause-rsn (:run/pause-reason data)
+        top       (str (status-icon phase)
+                       " mcp-run " id
+                       " [" (phase-label phase) "]"
+                       " · " (name entity) " #" task-id
+                       " · state " (name (or cur-state :unknown))
+                       " · step " cur-step
+                       " · " elapsed "s")
+        detail    (when (seq (str/trim (str message)))
+                    (str "  " (task-preview (str/trim (str message)) 100)))
+        actions   (cond
+                    (= phase :running)
+                    (str "  /mcp-tasks-run pause " id " · /mcp-tasks-run cancel " id)
 
-                     (= phase :paused)
-                     (cond
-                       (= pause-rsn :wait-pr-merge)
-                       (str "  /mcp-tasks-run resume " id " merge · /mcp-tasks-run cancel " id)
+                    (= phase :paused)
+                    (cond
+                      (= pause-rsn :wait-pr-merge)
+                      (str "  /mcp-tasks-run resume " id " merge · /mcp-tasks-run cancel " id)
 
-                       (= pause-rsn :wait-user-confirmation)
-                       (str "  /mcp-tasks-run resume " id " <answer> · /mcp-tasks-run cancel " id)
+                      (= pause-rsn :wait-user-confirmation)
+                      (str "  /mcp-tasks-run resume " id " <answer> · /mcp-tasks-run cancel " id)
 
-                       :else
-                       (str "  /mcp-tasks-run resume " id " · /mcp-tasks-run cancel " id))
+                      :else
+                      (str "  /mcp-tasks-run resume " id " · /mcp-tasks-run cancel " id))
 
-                     (= phase :error)
-                     (str "  /mcp-tasks-run retry " id " · /mcp-tasks-run cancel " id)
+                    (= phase :error)
+                    (str "  /mcp-tasks-run retry " id " · /mcp-tasks-run cancel " id)
 
-                     :else nil)]
+                    :else nil)]
     (cond-> [top]
-      (seq detail) (conj detail)
+      (seq detail)  (conj detail)
       (seq actions) (conj actions))))
 
 (defn- refresh-widgets!
@@ -1120,9 +891,7 @@
     (Thread/sleep 25)
     (refresh-widgets!)))
 
-;; ---------------------------------------------------------------------------
-;; Workflow-native step runner (overrides legacy loop by redefining var)
-;; ---------------------------------------------------------------------------
+;;; Workflow-native step runner
 
 (defn- run-loop-job
   [{:keys [run-id task-id project-dir worktree-dir control max-steps
@@ -1223,7 +992,7 @@
                          :started-ms    started-ms
                          :error-message err})
             (let [{:keys [task children entity-type state completed-count]} derived
-                  step-state (if (and (= state :wait-pr-merge) merge?) :merging-pr state)]
+                  step-state                                                (if (and (= state :wait-pr-merge) merge?) :merging-pr state)]
               (cond
                 (= state :terminated)
                 (run-result {:status        :done

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -8,7 +8,7 @@
      /mcp-tasks-run <task-id>
      /mcp-tasks-run list
      /mcp-tasks-run pause <run-id>
-     /mcp-tasks-run resume <run-id> [merge]
+     /mcp-tasks-run resume <run-id> [merge|<answer>]
      /mcp-tasks-run cancel <run-id>
      /mcp-tasks-run retry <run-id>
 
@@ -82,21 +82,23 @@
         "6) Summarize PR URL and PR number.")})
 
 (def ^:private task-state->prompt
-  {:unrefined    "refine-task"
-   :refined      "execute-task"
-   :done         "review-task-implementation"
-   :awaiting-pr  "create-task-pr"
-   :merging-pr   "squash-merge-on-gh"
-   :complete     "complete-story"})
+  {:unrefined              "refine-task"
+   :refined                "execute-task"
+   :wait-user-confirmation "execute-task"
+   :done                   "review-task-implementation"
+   :awaiting-pr            "create-task-pr"
+   :merging-pr             "squash-merge-on-gh"
+   :complete               "complete-story"})
 
 (def ^:private story-state->prompt
-  {:unrefined    "refine-task"
-   :refined      "create-story-tasks"
-   :has-tasks    "execute-story-child"
-   :done         "review-story-implementation"
-   :awaiting-pr  "create-story-pr"
-   :merging-pr   "squash-merge-on-gh"
-   :complete     "complete-story"})
+  {:unrefined              "refine-task"
+   :refined                "create-story-tasks"
+   :has-tasks              "execute-story-child"
+   :wait-user-confirmation "execute-story-child"
+   :done                   "review-story-implementation"
+   :awaiting-pr            "create-story-pr"
+   :merging-pr             "squash-merge-on-gh"
+   :complete               "complete-story"})
 
 ;; ---------------------------------------------------------------------------
 ;; Basics
@@ -315,6 +317,29 @@
 (defn- safe-read-string [s]
   (binding [*read-eval* false]
     (read-string (str/replace (or s "") #":::(\w)" ":$1"))))
+
+(def ^:private user-confirmation-prefix "MCP_TASKS_RUN_USER_CONFIRMATION:")
+
+(defn- parse-user-confirmation
+  [text]
+  (let [line (some->> (str/split-lines (or text ""))
+                      (map str/trim)
+                      (filter #(str/starts-with? % user-confirmation-prefix))
+                      first)
+        payload-str (some-> line
+                            (subs (count user-confirmation-prefix))
+                            str/trim)]
+    (when (seq payload-str)
+      (try
+        (let [m (safe-read-string payload-str)]
+          (when (map? m)
+            {:question      (or (:question m) (:prompt m))
+             :context       (:context m)
+             :expected      (or (:expected-answer m)
+                                (:expected-answer-shape m)
+                                :free-text)
+             :raw           m}))
+        (catch Exception _ nil)))))
 
 (defn- run-shell
   [{:keys [dir args]}]
@@ -581,7 +606,8 @@
 
 (defn- build-step-request
   [{:keys [step-name prompt-body task-id entity-type
-           project-dir worktree-dir task children derived-state]}]
+           project-dir worktree-dir task children state
+           user-confirmation user-answer]}]
   (let [prompt* (interpolate-arguments prompt-body task-id)]
     (str
      "You are executing ONE mcp-tasks workflow step as a sub-agent.\n\n"
@@ -618,6 +644,18 @@
        (str "Current story children snapshot (EDN):\n"
             (pr-str children) "\n\n"))
 
+     (when (= :wait-user-confirmation state)
+       (str "Workflow is waiting for explicit user confirmation answer.\n"
+            "Current confirmation payload (EDN):\n"
+            (pr-str user-confirmation) "\n\n"
+            "You must provide a deterministic safe answer and call:\n"
+            "mcp-tasks-run resume <run-id> <answer>\n"
+            "using available extension command mechanism if present; otherwise set answer in workflow data via CLI-supported path.\n\n"))
+
+     (when user-answer
+       (str "Resume answer payload provided for this step (EDN):\n"
+            (pr-str user-answer) "\n\n"))
+
      "Return a concise summary with:\n"
      "1) actions taken\n"
      "2) key outputs\n"
@@ -625,7 +663,8 @@
 
 (defn- run-step-subagent!
   [{:keys [run-id step-name prompt-body task-id entity-type
-           project-dir worktree-dir task children derived-state]}]
+           project-dir worktree-dir task children state
+           user-confirmation user-answer]}]
   (let [started (now-ms)
         model   (resolve-active-model)
         api-key (when-let [f (some-> @state :api :get-api-key)]
@@ -638,7 +677,9 @@
                                      :worktree-dir worktree-dir
                                      :task task
                                      :children children
-                                     :derived-state derived-state})
+                                     :state state
+                                     :user-confirmation user-confirmation
+                                     :user-answer user-answer})
         user-msg {:role      "user"
                   :content   [{:type :text :text req}]
                   :timestamp (java.time.Instant/now)}]
@@ -691,7 +732,7 @@
   (let [run-id (str run-id)
         a      (:run-controls @state)]
     (or (get @a run-id)
-        (let [ctrl (atom {:pause? false :cancel? false :merge? false})]
+        (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
           (swap! a assoc run-id ctrl)
           ctrl))))
 
@@ -731,7 +772,7 @@
 (defn- run-result
   [{:keys [status run-id task-id entity-type worktree-dir current-state
            steps history last-step last-output final-state pause-reason
-           started-ms error-message]}]
+           user-confirmation user-answer started-ms error-message]}]
   (let [elapsed  (- (now-ms) started-ms)
         entity*  (or entity-type :task)
         summary  (summarize-run {:status status
@@ -755,12 +796,14 @@
              :last-output     last-output
              :elapsed-ms      elapsed
              :summary         summary}
-      final-state   (assoc :final-state final-state)
-      pause-reason  (assoc :pause-reason pause-reason)
-      error-message (assoc :error-message error-message))))
+      final-state       (assoc :final-state final-state)
+      pause-reason      (assoc :pause-reason pause-reason)
+      user-confirmation (assoc :user-confirmation user-confirmation)
+      user-answer       (assoc :user-answer user-answer)
+      error-message     (assoc :error-message error-message))))
 
-(defn- run-loop-job
-  [{:keys [run-id task-id project-dir worktree-dir max-steps]}]
+(defn- run-loop-job-legacy
+  [{:keys [run-id task-id project-dir worktree-dir control max-steps]}]
   (let [started-ms (now-ms)
         max-steps* (long (or max-steps max-steps-default))
         ctrl0      (or (control-for run-id)
@@ -1027,8 +1070,14 @@
                      (str "  /mcp-tasks-run pause " id " · /mcp-tasks-run cancel " id)
 
                      (= phase :paused)
-                     (if (= pause-rsn :wait-pr-merge)
+                     (cond
+                       (= pause-rsn :wait-pr-merge)
                        (str "  /mcp-tasks-run resume " id " merge · /mcp-tasks-run cancel " id)
+
+                       (= pause-rsn :wait-user-confirmation)
+                       (str "  /mcp-tasks-run resume " id " <answer> · /mcp-tasks-run cancel " id)
+
+                       :else
                        (str "  /mcp-tasks-run resume " id " · /mcp-tasks-run cancel " id))
 
                      (= phase :error)
@@ -1072,6 +1121,290 @@
     (refresh-widgets!)))
 
 ;; ---------------------------------------------------------------------------
+;; Workflow-native step runner (overrides legacy loop by redefining var)
+;; ---------------------------------------------------------------------------
+
+(defn- run-loop-job
+  [{:keys [run-id task-id project-dir worktree-dir control max-steps
+           current-state steps history user-confirmation user-answer]}]
+  (let [started-ms (now-ms)
+        max-steps* (long (or max-steps max-steps-default))
+        steps      (long (or steps 0))
+        history    (vec (or history []))
+        phase      (or current-state :ensure-worktree)
+        merge?     (boolean (:merge? @control))
+        answer     (or (:answer @control) user-answer)]
+    (try
+      (cond
+        (>= steps max-steps*)
+        (run-result {:status        :error
+                     :run-id        run-id
+                     :task-id       task-id
+                     :worktree-dir  worktree-dir
+                     :current-state phase
+                     :steps         steps
+                     :history       history
+                     :started-ms    started-ms
+                     :error-message (str "Reached max steps (" max-steps* ")")})
+
+        (:cancel? @control)
+        (run-result {:status        :cancelled
+                     :run-id        run-id
+                     :task-id       task-id
+                     :worktree-dir  worktree-dir
+                     :current-state phase
+                     :steps         steps
+                     :history       history
+                     :started-ms    started-ms
+                     :final-state   :cancelled})
+
+        (and (:pause? @control)
+             (not (contains? #{:wait-pr-merge :wait-user-confirmation} phase)))
+        (run-result {:status        :paused
+                     :run-id        run-id
+                     :task-id       task-id
+                     :worktree-dir  worktree-dir
+                     :current-state :paused
+                     :steps         steps
+                     :history       history
+                     :started-ms    started-ms
+                     :pause-reason  :user-paused})
+
+        (= phase :ensure-worktree)
+        (let [{wt :worktree-dir wt-error :error}
+              (if (seq worktree-dir)
+                {:worktree-dir worktree-dir}
+                (ensure-worktree! project-dir task-id))]
+          (if wt-error
+            (run-result {:status        :error
+                         :run-id        run-id
+                         :task-id       task-id
+                         :worktree-dir  worktree-dir
+                         :current-state phase
+                         :steps         steps
+                         :history       history
+                         :started-ms    started-ms
+                         :error-message wt-error})
+            (run-result {:status        :running
+                         :run-id        run-id
+                         :task-id       task-id
+                         :worktree-dir  wt
+                         :current-state :derive-state
+                         :steps         steps
+                         :history       history
+                         :started-ms    started-ms})))
+
+        (and (= phase :wait-user-confirmation)
+             (str/blank? (str answer)))
+        (run-result {:status            :paused
+                     :run-id            run-id
+                     :task-id           task-id
+                     :worktree-dir      worktree-dir
+                     :current-state     :wait-user-confirmation
+                     :steps             steps
+                     :history           history
+                     :started-ms        started-ms
+                     :pause-reason      :wait-user-confirmation
+                     :user-confirmation user-confirmation
+                     :user-answer       nil
+                     :error-message     "Resume requires explicit answer payload for user confirmation."})
+
+        (contains? #{:derive-state :select-step :run-step :rederive-state
+                     :wait-pr-merge :wait-user-confirmation} phase)
+        (let [derived (derive-current! project-dir worktree-dir task-id)]
+          (if-let [err (:error derived)]
+            (run-result {:status        :error
+                         :run-id        run-id
+                         :task-id       task-id
+                         :worktree-dir  worktree-dir
+                         :current-state phase
+                         :steps         steps
+                         :history       history
+                         :started-ms    started-ms
+                         :error-message err})
+            (let [{:keys [task children entity-type state completed-count]} derived
+                  step-state (if (and (= state :wait-pr-merge) merge?) :merging-pr state)]
+              (cond
+                (= state :terminated)
+                (run-result {:status        :done
+                             :run-id        run-id
+                             :task-id       task-id
+                             :entity-type   entity-type
+                             :worktree-dir  worktree-dir
+                             :current-state :done
+                             :steps         steps
+                             :history       history
+                             :started-ms    started-ms
+                             :final-state   :terminated})
+
+                (and (= state :wait-pr-merge) (not merge?))
+                (run-result {:status        :paused
+                             :run-id        run-id
+                             :task-id       task-id
+                             :entity-type   entity-type
+                             :worktree-dir  worktree-dir
+                             :current-state :wait-pr-merge
+                             :steps         steps
+                             :history       history
+                             :started-ms    started-ms
+                             :pause-reason  :wait-pr-merge})
+
+                (= state :wait-user-confirmation)
+                (run-result {:status            :paused
+                             :run-id            run-id
+                             :task-id           task-id
+                             :entity-type       entity-type
+                             :worktree-dir      worktree-dir
+                             :current-state     :wait-user-confirmation
+                             :steps             steps
+                             :history           history
+                             :started-ms        started-ms
+                             :pause-reason      :wait-user-confirmation
+                             :user-confirmation user-confirmation})
+
+                :else
+                (if-let [prompt-name (step-prompt-name entity-type step-state)]
+                  (let [prompt-body  (resolve-step-prompt project-dir prompt-name)
+                        step-start   (now-ms)
+                        step-result  (run-step-subagent!
+                                      {:run-id run-id
+                                       :step-name prompt-name
+                                       :prompt-body prompt-body
+                                       :task-id task-id
+                                       :entity-type entity-type
+                                       :project-dir project-dir
+                                       :worktree-dir worktree-dir
+                                       :task task
+                                       :children children
+                                       :state step-state
+                                       :user-confirmation user-confirmation
+                                       :user-answer user-answer})
+                        step-elapsed (- (now-ms) step-start)
+                        base-entry   {:state      step-state
+                                      :step       prompt-name
+                                      :elapsed-ms step-elapsed
+                                      :output     (task-preview (:text step-result) 500)}]
+                    (if-not (:ok? step-result)
+                      (let [history' (conj history (assoc base-entry :ok? false))]
+                        (run-result {:status        :error
+                                     :run-id        run-id
+                                     :task-id       task-id
+                                     :entity-type   entity-type
+                                     :worktree-dir  worktree-dir
+                                     :current-state step-state
+                                     :steps         steps
+                                     :history       history'
+                                     :last-step     prompt-name
+                                     :last-output   (task-preview (:text step-result) 500)
+                                     :started-ms    started-ms
+                                     :error-message (or (:error-message step-result)
+                                                        (:text step-result)
+                                                        "Step failed")}))
+                      (let [confirmation (parse-user-confirmation (:text step-result))
+                            history'     (conj history (assoc base-entry :ok? true))]
+                        (if confirmation
+                          (do
+                            (when (instance? clojure.lang.IAtom control)
+                              (swap! control assoc :answer nil :pause? false))
+                            (run-result {:status            :paused
+                                         :run-id            run-id
+                                         :task-id           task-id
+                                         :entity-type       entity-type
+                                         :worktree-dir      worktree-dir
+                                         :current-state     :wait-user-confirmation
+                                         :steps             (inc steps)
+                                         :history           history'
+                                         :last-step         prompt-name
+                                         :last-output       (task-preview (:text step-result) 500)
+                                         :started-ms        started-ms
+                                         :pause-reason      :wait-user-confirmation
+                                         :user-confirmation confirmation
+                                         :user-answer       nil}))
+                          (let [derived2 (derive-current! project-dir worktree-dir task-id)]
+                            (if-let [err2 (:error derived2)]
+                              (run-result {:status        :error
+                                           :run-id        run-id
+                                           :task-id       task-id
+                                           :entity-type   entity-type
+                                           :worktree-dir  worktree-dir
+                                           :current-state step-state
+                                           :steps         steps
+                                           :history       history'
+                                           :last-step     prompt-name
+                                           :last-output   (task-preview (:text step-result) 500)
+                                           :started-ms    started-ms
+                                           :error-message err2})
+                              (let [next-state     (:state derived2)
+                                    next-completed (:completed-count derived2)
+                                    progress?      (not (no-progress? state next-state
+                                                                      completed-count
+                                                                      next-completed))
+                                    history-entry  (assoc base-entry
+                                                          :ok? true
+                                                          :next-state next-state
+                                                          :completed-count next-completed)
+                                    history''      (conj history history-entry)]
+                                (if-not progress?
+                                  (run-result {:status        :error
+                                               :run-id        run-id
+                                               :task-id       task-id
+                                               :entity-type   entity-type
+                                               :worktree-dir  worktree-dir
+                                               :current-state next-state
+                                               :steps         (inc steps)
+                                               :history       history''
+                                               :last-step     prompt-name
+                                               :last-output   (task-preview (:text step-result) 500)
+                                               :started-ms    started-ms
+                                               :error-message (str "No progress after step " prompt-name
+                                                                   ", state remained " (name next-state))})
+                                  (do
+                                    (when (= step-state :merging-pr)
+                                      (swap! control assoc :merge? false))
+                                    (run-result {:status        :running
+                                                 :run-id        run-id
+                                                 :task-id       task-id
+                                                 :entity-type   entity-type
+                                                 :worktree-dir  worktree-dir
+                                                 :current-state :derive-state
+                                                 :steps         (inc steps)
+                                                 :history       history''
+                                                 :last-step     prompt-name
+                                                 :last-output   (task-preview (:text step-result) 500)
+                                                 :started-ms    started-ms}))))))))))
+                  (run-result {:status        :error
+                               :run-id        run-id
+                               :task-id       task-id
+                               :entity-type   entity-type
+                               :worktree-dir  worktree-dir
+                               :current-state step-state
+                               :steps         steps
+                               :history       history
+                               :started-ms    started-ms
+                               :error-message (str "No prompt mapping for state " (name step-state))}))))))
+
+        :else
+        (run-result {:status        :error
+                     :run-id        run-id
+                     :task-id       task-id
+                     :worktree-dir  worktree-dir
+                     :current-state phase
+                     :steps         steps
+                     :history       history
+                     :started-ms    started-ms
+                     :error-message (str "Unknown workflow phase: " (name phase))}))
+      (catch Exception e
+        (run-result {:status        :error
+                     :run-id        run-id
+                     :task-id       task-id
+                     :worktree-dir  worktree-dir
+                     :current-state phase
+                     :steps         steps
+                     :history       history
+                     :started-ms    started-ms
+                     :error-message (or (ex-message e) "Unexpected run failure")})))))
+
+;; ---------------------------------------------------------------------------
 ;; Workflow chart
 ;; ---------------------------------------------------------------------------
 
@@ -1081,15 +1414,15 @@
         control (or (control-for run-id)
                     (ensure-control! run-id))]
     (when (instance? clojure.lang.IAtom control)
-      (reset! control {:pause? false :cancel? false :merge? false}))
+      (reset! control {:pause? false :cancel? false :merge? false :answer nil}))
     (set-live-progress!
      run-id
      {:status  :running
-      :state   :initializing
-      :step    "init"
+      :state   :ensure-worktree
+      :step    "ensure-worktree"
       :message "Starting run"})
     [{:op :assign
-      :data {:run/current-state   :initializing
+      :data {:run/current-state   :ensure-worktree
              :run/entity-type     nil
              :run/pause-reason    nil
              :run/final-state     nil
@@ -1097,16 +1430,24 @@
              :run/last-output     nil
              :run/steps-completed 0
              :run/history         []
+             :run/user-confirmation nil
+             :run/user-answer     nil
              :workflow/error-message nil
              :workflow/result     nil}}]))
 
 (defn- invoke-params
   [_ data]
-  {:run-id       (:run/id data)
-   :task-id      (:run/task-id data)
-   :project-dir  (:run/project-dir data)
-   :worktree-dir (:run/worktree-dir data)
-   :max-steps    (:run/max-steps data)})
+  {:run-id         (:run/id data)
+   :task-id        (:run/task-id data)
+   :project-dir    (:run/project-dir data)
+   :worktree-dir   (:run/worktree-dir data)
+   :control        (:run/control data)
+   :max-steps      (:run/max-steps data)
+   :current-state  (:run/current-state data)
+   :steps          (:run/steps-completed data)
+   :history        (:run/history data)
+   :user-confirmation (:run/user-confirmation data)
+   :user-answer    (:run/user-answer data)})
 
 (defn- ev-status [data]
   (keyword (or (some-> data (get-in [:_event :data :status]) name)
@@ -1116,6 +1457,30 @@
 (defn- result-done? [_ data] (= :done (ev-status data)))
 (defn- result-paused? [_ data] (= :paused (ev-status data)))
 (defn- result-cancelled? [_ data] (= :cancelled (ev-status data)))
+
+(defn- merge-resume-outside-gate?
+  [_ data]
+  (let [merge?    (boolean (get-in data [:_event :data :merge?]))
+        pause-rsn (:run/pause-reason data)]
+    (and merge? (not= pause-rsn :wait-pr-merge))))
+
+(defn- reject-merge-resume-script
+  [_ data]
+  (let [control (:run/control data)
+        run-id  (:run/id data)
+        msg     "Merge authorization is only valid at :wait-pr-merge gate. Resume without merge until gate is reached."]
+    (when (instance? clojure.lang.IAtom control)
+      (swap! control assoc :merge? false))
+    (set-live-progress!
+     run-id
+     {:status  :paused
+      :state   :paused
+      :step    "resume"
+      :message msg})
+    [{:op :assign
+      :data {:run/pause-reason :merge-not-authorized
+             :run/last-output msg
+             :workflow/error-message nil}}]))
 
 (defn- apply-result-script
   [_ data]
@@ -1144,6 +1509,8 @@
                      :run/worktree-dir      (:worktree-dir ev)
                      :run/steps-completed   (long (or (:steps-completed ev) 0))
                      :run/history           (vec (or (:history ev) []))
+                     :run/user-confirmation (:user-confirmation ev)
+                     :run/user-answer       (:user-answer ev)
                      :workflow/result       (:summary ev)
                      :workflow/error-message nil}
               (= status :error)
@@ -1154,20 +1521,24 @@
 
 (defn- resume-script
   [_ data]
-  (let [run-id  (:run/id data)
-        control (or (control-for run-id)
-                    (ensure-control! run-id))
-        merge?  (boolean (get-in data [:_event :data :merge?]))]
+  (let [control (:run/control data)
+        merge?  (boolean (get-in data [:_event :data :merge?]))
+        answer  (get-in data [:_event :data :answer])
+        run-id  (:run/id data)]
     (when (instance? clojure.lang.IAtom control)
-      (swap! control assoc :pause? false :cancel? false :merge? merge?))
+      (swap! control assoc :pause? false :cancel? false :merge? merge? :answer answer))
     (set-live-progress!
      run-id
      {:status  :running
       :state   :resuming
       :step    "resume"
-      :message (if merge? "Resuming with merge intent" "Resuming")})
+      :message (cond
+                 merge? "Resuming with merge intent"
+                 answer "Resuming with user answer"
+                 :else "Resuming")})
     [{:op :assign
       :data {:run/pause-reason nil
+             :run/user-answer answer
              :workflow/error-message nil}}]))
 
 (defn- retry-script
@@ -1176,7 +1547,7 @@
         control (or (control-for run-id)
                     (ensure-control! run-id))]
     (when (instance? clojure.lang.IAtom control)
-      (swap! control assoc :pause? false :cancel? false :merge? false))
+      (swap! control assoc :pause? false :cancel? false :merge? false :answer nil))
     (set-live-progress!
      run-id
      {:status  :running
@@ -1228,6 +1599,9 @@
                               (ele/script {:expr apply-result-script})))
 
    (ele/state {:id :paused}
+              (ele/transition {:event :run/resume :target :paused
+                               :cond merge-resume-outside-gate?}
+                              (ele/script {:expr reject-merge-resume-script}))
               (ele/transition {:event :run/resume :target :running}
                               (ele/script {:expr resume-script}))
               (ele/transition {:event :run/cancel :target :cancelled}
@@ -1263,6 +1637,9 @@
                                           :run/last-output    nil
                                           :run/steps-completed 0
                                           :run/history        []
+                                          :run/user-confirmation nil
+                                          :run/user-answer    nil
+                                          :run/control        (ensure-control! run-id)
                                           :run/max-steps      (long (or (:max-steps input)
                                                                         max-steps-default))}))
                     :public-data-fn  (fn [data]
@@ -1278,7 +1655,9 @@
                                                      :run/last-step
                                                      :run/last-output
                                                      :run/steps-completed
-                                                     :run/history]))})]
+                                                     :run/history
+                                                     :run/user-confirmation
+                                                     :run/user-answer]))})]
     (when-let [e (:psi.extension.workflow/error r)]
       (notify! (str "Failed to register mcp-tasks-run workflow type: " e) :error))))
 
@@ -1292,7 +1671,7 @@
    "  /mcp-tasks-run <task-id>\n"
    "  /mcp-tasks-run list\n"
    "  /mcp-tasks-run pause <run-id>\n"
-   "  /mcp-tasks-run resume <run-id> [merge]\n"
+   "  /mcp-tasks-run resume <run-id> [merge|<answer>]\n"
    "  /mcp-tasks-run cancel <run-id>\n"
    "  /mcp-tasks-run retry <run-id>"))
 
@@ -1367,7 +1746,7 @@
     (println (str "Run not found: " run-id))))
 
 (defn- resume-run!
-  [run-id merge?]
+  [run-id merge? answer]
   (if (active-running-workflow)
     (println "Another run is currently running. Pause/cancel it before resuming another.")
     (if-let [wf (workflow-by-id run-id)]
@@ -1376,17 +1755,29 @@
             pause-rsn  (:run/pause-reason data)]
         (if (not= phase :paused)
           (println (str run-id " is not paused."))
-          (if (and (= pause-rsn :wait-pr-merge) (not merge?))
+          (cond
+            (and (= pause-rsn :wait-pr-merge) (not merge?))
             (println (str "Run " run-id " is waiting for PR merge. "
                           "Use: /mcp-tasks-run resume " run-id " merge"))
+
+            (and (= pause-rsn :wait-user-confirmation)
+                 (str/blank? (str answer)))
+            (println (str "Run " run-id " is waiting for user confirmation. "
+                          "Use: /mcp-tasks-run resume " run-id " <answer>"))
+
+            :else
             (let [r (mutate! 'psi.extension.workflow/send-event
                              {:id    (str run-id)
                               :event :run/resume
-                              :data  {:merge? (boolean merge?)}})]
+                              :data  (cond-> {:merge? (boolean merge?)}
+                                       (seq (str answer)) (assoc :answer answer))})]
               (if (:psi.extension.workflow/event-accepted? r)
                 (do
                   (println (str "Resumed " run-id
-                                (when merge? " with merge intent")
+                                (cond
+                                  merge? " with merge intent"
+                                  (seq (str answer)) " with answer"
+                                  :else "")
                                 "."))
                   (refresh-widgets-later!))
                 (println (str "Failed to resume " run-id ": "
@@ -1468,8 +1859,9 @@
 
       (= "resume" cmd)
       (if-let [rid (second parts)]
-        (resume-run! rid (= "merge" (nth parts 2 nil)))
-        (println "Usage: /mcp-tasks-run resume <run-id> [merge]"))
+        (let [arg3 (nth parts 2 nil)]
+          (resume-run! rid (= "merge" arg3) (when (and arg3 (not= "merge" arg3)) arg3)))
+        (println "Usage: /mcp-tasks-run resume <run-id> [merge|<answer>]"))
 
       (= "cancel" cmd)
       (if-let [rid (second parts)]

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -72,3 +72,168 @@
 
         (let [out-list (with-out-str (handler "list"))]
           (is (re-find #"run-1" out-list)))))))
+
+(deftest workflow-native-step-progression-test
+  (testing "run-loop-job advances a single orchestration unit per invocation"
+    (let [ctrl            (atom {:pause? false :cancel? false :merge? false})
+          derived-states  (atom [:refined :done :done :terminated])]
+      (with-redefs [sut/ensure-worktree! (fn [_project-dir _task-id]
+                                           {:worktree-dir "/tmp/wt"})
+                    sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
+                                          (let [s (or (first @derived-states) :terminated)]
+                                            (swap! derived-states #(if (seq %) (vec (rest %)) %))
+                                            {:task {:id 42 :type :task}
+                                             :children []
+                                             :entity-type :task
+                                             :state s
+                                             :completed-count nil}))
+                    sut/resolve-step-prompt (fn [_project-dir _prompt-name] "prompt")
+                    sut/run-step-subagent! (fn [_] {:ok? true :text "ok"})]
+        (let [step-1 (#'sut/run-loop-job {:run-id "run-1"
+                                          :task-id 42
+                                          :project-dir "/tmp"
+                                          :worktree-dir nil
+                                          :control ctrl
+                                          :current-state :ensure-worktree
+                                          :steps 0
+                                          :history []
+                                          :max-steps 10})
+              step-2 (#'sut/run-loop-job {:run-id "run-1"
+                                          :task-id 42
+                                          :project-dir "/tmp"
+                                          :worktree-dir (:worktree-dir step-1)
+                                          :control ctrl
+                                          :current-state (:current-state step-1)
+                                          :steps (:steps-completed step-1)
+                                          :history (:history step-1)
+                                          :max-steps 10})
+              step-3 (#'sut/run-loop-job {:run-id "run-1"
+                                          :task-id 42
+                                          :project-dir "/tmp"
+                                          :worktree-dir (:worktree-dir step-2)
+                                          :control ctrl
+                                          :current-state (:current-state step-2)
+                                          :steps (:steps-completed step-2)
+                                          :history (:history step-2)
+                                          :max-steps 10})]
+          (is (= :running (:status step-1)))
+          (is (= :derive-state (:current-state step-1)))
+          (is (= :running (:status step-2)))
+          (is (= :derive-state (:current-state step-2)))
+          (is (= 1 (:steps-completed step-2)))
+          (is (= 1 (count (:history step-2))))
+          (is (= :running (:status step-3)))
+          (is (= :derive-state (:current-state step-3)))
+          (is (= 2 (:steps-completed step-3))))))))
+
+(deftest workflow-native-wait-pr-merge-test
+  (testing "run-loop-job pauses explicitly at wait-pr-merge without merge authorization"
+    (let [ctrl (atom {:pause? false :cancel? false :merge? false})]
+      (with-redefs [sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
+                                          {:task {:id 42 :type :task}
+                                           :children []
+                                           :entity-type :task
+                                           :state :wait-pr-merge
+                                           :completed-count nil})]
+        (let [res (#'sut/run-loop-job {:run-id "run-1"
+                                       :task-id 42
+                                       :project-dir "/tmp"
+                                       :worktree-dir "/tmp/wt"
+                                       :control ctrl
+                                       :current-state :derive-state
+                                       :steps 0
+                                       :history []
+                                       :max-steps 10})]
+          (is (= :paused (:status res)))
+          (is (= :wait-pr-merge (:current-state res)))
+          (is (= :wait-pr-merge (:pause-reason res))))))))
+
+(deftest workflow-merge-gate-guard-test
+  (testing "merge resume guard only matches when merge intent is outside wait-pr-merge gate"
+    (is (true? (#'sut/merge-resume-outside-gate?
+                nil
+                {:_event {:data {:merge? true}}
+                 :run/pause-reason :user-paused})))
+    (is (false? (#'sut/merge-resume-outside-gate?
+                 nil
+                 {:_event {:data {:merge? true}}
+                  :run/pause-reason :wait-pr-merge})))
+    (is (false? (#'sut/merge-resume-outside-gate?
+                 nil
+                 {:_event {:data {:merge? false}}
+                  :run/pause-reason :user-paused}))))
+
+  (testing "reject script writes explicit merge authorization failure context"
+    (let [ctrl (atom {:pause? false :cancel? false :merge? true})
+          ops  (#'sut/reject-merge-resume-script
+                nil
+                {:run/control ctrl
+                 :run/id "run-1"})]
+      (is (= false (:merge? @ctrl)))
+      (is (= [{:op :assign
+               :data {:run/pause-reason :merge-not-authorized
+                      :run/last-output "Merge authorization is only valid at :wait-pr-merge gate. Resume without merge until gate is reached."
+                      :workflow/error-message nil}}]
+             ops)))))
+
+(deftest user-confirmation-parsing-test
+  (testing "parse-user-confirmation reads sentinel payload"
+    (is (= {:question "Proceed with destructive change?"
+            :context {:task-id 18}
+            :expected :yes-no
+            :raw {:question "Proceed with destructive change?"
+                  :context {:task-id 18}
+                  :expected-answer :yes-no}}
+           (#'sut/parse-user-confirmation
+            "text before\nMCP_TASKS_RUN_USER_CONFIRMATION: {:question \"Proceed with destructive change?\" :context {:task-id 18} :expected-answer :yes-no}\ntext after"))))
+
+  (testing "parse-user-confirmation returns nil when sentinel missing"
+    (is (nil? (#'sut/parse-user-confirmation "no confirmation marker")))))
+
+(deftest workflow-user-confirmation-wait-and-resume-test
+  (testing "run-loop-job pauses explicitly on user confirmation marker"
+    (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
+      (with-redefs [sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
+                                          {:task {:id 42 :type :task}
+                                           :children []
+                                           :entity-type :task
+                                           :state :refined
+                                           :completed-count nil})
+                    sut/resolve-step-prompt (fn [_project-dir _prompt-name] "prompt")
+                    sut/run-step-subagent! (fn [_]
+                                             {:ok? true
+                                              :text "MCP_TASKS_RUN_USER_CONFIRMATION: {:question \"Continue?\" :expected-answer :yes-no}"})]
+        (let [res (#'sut/run-loop-job {:run-id "run-1"
+                                       :task-id 42
+                                       :project-dir "/tmp"
+                                       :worktree-dir "/tmp/wt"
+                                       :control ctrl
+                                       :current-state :derive-state
+                                       :steps 0
+                                       :history []
+                                       :user-confirmation nil
+                                       :user-answer nil
+                                       :max-steps 10})]
+          (is (= :paused (:status res)))
+          (is (= :wait-user-confirmation (:current-state res)))
+          (is (= :wait-user-confirmation (:pause-reason res)))
+          (is (= "Continue?" (get-in res [:user-confirmation :question]))))))))
+
+(deftest workflow-user-confirmation-requires-answer-test
+  (testing "run-loop-job remains paused when confirmation answer is missing"
+    (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})
+          res  (#'sut/run-loop-job {:run-id "run-1"
+                                    :task-id 42
+                                    :project-dir "/tmp"
+                                    :worktree-dir "/tmp/wt"
+                                    :control ctrl
+                                    :current-state :wait-user-confirmation
+                                    :steps 1
+                                    :history []
+                                    :user-confirmation {:question "Continue?"}
+                                    :user-answer nil
+                                    :max-steps 10})]
+      (is (= :paused (:status res)))
+      (is (= :wait-user-confirmation (:current-state res)))
+      (is (= :wait-user-confirmation (:pause-reason res)))
+      (is (re-find #"requires explicit answer" (:error-message res))))))

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -220,8 +220,7 @@
           (is (= "Continue?" (get-in res [:user-confirmation :question]))))))))
 
 (deftest active-running-excludes-paused-test
-  ;; Paused workflows should not block starting, resuming, or retrying runs.
-  ;; active-running-workflow must only match phase :running, not :paused.
+  ;; active-running-workflow only gates start-run!; resume/retry check own phase.
   (testing "active-running-workflow"
     (testing "does not match a paused workflow"
       (let [{:keys [api state]} (nullable/create-nullable-extension-api
@@ -237,7 +236,37 @@
           ;; Starting a second run should succeed, not be blocked
           (let [out (with-out-str (handler "99"))]
             (is (re-find #"Started mcp-tasks run run-2" out)
-                "paused run should not block starting a new run")))))))
+                "paused run should not block starting a new run"))))))
+
+  (testing "resume checks only its own run phase"
+    (testing "allows resuming a paused run"
+      (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/mcp_tasks_run.clj"})]
+        (sut/init api)
+        (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+          (with-out-str (handler "42"))
+          (swap! state update-in [:workflows "run-1"]
+                 assoc
+                 :psi.extension.workflow/running? true
+                 :psi.extension.workflow/phase :paused
+                 :psi.extension.workflow/data {:run/pause-reason :wait-pr-merge})
+          (let [out (with-out-str (handler "resume run-1 merge"))]
+            (is (not (re-find #"already running" out))
+                "paused run should be resumable")))))
+
+    (testing "rejects resuming an already running run"
+      (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/mcp_tasks_run.clj"})]
+        (sut/init api)
+        (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+          (with-out-str (handler "42"))
+          (swap! state update-in [:workflows "run-1"]
+                 assoc
+                 :psi.extension.workflow/running? true
+                 :psi.extension.workflow/phase :running)
+          (let [out (with-out-str (handler "resume run-1"))]
+            (is (re-find #"already running" out)
+                "running run should not be resumable")))))))
 
 (deftest workflow-user-confirmation-requires-answer-test
   (testing "run-loop-job remains paused when confirmation answer is missing"

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -219,6 +219,26 @@
           (is (= :wait-user-confirmation (:pause-reason res)))
           (is (= "Continue?" (get-in res [:user-confirmation :question]))))))))
 
+(deftest active-running-excludes-paused-test
+  ;; Paused workflows should not block starting, resuming, or retrying runs.
+  ;; active-running-workflow must only match phase :running, not :paused.
+  (testing "active-running-workflow"
+    (testing "does not match a paused workflow"
+      (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/mcp_tasks_run.clj"})]
+        (sut/init api)
+        (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+          ;; Start a run, then mark it paused (running? true, phase :paused)
+          (with-out-str (handler "42"))
+          (swap! state update-in [:workflows "run-1"]
+                 assoc
+                 :psi.extension.workflow/running? true
+                 :psi.extension.workflow/phase :paused)
+          ;; Starting a second run should succeed, not be blocked
+          (let [out (with-out-str (handler "99"))]
+            (is (re-find #"Started mcp-tasks run run-2" out)
+                "paused run should not block starting a new run")))))))
+
 (deftest workflow-user-confirmation-requires-answer-test
   (testing "run-loop-job remains paused when confirmation answer is missing"
     (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})


### PR DESCRIPTION
## Summary
Convert `mcp-tasks-run` orchestration from imperative internal loop control to workflow-native, explicit state/event progression for safety and introspection.

## Story Context
- Story #15: Convert mcp-tasks-run to workflow-native orchestration
- Purpose: make pause/resume/merge/user-confirmation behavior explicit and queryable in workflow data

## Design Notes
- Preserve existing command surface (`start/list/pause/resume/cancel/retry`)
- Move control authority into explicit workflow transitions
- Enforce merge authorization at wait-pr-merge gate
- Model user-confirmation pause/resume with structured payloads

## Included Work (from branch commits)
- `77a5570` Complete task #19 status visibility and transition/regression coverage for workflow-native mcp-tasks-run

## Validation
- Focused extension tests pass for workflow progression, merge-gate rejection, user-confirmation pause/resume, and resume input requirements (10 tests, 50 assertions).