### PR TITLE
feat: Pre-resolve workflow prompt in mcp-tasks-run execute-task and execute-story-child

### DIFF
--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -28,7 +28,8 @@
    [psi.agent-core.core :as agent]
    [psi.agent-session.executor :as executor]
    [psi.agent-session.tools :as session-tools]
-   [psi.ai.models :as models]))
+   [psi.ai.models :as models]
+   [taoensso.timbre :as timbre]))
 
 (def ^:private run-workflow-type :mcp-tasks-run)
 (def ^:private max-steps-default 50)
@@ -531,6 +532,34 @@
       (load-mcp-prompt! project-dir prompt-name)
       (str "Run workflow step: " prompt-name)))
 
+(defn- open-unblocked?
+  [child]
+  (and (#{:open "open"} (:status child))
+       (not (:is-blocked child))))
+
+(defn- resolve-category-for-step
+  "Pre-resolve the category workflow prompt for execute-task/execute-story-child.
+   Returns the category prompt content string, or nil on any failure."
+  [step-name task children _entity-type project-dir]
+  (let [category (case step-name
+                   "execute-task"
+                   (:category task)
+
+                   "execute-story-child"
+                   (:category (first (filter open-unblocked? children)))
+
+                   nil)]
+    (if-not category
+      (do
+        (when (#{"execute-task" "execute-story-child"} step-name)
+          (timbre/warn "No category found for step" step-name))
+        nil)
+      (try
+        (load-mcp-prompt! project-dir (str category))
+        (catch Exception e
+          (timbre/warn "Failed to load category prompt for" category ":" (ex-message e))
+          nil)))))
+
 (defn- interpolate-arguments
   [prompt-text task-id]
   (str/replace (or prompt-text "") "$ARGUMENTS" (str task-id)))
@@ -607,7 +636,7 @@
 (defn- build-step-request
   [{:keys [step-name prompt-body task-id entity-type
            project-dir worktree-dir task children state
-           user-confirmation user-answer]}]
+           user-confirmation user-answer category-prompt]}]
   (let [prompt* (interpolate-arguments prompt-body task-id)]
     (str
      "You are executing ONE mcp-tasks workflow step as a sub-agent.\n\n"
@@ -637,6 +666,12 @@
      prompt* "\n"
      "-----\n\n"
 
+     (when category-prompt
+       (str "Pre-resolved category instructions (referenced by workflow prompt above):\n"
+            "-----\n"
+            category-prompt "\n"
+            "-----\n\n"))
+
      "Current task snapshot (EDN):\n"
      (pr-str task) "\n\n"
 
@@ -664,7 +699,8 @@
 (defn- run-step-subagent!
   [{:keys [run-id step-name prompt-body task-id entity-type
            project-dir worktree-dir task children state
-           user-confirmation user-answer get-api-key-fn]}]
+           user-confirmation user-answer get-api-key-fn
+           category-prompt]}]
   (let [started (now-ms)
         model   (resolve-active-model)
         api-key (when (fn? get-api-key-fn)
@@ -679,7 +715,8 @@
                                      :children children
                                      :state state
                                      :user-confirmation user-confirmation
-                                     :user-answer user-answer})
+                                     :user-answer user-answer
+                                     :category-prompt category-prompt})
         user-msg {:role      "user"
                   :content   [{:type :text :text req}]
                   :timestamp (java.time.Instant/now)}]
@@ -1034,22 +1071,25 @@
 
                 :else
                 (if-let [prompt-name (step-prompt-name entity-type step-state)]
-                  (let [prompt-body  (resolve-step-prompt project-dir prompt-name)
-                        step-start   (now-ms)
-                        step-result  (run-step-subagent!
-                                      {:run-id run-id
-                                       :step-name prompt-name
-                                       :prompt-body prompt-body
-                                       :task-id task-id
-                                       :entity-type entity-type
-                                       :project-dir project-dir
-                                       :worktree-dir worktree-dir
-                                       :task task
-                                       :children children
-                                       :state step-state
-                                       :user-confirmation user-confirmation
-                                       :user-answer user-answer
-                                       :get-api-key-fn get-api-key-fn})
+                  (let [prompt-body    (resolve-step-prompt project-dir prompt-name)
+                        cat-prompt     (resolve-category-for-step
+                                        prompt-name task children entity-type project-dir)
+                        step-start     (now-ms)
+                        step-result    (run-step-subagent!
+                                        {:run-id run-id
+                                         :step-name prompt-name
+                                         :prompt-body prompt-body
+                                         :task-id task-id
+                                         :entity-type entity-type
+                                         :project-dir project-dir
+                                         :worktree-dir worktree-dir
+                                         :task task
+                                         :children children
+                                         :state step-state
+                                         :user-confirmation user-confirmation
+                                         :user-answer user-answer
+                                         :get-api-key-fn get-api-key-fn
+                                         :category-prompt cat-prompt})
                         step-elapsed (- (now-ms) step-start)
                         base-entry   {:state      step-state
                                       :step       prompt-name

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -286,3 +286,111 @@
       (is (= :wait-user-confirmation (:current-state res)))
       (is (= :wait-user-confirmation (:pause-reason res)))
       (is (re-find #"requires explicit answer" (:error-message res))))))
+
+;;; Category prompt pre-resolution tests
+
+(deftest build-step-request-with-category-prompt-test
+  (testing "build-step-request includes category prompt section when provided"
+    (let [result (#'sut/build-step-request
+                  {:step-name "execute-task"
+                   :prompt-body "Do the thing"
+                   :task-id 42
+                   :entity-type :task
+                   :project-dir "/tmp"
+                   :worktree-dir "/tmp/wt"
+                   :task {:id 42 :category "simple"}
+                   :children []
+                   :state :refined
+                   :category-prompt "Do the simple thing"})]
+      (is (re-find #"Pre-resolved category instructions" result))
+      (is (re-find #"Do the simple thing" result))
+      ;; Category section should appear between prompt body and task snapshot
+      (let [cat-idx  (.indexOf result "Pre-resolved category instructions")
+            body-idx (.indexOf result "-----\nDo the thing")
+            task-idx (.indexOf result "Current task snapshot")]
+        (is (< body-idx cat-idx))
+        (is (< cat-idx task-idx))))))
+
+(deftest build-step-request-without-category-prompt-test
+  (testing "build-step-request omits category section when nil"
+    (let [result (#'sut/build-step-request
+                  {:step-name "execute-task"
+                   :prompt-body "Do the thing"
+                   :task-id 42
+                   :entity-type :task
+                   :project-dir "/tmp"
+                   :worktree-dir "/tmp/wt"
+                   :task {:id 42}
+                   :children []
+                   :state :refined
+                   :category-prompt nil})]
+      (is (not (re-find #"Pre-resolved category instructions" result))))))
+
+(deftest resolve-category-for-step-execute-task-test
+  (testing "resolve-category-for-step extracts category from task for execute-task"
+    (with-redefs [sut/load-mcp-prompt! (fn [_dir cat]
+                                         (when (= "simple" cat)
+                                           "Simple category instructions"))]
+      (let [result (#'sut/resolve-category-for-step
+                    "execute-task"
+                    {:id 42 :category "simple"}
+                    []
+                    :task
+                    "/tmp")]
+        (is (= "Simple category instructions" result))))))
+
+(deftest resolve-category-for-step-story-child-test
+  (testing "resolve-category-for-step picks first open unblocked child for execute-story-child"
+    (with-redefs [sut/load-mcp-prompt! (fn [_dir cat]
+                                         (str cat " instructions"))]
+      (let [children [{:status "open" :is-blocked true :category "large"}
+                      {:status "open" :is-blocked false :category "medium"}
+                      {:status "open" :is-blocked false :category "simple"}]
+            result   (#'sut/resolve-category-for-step
+                      "execute-story-child"
+                      {:id 20 :type "story"}
+                      children
+                      :story
+                      "/tmp")]
+        (is (= "medium instructions" result)))))
+
+  (testing "resolve-category-for-step handles keyword status for children"
+    (with-redefs [sut/load-mcp-prompt! (fn [_dir cat]
+                                         (str cat " instructions"))]
+      (let [children [{:status :open :is-blocked false :category "medium"}]
+            result   (#'sut/resolve-category-for-step
+                      "execute-story-child"
+                      {:id 20 :type "story"}
+                      children
+                      :story
+                      "/tmp")]
+        (is (= "medium instructions" result))))))
+
+(deftest resolve-category-for-step-missing-category-test
+  (testing "resolve-category-for-step returns nil when task has no category"
+    (with-redefs [sut/load-mcp-prompt! (fn [_dir _cat]
+                                         (throw (ex-info "should not be called" {})))]
+      (let [result (#'sut/resolve-category-for-step
+                    "execute-task"
+                    {:id 42}
+                    []
+                    :task
+                    "/tmp")]
+        (is (nil? result))))))
+
+(deftest resolve-category-for-step-non-matching-step-test
+  (testing "resolve-category-for-step returns nil for non-matching step names"
+    (with-redefs [sut/load-mcp-prompt! (fn [_dir _cat]
+                                         (throw (ex-info "should not be called" {})))]
+      (is (nil? (#'sut/resolve-category-for-step
+                 "refine-task"
+                 {:id 42 :category "simple"}
+                 []
+                 :task
+                 "/tmp")))
+      (is (nil? (#'sut/resolve-category-for-step
+                 "create-story-tasks"
+                 {:id 42 :category "simple"}
+                 []
+                 :task
+                 "/tmp"))))))


### PR DESCRIPTION
## Summary

Eliminates a redundant CLI call by the sub-agent. Previously, execute-task and execute-story-child prompt steps told the sub-agent to call `mcp-tasks prompts show <category>` at runtime. The orchestrator already has the task data and prompt-loading machinery, so it now pre-resolves the category prompt and injects it into the sub-agent request.

## Changes

- **`resolve-category-for-step` helper**: Extracts the category from the task (for execute-task) or from the first open unblocked child (for execute-story-child), then loads the category prompt via `load-mcp-prompt!`. Returns nil gracefully on missing category or load failure.
- **`build-step-request` modification**: Accepts `:category-prompt` and appends a clearly delimited "Pre-resolved category instructions" section between the workflow prompt body and task snapshot.
- **`run-loop-job` wiring**: Calls `resolve-category-for-step` after resolving the step prompt, passes result through `run-step-subagent!` to `build-step-request`.
- **6 new tests** covering: injection present/absent, category extraction for both step types, missing category handling, non-matching step names.

## Commits

- `2b037a7` ⚒ Pre-resolve category workflow prompt in build-step-request (#21)

## Design Notes

- Append-only approach: category prompt appended as separate section, no modification to upstream execute-task.md or execute-story-child.md
- Graceful degradation: missing category or failed load → sub-agent falls back to CLI call
- Uses existing `load-mcp-prompt!` cache — no duplicate CLI calls for same category

Story #20