### PR TITLE
Implement tool-output delta + EQL limit/context introspection

### DIFF
--- a/LEARNING.md
+++ b/LEARNING.md
@@ -4,6 +4,66 @@ Accumulated discoveries from ψ evolution.
 
 ---
 
+## 2026-02-28 - Tool Output Delta
+
+### λ Tool-output EQL introspection contract (stable attrs)
+
+Tool-output policy and telemetry are queryable via these stable attrs:
+
+- `:psi.tool-output/default-max-lines`
+- `:psi.tool-output/default-max-bytes`
+- `:psi.tool-output/overrides`
+- `:psi.tool-output/calls`
+- `:psi.tool-output/stats`
+
+Per-call entities use `:psi.tool-output.call/*` attrs:
+
+- `:psi.tool-output.call/tool-call-id`
+- `:psi.tool-output.call/tool-name`
+- `:psi.tool-output.call/timestamp`
+- `:psi.tool-output.call/limit-hit?`
+- `:psi.tool-output.call/truncated-by`
+- `:psi.tool-output.call/effective-max-lines`
+- `:psi.tool-output.call/effective-max-bytes`
+- `:psi.tool-output.call/output-bytes`
+- `:psi.tool-output.call/context-bytes-added`
+
+### λ Policy + truncation semantics
+
+- Default tool output policy: `max-lines=1000`, `max-bytes=25600`.
+- Per-tool overrides are read from session data `:tool-output-overrides`.
+- `read`, `eql_query`, `ls`, `find`, `grep` use head-style truncation.
+- `bash` uses tail-style truncation.
+- Truncated `bash`/`eql_query` responses include `:details {:full-output-path ...}`.
+
+### λ Context-bytes-added semantics
+
+`contextBytesAdded` is measured from the shaped tool result content that is
+actually recorded in the tool result message (post-truncation / post-formatting),
+not raw underlying command/file output bytes.
+
+### λ Temp artifact lifecycle
+
+- Truncated full-output artifacts are persisted under one process temp root.
+- `tool-output/cleanup-temp-store!` is invoked on orderly teardown paths.
+- Cleanup failures are warning-only and do not block shutdown.
+
+### λ EQL query pattern for telemetry
+
+Example query shape:
+
+```clojure
+[:psi.tool-output/stats
+ {:psi.tool-output/calls
+  [:psi.tool-output.call/tool-name
+   :psi.tool-output.call/limit-hit?
+   :psi.tool-output.call/output-bytes
+   :psi.tool-output.call/context-bytes-added]}]
+```
+
+Use this after one or more tool calls to inspect per-call limit hits plus session
+aggregates (`:total-context-bytes`, `:by-tool`, `:limit-hits-by-tool`).
+
 ## 2026-02-27 - mcp-tasks-run Orchestration + Tool Scoping
 
 ### λ mcp-tasks CLI Is CWD-Sensitive

--- a/components/agent-session/src/psi/agent_session/core.clj
+++ b/components/agent-session/src/psi/agent_session/core.clj
@@ -253,23 +253,27 @@
          ui-state-atom     (ext-ui/create-ui-state)
          merged-config     (merge session/default-config (or config {}))
          ;; Build ctx without actions-fn so we can close over it
-         ctx               {:sc-env             sc-env
-                            :sc-session-id      sc-session-id
-                            :session-data-atom  session-data-atom
-                            :agent-ctx          agent-ctx
-                            :extension-registry ext-reg
-                            :workflow-registry  wf-reg
-                            :journal-atom       journal-atom
-                            :flush-state-atom   flush-state-atom
-                            :turn-ctx-atom      (atom nil)
-                            :ui-state-atom      ui-state-atom
-                            :event-queue        event-queue
-                            :cwd                resolved-cwd
-                            :persist?           persist?
-                            :oauth-ctx          oauth-ctx
-                            :compaction-fn      (or compaction-fn compaction/stub-compaction-fn)
-                            :branch-summary-fn  (or branch-summary-fn compaction/stub-branch-summary-fn)
-                            :config             merged-config}
+         ctx               {:sc-env                sc-env
+                            :sc-session-id         sc-session-id
+                            :session-data-atom     session-data-atom
+                            :tool-output-stats-atom (atom {:calls []
+                                                            :aggregates {:total-context-bytes 0
+                                                                         :by-tool {}
+                                                                         :limit-hits-by-tool {}}})
+                            :agent-ctx             agent-ctx
+                            :extension-registry    ext-reg
+                            :workflow-registry     wf-reg
+                            :journal-atom          journal-atom
+                            :flush-state-atom      flush-state-atom
+                            :turn-ctx-atom         (atom nil)
+                            :ui-state-atom         ui-state-atom
+                            :event-queue           event-queue
+                            :cwd                   resolved-cwd
+                            :persist?              persist?
+                            :oauth-ctx             oauth-ctx
+                            :compaction-fn         (or compaction-fn compaction/stub-compaction-fn)
+                            :branch-summary-fn     (or branch-summary-fn compaction/stub-branch-summary-fn)
+                            :config                merged-config}
          actions-fn        (make-actions-fn ctx)]
 
      ;; Watch agent-core events atom — forward new events to session statechart

--- a/components/agent-session/src/psi/agent_session/executor.clj
+++ b/components/agent-session/src/psi/agent_session/executor.clj
@@ -36,6 +36,7 @@
    [psi.ai.core :as ai]
    [psi.ai.conversation :as conv]
    [psi.agent-core.core :as agent]
+   [psi.agent-session.tool-output :as tool-output]
    [psi.agent-session.tools :as tools]
    [psi.agent-session.turn-statechart :as turn-sc]))
 
@@ -321,6 +322,41 @@
   [assistant-msg]
   (filter #(= :tool-call (:type %)) (:content assistant-msg)))
 
+(defn- effective-tool-output-policy
+  [agent-session-ctx tool-name]
+  (tool-output/effective-policy
+   (or (:tool-output-overrides @(:session-data-atom agent-session-ctx)) {})
+   tool-name))
+
+(defn- utf8-bytes
+  [s]
+  (count (.getBytes (str (or s "")) "UTF-8")))
+
+(defn- record-tool-output-stat!
+  [agent-session-ctx {:keys [tool-call-id tool-name content details effective-policy]}]
+  (let [truncation          (:truncation details)
+        limit-hit?          (boolean (:truncated truncation))
+        truncated-by        (or (:truncated-by truncation) :none)
+        output-bytes        (utf8-bytes content)
+        context-bytes-added output-bytes
+        stat                {:tool-call-id         tool-call-id
+                             :tool-name            tool-name
+                             :timestamp            (java.time.Instant/now)
+                             :limit-hit            limit-hit?
+                             :truncated-by         truncated-by
+                             :effective-max-lines  (:max-lines effective-policy)
+                             :effective-max-bytes  (:max-bytes effective-policy)
+                             :output-bytes         output-bytes
+                             :context-bytes-added  context-bytes-added}]
+    (swap! (:tool-output-stats-atom agent-session-ctx)
+           (fn [state]
+             (-> state
+                 (update :calls (fnil conj []) stat)
+                 (update-in [:aggregates :total-context-bytes] (fnil + 0) context-bytes-added)
+                 (update-in [:aggregates :by-tool tool-name] (fnil + 0) context-bytes-added)
+                 (update-in [:aggregates :limit-hits-by-tool tool-name] (fnil + 0)
+                            (if limit-hit? 1 0)))))))
+
 (defn- execute-tool-with-registry
   "Execute a tool by name, preferring an :execute fn from the current
    agent tool registry when present. Falls back to built-in tools.
@@ -335,8 +371,9 @@
 
 (defn- run-tool-call!
   "Execute one tool call, record the result in agent-core, return the result map."
-  [agent-ctx tool-call progress-queue]
-  (let [call-id  (:id tool-call)
+  [agent-session-ctx tool-call progress-queue]
+  (let [agent-ctx (:agent-ctx agent-session-ctx)
+        call-id  (:id tool-call)
         name     (:name tool-call)
         args     (parse-args (:arguments tool-call))]
     (agent/emit-tool-start-in! agent-ctx tool-call)
@@ -345,17 +382,19 @@
                      :tool-id     call-id
                      :tool-name   name
                      :parsed-args args})
-    (let [{:keys [content is-error]}
+    (let [{:keys [content is-error details] :as tool-result}
           (try
             (execute-tool-with-registry agent-ctx name args)
             (catch Exception e
               {:content  (str "Error: " (ex-message e))
                :is-error true}))
+          policy     (effective-tool-output-policy agent-session-ctx name)
           result-msg {:role         "toolResult"
                       :tool-call-id call-id
                       :tool-name    name
                       :content      [{:type :text :text content}]
                       :is-error     is-error
+                      :details      details
                       :timestamp    (java.time.Instant/now)}]
       (emit-progress! progress-queue
                       {:event-kind  :tool-result
@@ -363,7 +402,14 @@
                        :tool-name   name
                        :result-text content
                        :is-error    is-error})
-      (agent/emit-tool-end-in! agent-ctx tool-call {:content content} is-error)
+      (record-tool-output-stat!
+       agent-session-ctx
+       {:tool-call-id    call-id
+        :tool-name       name
+        :content         content
+        :details         details
+        :effective-policy policy})
+      (agent/emit-tool-end-in! agent-ctx tool-call tool-result is-error)
       (agent/record-tool-result-in! agent-ctx result-msg)
       result-msg)))
 
@@ -376,6 +422,7 @@
      stream → check tools → execute tools → stream again (recursive).
 
    `ai-ctx`            — ai component context (has :provider-registry)
+   `agent-session-ctx` — agent session context
    `agent-ctx`         — agent-core context
    `ai-model`          — ai.schemas.Model map
    `turn-ctx-atom`     — optional atom, stores current turn context for introspection
@@ -384,13 +431,13 @@
 
    Returns the final (non-tool) assistant message map.
    Emits agent-core events throughout."
-  ([ai-ctx agent-ctx ai-model]
-   (run-turn! ai-ctx agent-ctx ai-model nil nil nil))
-  ([ai-ctx agent-ctx ai-model turn-ctx-atom]
-   (run-turn! ai-ctx agent-ctx ai-model turn-ctx-atom nil nil))
-  ([ai-ctx agent-ctx ai-model turn-ctx-atom extra-ai-options]
-   (run-turn! ai-ctx agent-ctx ai-model turn-ctx-atom extra-ai-options nil))
-  ([ai-ctx agent-ctx ai-model turn-ctx-atom extra-ai-options progress-queue]
+  ([ai-ctx agent-session-ctx agent-ctx ai-model]
+   (run-turn! ai-ctx agent-session-ctx agent-ctx ai-model nil nil nil))
+  ([ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom]
+   (run-turn! ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom nil nil))
+  ([ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom extra-ai-options]
+   (run-turn! ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom extra-ai-options nil))
+  ([ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom extra-ai-options progress-queue]
    (agent/emit-in! agent-ctx {:type :turn-start})
    (let [assistant-msg (stream-turn! ai-ctx agent-ctx ai-model turn-ctx-atom
                                      extra-ai-options progress-queue)
@@ -400,8 +447,8 @@
        ;; Tool calls requested — execute them all then recurse
        (do
          (doseq [tc tool-calls]
-           (run-tool-call! agent-ctx tc progress-queue))
-         (run-turn! ai-ctx agent-ctx ai-model turn-ctx-atom
+           (run-tool-call! agent-session-ctx tc progress-queue))
+         (run-turn! ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom
                     extra-ai-options progress-queue))
        ;; No tool calls (or error) — we're done
        assistant-msg))))
@@ -419,13 +466,13 @@
      :progress-queue — LinkedBlockingQueue for TUI progress events
 
    Returns the final assistant message."
-  ([ai-ctx agent-ctx ai-model new-messages]
-   (run-agent-loop! ai-ctx agent-ctx ai-model new-messages nil))
-  ([ai-ctx agent-ctx ai-model new-messages {:keys [turn-ctx-atom api-key progress-queue]}]
+  ([ai-ctx agent-session-ctx agent-ctx ai-model new-messages]
+   (run-agent-loop! ai-ctx agent-session-ctx agent-ctx ai-model new-messages nil))
+  ([ai-ctx agent-session-ctx agent-ctx ai-model new-messages {:keys [turn-ctx-atom api-key progress-queue]}]
    (agent/start-loop-in! agent-ctx new-messages)
    (let [extra-ai-options (when api-key {:api-key api-key})
          result (try
-                  (run-turn! ai-ctx agent-ctx ai-model turn-ctx-atom
+                  (run-turn! ai-ctx agent-session-ctx agent-ctx ai-model turn-ctx-atom
                              extra-ai-options progress-queue)
                   (catch Exception e
                     (cond-> {:role "assistant" :content []

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -301,7 +301,7 @@
                   :timestamp (java.time.Instant/now)}
         _        (session/journal-append-in! ctx (persist/message-entry user-msg))
         api-key  (resolve-api-key oauth-ctx ai-model)
-        result   (executor/run-agent-loop! ai-ctx (:agent-ctx ctx) ai-model [user-msg]
+        result   (executor/run-agent-loop! ai-ctx ctx (:agent-ctx ctx) ai-model [user-msg]
                                            {:turn-ctx-atom (:turn-ctx-atom ctx)
                                             :api-key       api-key})]
     (update-context-usage-from-result! ctx ai-model result)
@@ -550,7 +550,7 @@
                                                 ctx (persist/message-entry user-msg))
                                       api-key  (resolve-api-key oauth-ctx ai-model)
                                       result   (executor/run-agent-loop!
-                                                ai-ctx (:agent-ctx ctx)
+                                                ai-ctx ctx (:agent-ctx ctx)
                                                 ai-model [user-msg]
                                                 {:turn-ctx-atom  (:turn-ctx-atom ctx)
                                                  :api-key        api-key

--- a/components/agent-session/src/psi/agent_session/resolvers.clj
+++ b/components/agent-session/src/psi/agent_session/resolvers.clj
@@ -38,6 +38,26 @@
    :psi.agent-session/tool-call-history   — [{:psi.tool-call/*}], nested tool call entities
    :psi.agent-session/tool-call-history-count — number of tool calls
 
+   Tool-output policy and telemetry
+   ────────────────────────────────
+   :psi.tool-output/default-max-lines
+   :psi.tool-output/default-max-bytes
+   :psi.tool-output/overrides
+   :psi.tool-output/calls            — [{:psi.tool-output.call/*}]
+   :psi.tool-output/stats            — {:total-context-bytes :by-tool :limit-hits-by-tool}
+
+   Tool-output call entities (nested under :psi.tool-output/calls)
+   ──────────────────────────────────────────────────────────────
+   :psi.tool-output.call/tool-call-id
+   :psi.tool-output.call/tool-name
+   :psi.tool-output.call/timestamp
+   :psi.tool-output.call/limit-hit?
+   :psi.tool-output.call/truncated-by
+   :psi.tool-output.call/effective-max-lines
+   :psi.tool-output.call/effective-max-bytes
+   :psi.tool-output.call/output-bytes
+   :psi.tool-output.call/context-bytes-added
+
    Session entry entities (nested under session-entries)
    ──────────────────────────────────────────────────────
    :psi.session-entry/id
@@ -185,6 +205,7 @@
    [com.wsscode.pathom3.interface.eql :as p.eql]
    [psi.agent-session.persistence :as persist]
    [psi.agent-session.session :as session]
+   [psi.agent-session.tool-output :as tool-output]
    [psi.agent-session.prompt-templates :as pt]
    [psi.agent-session.skills :as skills]
    [psi.agent-session.extensions :as ext]
@@ -481,6 +502,62 @@
     {:psi.agent-session/context-tokens   (:context-tokens sd)
      :psi.agent-session/context-window   (:context-window sd)
      :psi.agent-session/context-fraction (session/context-fraction-used sd)}))
+
+;; ── Tool-output policy and telemetry ───────────────────
+
+(defn- tool-output-call->eql
+  [call]
+  {:psi.tool-output.call/tool-call-id        (:tool-call-id call)
+   :psi.tool-output.call/tool-name           (:tool-name call)
+   :psi.tool-output.call/timestamp           (:timestamp call)
+   :psi.tool-output.call/limit-hit?          (:limit-hit call)
+   :psi.tool-output.call/truncated-by        (:truncated-by call)
+   :psi.tool-output.call/effective-max-lines (:effective-max-lines call)
+   :psi.tool-output.call/effective-max-bytes (:effective-max-bytes call)
+   :psi.tool-output.call/output-bytes        (:output-bytes call)
+   :psi.tool-output.call/context-bytes-added (:context-bytes-added call)})
+
+(pco/defresolver tool-output-policy
+  "Resolve tool-output defaults and per-tool overrides."
+  [{:keys [psi/agent-session-ctx]}]
+  {::pco/input  [:psi/agent-session-ctx]
+   ::pco/output [:psi.tool-output/default-max-lines
+                 :psi.tool-output/default-max-bytes
+                 :psi.tool-output/overrides]}
+  {:psi.tool-output/default-max-lines tool-output/default-max-lines
+   :psi.tool-output/default-max-bytes tool-output/default-max-bytes
+   :psi.tool-output/overrides         (or (:tool-output-overrides
+                                           @(:session-data-atom agent-session-ctx))
+                                          {})})
+
+(pco/defresolver tool-output-calls
+  "Resolve per-call tool-output telemetry records."
+  [{:keys [psi/agent-session-ctx]}]
+  {::pco/input  [:psi/agent-session-ctx]
+   ::pco/output [{:psi.tool-output/calls
+                  [:psi.tool-output.call/tool-call-id
+                   :psi.tool-output.call/tool-name
+                   :psi.tool-output.call/timestamp
+                   :psi.tool-output.call/limit-hit?
+                   :psi.tool-output.call/truncated-by
+                   :psi.tool-output.call/effective-max-lines
+                   :psi.tool-output.call/effective-max-bytes
+                   :psi.tool-output.call/output-bytes
+                   :psi.tool-output.call/context-bytes-added]}]}
+  {:psi.tool-output/calls
+   (mapv tool-output-call->eql
+         (or (:calls @(:tool-output-stats-atom agent-session-ctx)) []))})
+
+(pco/defresolver tool-output-stats
+  "Resolve aggregate tool-output telemetry."
+  [{:keys [psi/agent-session-ctx]}]
+  {::pco/input  [:psi/agent-session-ctx]
+   ::pco/output [:psi.tool-output/stats]}
+  {:psi.tool-output/stats
+   (let [aggregates (:aggregates @(:tool-output-stats-atom agent-session-ctx))]
+     {:total-context-bytes (or (:total-context-bytes aggregates) 0)
+      :by-tool             (or (:by-tool aggregates) {})
+      :limit-hits-by-tool  (or (:limit-hits-by-tool aggregates) {})})})
 
 ;; ── Journal ─────────────────────────────────────────────
 
@@ -1202,6 +1279,9 @@
    agent-session-resources
    agent-session-extensions
    agent-session-context-usage
+   tool-output-policy
+   tool-output-calls
+   tool-output-stats
    agent-session-journal
    agent-session-stats
    ;; Session-derived usage/git attrs

--- a/components/agent-session/src/psi/agent_session/session.clj
+++ b/components/agent-session/src/psi/agent_session/session.clj
@@ -117,7 +117,10 @@
       [:extension-errors [:vector [:map [:path :string] [:error :string]]]]
       [:mutations [:vector qualified-symbol?]]]]]
    [:context-tokens {:optional true} [:maybe :int]]
-   [:context-window {:optional true} [:maybe :int]]])
+   [:context-window {:optional true} [:maybe :int]]
+   [:tool-output-overrides {:optional true} [:map-of :string [:map
+                                                              [:max-lines {:optional true} [:maybe :int]]
+                                                              [:max-bytes {:optional true} [:maybe :int]]]]]])
 
 ;; ============================================================
 ;; Validation
@@ -168,7 +171,8 @@
      :extensions              {}
      :session-entries         []
      :context-tokens          nil
-     :context-window          nil}
+     :context-window          nil
+     :tool-output-overrides   {}}
     overrides)))
 
 ;; ============================================================

--- a/components/agent-session/src/psi/agent_session/tool_output.clj
+++ b/components/agent-session/src/psi/agent_session/tool_output.clj
@@ -1,0 +1,291 @@
+(ns psi.agent-session.tool-output
+  "Shared output-policy resolution, truncation helpers, and process temp store.
+
+   Output Policy:
+   - default-max-lines (1000) and default-max-bytes (25600)
+   - Per-tool overrides via {:tool-name {:max-lines N :max-bytes N}}
+   - effective-policy merges overrides over defaults
+
+   Truncation:
+   - head-truncate: keeps first N lines/bytes (used by read, eql_query, ls, find, grep)
+   - tail-truncate: keeps last N lines/bytes (used by bash)
+
+   Temp Store:
+   - Process-wide temp directory for truncated full-output artifacts
+   - Init once, cleanup on orderly shutdown (warning-only on failure)"
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [taoensso.timbre :as timbre])
+  (:import
+   [java.io File]
+   [java.nio.file Files]
+   [java.time Instant]))
+
+;;; Policy defaults
+
+(def default-max-lines
+  "Default maximum lines for tool output."
+  1000)
+
+(def default-max-bytes
+  "Default maximum bytes for tool output."
+  25600)
+
+(defn effective-policy
+  "Resolve effective output policy for a tool.
+   Merges tool-specific overrides over defaults; nil override fields
+   fall through to defaults.
+
+   Returns {:max-lines N :max-bytes N}."
+  [overrides-map tool-name]
+  (let [defaults  {:max-lines default-max-lines
+                   :max-bytes default-max-bytes}
+        overrides (get overrides-map tool-name)]
+    (if overrides
+      (merge defaults (into {} (filter (comp some? val)) overrides))
+      defaults)))
+
+;;; Truncation helpers
+
+(defn head-truncate
+  "Truncate text keeping the first N lines and/or bytes.
+
+   Returns a map with:
+   - :content        — the (possibly truncated) string
+   - :truncated      — boolean
+   - :truncated-by   — :lines, :bytes, or :none
+   - :total-lines    — total line count of input
+   - :total-bytes    — total byte count of input
+   - :output-lines   — line count of output
+   - :output-bytes   — byte count of output
+   - :max-lines      — the limit applied
+   - :max-bytes      — the limit applied
+   - :first-line-exceeds-limit — true if the first line alone exceeds max-bytes"
+  [text {:keys [max-lines max-bytes]}]
+  (let [total-bytes (count (.getBytes (str text) "UTF-8"))
+        lines       (str/split-lines (str text))
+        total-lines (count lines)]
+    (if (and (<= total-lines max-lines)
+             (<= total-bytes max-bytes))
+      ;; Within limits
+      {:content                 text
+       :truncated               false
+       :truncated-by            :none
+       :total-lines             total-lines
+       :total-bytes             total-bytes
+       :output-lines            total-lines
+       :output-bytes            total-bytes
+       :max-lines               max-lines
+       :max-bytes               max-bytes
+       :first-line-exceeds-limit false}
+      ;; Need truncation — apply line limit first, then byte limit
+      (let [line-limited    (take max-lines lines)
+            line-joined     (str/join "\n" line-limited)
+            line-joined-bytes (count (.getBytes line-joined "UTF-8"))
+            truncated-by-lines (> total-lines max-lines)]
+        (if (<= line-joined-bytes max-bytes)
+          ;; Line-limited but within byte limit
+          {:content                 line-joined
+           :truncated               truncated-by-lines
+           :truncated-by            (if truncated-by-lines :lines :none)
+           :total-lines             total-lines
+           :total-bytes             total-bytes
+           :output-lines            (count line-limited)
+           :output-bytes            line-joined-bytes
+           :max-lines               max-lines
+           :max-bytes               max-bytes
+           :first-line-exceeds-limit false}
+          ;; Need byte truncation
+          (let [first-line       (first lines)
+                first-line-bytes (count (.getBytes (str first-line) "UTF-8"))]
+            (if (> first-line-bytes max-bytes)
+              ;; First line alone exceeds byte limit
+              {:content                 ""
+               :truncated               true
+               :truncated-by            :bytes
+               :total-lines             total-lines
+               :total-bytes             total-bytes
+               :output-lines            0
+               :output-bytes            0
+               :max-lines               max-lines
+               :max-bytes               max-bytes
+               :first-line-exceeds-limit true}
+              ;; Accumulate lines until byte limit
+              (loop [acc-lines  []
+                     acc-bytes  0
+                     remaining  (seq line-limited)]
+                (if-not remaining
+                  (let [content (str/join "\n" acc-lines)]
+                    {:content                 content
+                     :truncated               truncated-by-lines
+                     :truncated-by            (if truncated-by-lines :lines :bytes)
+                     :total-lines             total-lines
+                     :total-bytes             total-bytes
+                     :output-lines            (count acc-lines)
+                     :output-bytes            (count (.getBytes content "UTF-8"))
+                     :max-lines               max-lines
+                     :max-bytes               max-bytes
+                     :first-line-exceeds-limit false})
+                  (let [line       (first remaining)
+                        line-bytes (count (.getBytes line "UTF-8"))
+                        sep-bytes  (if (seq acc-lines) 1 0) ; newline separator
+                        new-bytes  (+ acc-bytes sep-bytes line-bytes)]
+                    (if (> new-bytes max-bytes)
+                      ;; This line would exceed byte limit
+                      (let [content (str/join "\n" acc-lines)]
+                        {:content                 content
+                         :truncated               true
+                         :truncated-by            :bytes
+                         :total-lines             total-lines
+                         :total-bytes             total-bytes
+                         :output-lines            (count acc-lines)
+                         :output-bytes            (count (.getBytes content "UTF-8"))
+                         :max-lines               max-lines
+                         :max-bytes               max-bytes
+                         :first-line-exceeds-limit false})
+                      (recur (conj acc-lines line)
+                             new-bytes
+                             (next remaining)))))))))))))
+
+(defn tail-truncate
+  "Truncate text keeping the last N lines and/or bytes.
+
+   Returns a map with:
+   - :content           — the (possibly truncated) string
+   - :truncated         — boolean
+   - :truncated-by      — :lines, :bytes, or :none
+   - :total-lines       — total line count of input
+   - :total-bytes       — total byte count of input
+   - :output-lines      — line count of output
+   - :output-bytes      — byte count of output
+   - :max-lines         — the limit applied
+   - :max-bytes         — the limit applied
+   - :last-line-partial — true if the last kept line was cut by byte limit"
+  [text {:keys [max-lines max-bytes]}]
+  (let [total-bytes (count (.getBytes (str text) "UTF-8"))
+        lines       (str/split-lines (str text))
+        total-lines (count lines)]
+    (if (and (<= total-lines max-lines)
+             (<= total-bytes max-bytes))
+      ;; Within limits
+      {:content            text
+       :truncated          false
+       :truncated-by       :none
+       :total-lines        total-lines
+       :total-bytes        total-bytes
+       :output-lines       total-lines
+       :output-bytes       total-bytes
+       :max-lines          max-lines
+       :max-bytes          max-bytes
+       :last-line-partial  false}
+      ;; Need truncation — take last N lines first, then byte limit
+      (let [line-limited      (vec (take-last max-lines lines))
+            line-joined       (str/join "\n" line-limited)
+            line-joined-bytes (count (.getBytes line-joined "UTF-8"))
+            truncated-by-lines (> total-lines max-lines)]
+        (if (<= line-joined-bytes max-bytes)
+          ;; Line-limited but within byte limit
+          {:content            line-joined
+           :truncated          truncated-by-lines
+           :truncated-by       (if truncated-by-lines :lines :none)
+           :total-lines        total-lines
+           :total-bytes        total-bytes
+           :output-lines       (count line-limited)
+           :output-bytes       line-joined-bytes
+           :max-lines          max-lines
+           :max-bytes          max-bytes
+           :last-line-partial  false}
+          ;; Need byte truncation — accumulate from the end
+          (loop [acc-lines  '()
+                 acc-bytes  0
+                 remaining  (reverse line-limited)]
+            (if-not (seq remaining)
+              ;; Exhausted lines but still over byte limit shouldn't happen,
+              ;; but handle gracefully
+              (let [content (str/join "\n" acc-lines)]
+                {:content            content
+                 :truncated          true
+                 :truncated-by       :bytes
+                 :total-lines        total-lines
+                 :total-bytes        total-bytes
+                 :output-lines       (count acc-lines)
+                 :output-bytes       (count (.getBytes content "UTF-8"))
+                 :max-lines          max-lines
+                 :max-bytes          max-bytes
+                 :last-line-partial  false})
+              (let [line       (first remaining)
+                    line-bytes (count (.getBytes line "UTF-8"))
+                    sep-bytes  (if (seq acc-lines) 1 0)
+                    new-bytes  (+ acc-bytes sep-bytes line-bytes)]
+                (if (> new-bytes max-bytes)
+                  ;; This line would exceed byte limit — stop
+                  (let [content (str/join "\n" acc-lines)]
+                    {:content            content
+                     :truncated          true
+                     :truncated-by       :bytes
+                     :total-lines        total-lines
+                     :total-bytes        total-bytes
+                     :output-lines       (count acc-lines)
+                     :output-bytes       (count (.getBytes content "UTF-8"))
+                     :max-lines          max-lines
+                     :max-bytes          max-bytes
+                     :last-line-partial  false})
+                  (recur (cons line acc-lines)
+                         new-bytes
+                         (rest remaining)))))))))))
+
+;;; Process temp store
+
+(defonce ^:private temp-store-atom
+  (atom nil))
+
+(defn init-temp-store!
+  "Create the process-wide temp directory for truncated output artifacts.
+   Idempotent — returns the existing root if already initialized.
+   Returns the root directory path as a string."
+  []
+  (if-let [existing @temp-store-atom]
+    (.getAbsolutePath ^File (:root-dir existing))
+    (let [root-path (Files/createTempDirectory
+                     "psi-tool-output-"
+                     (into-array java.nio.file.attribute.FileAttribute []))
+          root-file (.toFile root-path)]
+      (reset! temp-store-atom {:root-dir   root-file
+                               :created-at (Instant/now)})
+      (.getAbsolutePath root-file))))
+
+(defn persist-truncated-output!
+  "Write full (un-truncated) output to a file in the temp store.
+   Initializes the temp store if needed.
+   Returns the absolute path of the written file as a string."
+  [tool-name tool-call-id full-text]
+  (let [_         (init-temp-store!)
+        root-dir  (:root-dir @temp-store-atom)
+        filename  (str tool-name "-" tool-call-id ".log")
+        out-file  (io/file root-dir filename)]
+    (spit out-file full-text)
+    (.getAbsolutePath out-file)))
+
+(defn cleanup-temp-store!
+  "Recursively delete the temp store directory.
+   Catches exceptions and logs a warning — never blocks shutdown.
+   Returns true if cleanup succeeded, false if it failed or no store existed."
+  []
+  (if-let [{:keys [root-dir]} @temp-store-atom]
+    (try
+      (doseq [f (reverse (file-seq root-dir))]
+        (.delete ^File f))
+      (reset! temp-store-atom nil)
+      true
+      (catch Exception e
+        (timbre/warn "Temp store cleanup failed:" (ex-message e))
+        (reset! temp-store-atom nil)
+        false))
+    false))
+
+(defn temp-store-root
+  "Returns the current temp store root directory path, or nil if not initialized."
+  []
+  (when-let [{:keys [root-dir]} @temp-store-atom]
+    (.getAbsolutePath ^File root-dir)))

--- a/components/agent-session/src/psi/agent_session/tool_path.clj
+++ b/components/agent-session/src/psi/agent_session/tool_path.clj
@@ -1,0 +1,117 @@
+(ns psi.agent-session.tool-path
+  "Shared path resolution for built-in file and search tools.
+
+   Implements canonical behavior from spec/tools/path-resolution.allium:
+   - expand-path: strip @-prefix, normalize unicode spaces, expand ~/~
+   - resolve-to-cwd: resolve relative paths against working directory
+   - resolve-read-path: expand + resolve + try macOS filename variants
+
+   All file/search tools should use these helpers for consistent path handling."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str])
+  (:import
+   [java.io File]
+   [java.text Normalizer Normalizer$Form]))
+
+;;; Unicode space codepoints to normalize
+
+(def ^:private unicode-spaces
+  "Unicode space characters to normalize to ASCII space.
+   Includes narrow no-break space (U+202F), thin space (U+2009),
+   hair space (U+200A), em space (U+2003), en space (U+2002),
+   figure space (U+2007), punctuation space (U+2008),
+   ideographic space (U+3000), and no-break space (U+00A0)."
+  #{\u202F \u2009 \u200A \u2003 \u2002 \u2007 \u2008 \u3000 \u00A0})
+
+(defn expand-path
+  "Expand a raw path string:
+   1. Strip leading @ prefix
+   2. Replace unicode space characters with ASCII space
+   3. Expand ~ and ~/ to user home directory
+
+   Returns the expanded path string."
+  [raw-path]
+  (let [;; Step 1: Strip leading @
+        s (if (str/starts-with? raw-path "@")
+            (subs raw-path 1)
+            raw-path)
+        ;; Step 2: Normalize unicode spaces to ASCII space
+        s (apply str (map (fn [c] (if (unicode-spaces c) \space c)) s))
+        ;; Step 3: Expand tilde
+        home (System/getProperty "user.home")]
+    (cond
+      (= s "~")              home
+      (str/starts-with? s "~/") (str home (subs s 1))
+      :else                   s)))
+
+(defn resolve-to-cwd
+  "Resolve a path against a working directory.
+   If path is absolute, returns it as-is.
+   If relative, joins with cwd.
+
+   Returns a java.io.File."
+  ^File [cwd path]
+  (let [f (io/file path)]
+    (if (.isAbsolute f)
+      f
+      (if cwd
+        (io/file cwd path)
+        f))))
+
+;;; macOS filename variant helpers
+
+(defn- am-pm-variant
+  "Replace ASCII space before AM/PM with narrow no-break space (U+202F).
+   macOS sometimes uses this in filenames with timestamps."
+  [^String path]
+  (-> path
+      (str/replace #" (AM|PM)" (str "\u202F" "$1"))
+      (str/replace #" (am|pm)" (str "\u202F" "$1"))))
+
+(defn- nfd-variant
+  "Normalize path to NFD (decomposed) Unicode form.
+   macOS HFS+ uses NFD normalization for filenames."
+  [^String path]
+  (Normalizer/normalize path Normalizer$Form/NFD))
+
+(defn- curly-quote-variant
+  "Replace straight quotes with curly/smart quotes.
+   macOS sometimes stores filenames with curly quotes."
+  [^String path]
+  (-> path
+      (str/replace "'" "\u2019")
+      (str/replace "\"" "\u201C")))
+
+(defn- nfd-curly-variant
+  "Apply both NFD normalization and curly quote replacement."
+  [^String path]
+  (-> path nfd-variant curly-quote-variant))
+
+(defn resolve-read-path
+  "Resolve a path for reading, with macOS fallback variants.
+
+   1. Expand the raw path (strip @, normalize unicode spaces, expand ~)
+   2. Resolve against cwd
+   3. If the resolved file exists, return it
+   4. Otherwise try macOS variants in order:
+      - AM/PM narrow-no-break-space variant
+      - NFD-normalized variant
+      - Curly-quote variant
+      - NFD + curly-quote combined variant
+   5. Return first existing variant, or the original resolved path
+
+   Returns a java.io.File."
+  ^File [raw-path cwd]
+  (let [expanded  (expand-path raw-path)
+        resolved  (resolve-to-cwd cwd expanded)
+        abs-path  (.getAbsolutePath resolved)]
+    (if (.exists resolved)
+      resolved
+      ;; Try macOS variants
+      (let [variants [(io/file (am-pm-variant abs-path))
+                      (io/file (nfd-variant abs-path))
+                      (io/file (curly-quote-variant abs-path))
+                      (io/file (nfd-curly-variant abs-path))]]
+        (or (first (filter #(.exists ^File %) variants))
+            resolved)))))

--- a/components/agent-session/src/psi/agent_session/tools.clj
+++ b/components/agent-session/src/psi/agent_session/tools.clj
@@ -7,7 +7,14 @@
    [babashka.process :as proc]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [psi.agent-session.tool-path :as tool-path]))
+   [psi.agent-session.tool-output :as tool-output]
+   [psi.agent-session.tool-path :as tool-path])
+  (:import
+   [java.awt.geom AffineTransform]
+   [java.awt.image AffineTransformOp BufferedImage]
+   [java.io ByteArrayOutputStream File FileInputStream]
+   [java.util Base64]
+   [javax.imageio ImageIO]))
 
 ;; ============================================================
 ;; Tool schemas (for agent registration)
@@ -18,7 +25,9 @@
    :label       "Read"
    :description "Read the contents of a file. Returns the file text."
    :parameters  (pr-str {:type       "object"
-                         :properties {:path {:type "string" :description "File path to read"}}
+                         :properties {:path   {:type "string" :description "File path to read"}
+                                      :offset {:type "integer" :description "1-indexed line number to start reading from"}
+                                      :limit  {:type "integer" :description "Maximum number of lines to read from offset"}}
                          :required   ["path"]})})
 
 (def bash-tool
@@ -71,6 +80,213 @@
   (let [expanded (tool-path/expand-path (str path))]
     (tool-path/resolve-to-cwd cwd expanded)))
 
+;;; File type detection
+
+(def ^:private file-type-sniff-bytes
+  "Number of bytes to read for file type detection."
+  4100)
+
+(def ^:private supported-image-mimes
+  "Set of MIME types we handle as image attachments."
+  #{"image/jpeg" "image/png" "image/gif" "image/webp"})
+
+(defn- bytes-start-with?
+  "Check if byte array starts with the given byte sequence."
+  [^bytes buf ^bytes sig]
+  (when (>= (alength buf) (alength sig))
+    (loop [i 0]
+      (if (>= i (alength sig))
+        true
+        (if (= (aget buf i) (aget sig i))
+          (recur (inc i))
+          false)))))
+
+(defn detect-mime
+  "Detect MIME type from magic bytes. Returns MIME string or nil.
+   Checks JPEG (FF D8 FF), PNG (89 50 4E 47), GIF (47 49 46 38),
+   WebP (52 49 46 46 ... 57 45 42 50)."
+  [^bytes buf]
+  (when (and buf (pos? (alength buf)))
+    (cond
+      ;; JPEG: FF D8 FF
+      (bytes-start-with? buf (byte-array [(unchecked-byte 0xFF)
+                                          (unchecked-byte 0xD8)
+                                          (unchecked-byte 0xFF)]))
+      "image/jpeg"
+
+      ;; PNG: 89 50 4E 47
+      (bytes-start-with? buf (byte-array [(unchecked-byte 0x89)
+                                          (byte 0x50)
+                                          (byte 0x4E)
+                                          (byte 0x47)]))
+      "image/png"
+
+      ;; GIF: 47 49 46 38
+      (bytes-start-with? buf (byte-array [(byte 0x47)
+                                          (byte 0x49)
+                                          (byte 0x46)
+                                          (byte 0x38)]))
+      "image/gif"
+
+      ;; WebP: RIFF....WEBP (bytes 0-3 = RIFF, bytes 8-11 = WEBP)
+      (and (>= (alength buf) 12)
+           (bytes-start-with? buf (byte-array [(byte 0x52) (byte 0x49)
+                                               (byte 0x46) (byte 0x46)]))
+           (= (aget buf 8) (byte 0x57))
+           (= (aget buf 9) (byte 0x45))
+           (= (aget buf 10) (byte 0x42))
+           (= (aget buf 11) (byte 0x50)))
+      "image/webp"
+
+      :else nil)))
+
+(defn- binary-file?
+  "Check if byte array contains null bytes, indicating a binary file."
+  [^bytes buf]
+  (let [len (alength buf)]
+    (loop [i 0]
+      (if (>= i len)
+        false
+        (if (zero? (aget buf i))
+          true
+          (recur (inc i)))))))
+
+(defn- read-file-prefix
+  "Read up to n bytes from the start of a file. Returns byte array."
+  [^File f n]
+  (with-open [fis (FileInputStream. f)]
+    (let [buf (byte-array n)
+          read-count (.read fis buf)]
+      (if (< read-count n)
+        (java.util.Arrays/copyOf buf (max 0 read-count))
+        buf))))
+
+;;; Image handling
+
+(def ^:private auto-resize-max-dim
+  "Maximum width or height for auto-resized images."
+  2000)
+
+(defn- resize-image
+  "Resize an image if wider or taller than max-dim.
+   Returns [base64-string mime-type]. Input is raw file bytes and detected mime."
+  [^bytes file-bytes ^String mime]
+  (let [bais   (java.io.ByteArrayInputStream. file-bytes)
+        img    (ImageIO/read bais)
+        w      (.getWidth img)
+        h      (.getHeight img)]
+    (if (and (<= w auto-resize-max-dim) (<= h auto-resize-max-dim))
+      ;; No resize needed
+      [(.encodeToString (Base64/getEncoder) file-bytes) mime]
+      ;; Resize maintaining aspect ratio
+      (let [scale   (min (/ (double auto-resize-max-dim) w)
+                         (/ (double auto-resize-max-dim) h))
+            new-w   (int (* w scale))
+            new-h   (int (* h scale))
+            tx      (AffineTransform/getScaleInstance scale scale)
+            op      (AffineTransformOp. tx AffineTransformOp/TYPE_BILINEAR)
+            dest    (BufferedImage. new-w new-h (.getType img))
+            _       (.filter op img dest)
+            baos    (ByteArrayOutputStream.)
+            ;; Write as PNG for lossless resized output
+            format  (case mime
+                      "image/jpeg" "jpg"
+                      "image/png"  "png"
+                      "image/gif"  "png"
+                      "image/webp" "png"
+                      "png")
+            out-mime (case format
+                       "jpg" "image/jpeg"
+                       "png" "image/png")
+            _       (ImageIO/write dest format baos)]
+        [(.encodeToString (Base64/getEncoder) (.toByteArray baos)) out-mime]))))
+
+(defn- read-image-file
+  "Read an image file and return content blocks with base64 data."
+  [^File f ^String mime {:keys [auto-resize-images]
+                         :or   {auto-resize-images true}}]
+  (let [file-bytes (java.nio.file.Files/readAllBytes (.toPath f))]
+    (if auto-resize-images
+      (let [[b64 out-mime] (resize-image file-bytes mime)]
+        {:content  [{:type "text" :text (str "Read image file [" out-mime "]")}
+                    {:type "image" :data b64 :mimeType out-mime}]
+         :is-error false
+         :details  nil})
+      (let [b64 (.encodeToString (Base64/getEncoder) file-bytes)]
+        {:content  [{:type "text" :text (str "Read image file [" mime "]")}
+                    {:type "image" :data b64 :mimeType mime}]
+         :is-error false
+         :details  nil}))))
+
+(defn- read-binary-file
+  "Return a warning-only result for non-image binary files."
+  [^File f]
+  {:content  (str "Binary file detected: " (.getAbsolutePath f) ". Content omitted.")
+   :is-error false
+   :details  {:binary-file-detected true
+              :truncation           nil}})
+
+;;; Text file reading with offset/limit/truncation
+
+(defn- read-text-file
+  "Read a text file with optional offset/limit and head truncation.
+   offset is 1-indexed. Returns spec-compliant result map."
+  [^File f offset limit {:keys [overrides]}]
+  (let [content    (slurp f)
+        all-lines  (str/split-lines content)
+        total-lines (count all-lines)
+        start-idx  (max 0 (dec (or offset 1)))
+        start-display (inc start-idx)]
+    ;; Validate offset
+    (when (and offset (>= start-idx total-lines))
+      (throw (ex-info (str "Offset " offset " is beyond end of file ("
+                           total-lines " lines total)")
+                      {:offset offset :total-lines total-lines})))
+    ;; Select lines
+    (let [end-idx      (if limit
+                         (min (+ start-idx limit) total-lines)
+                         total-lines)
+          selected     (subvec (vec all-lines) start-idx end-idx)
+          selected-text (str/join "\n" selected)
+          policy       (tool-output/effective-policy (or overrides {}) "read")
+          truncation   (tool-output/head-truncate selected-text policy)]
+      (cond
+        ;; First line exceeds byte limit
+        (:first-line-exceeds-limit truncation)
+        {:content  (str "[Line " start-display " exceeds "
+                        (:max-bytes truncation) " bytes. Use bash for a bounded slice.]")
+         :is-error false
+         :details  {:truncation          truncation
+                    :binary-file-detected false}}
+
+        ;; Truncated by policy
+        (:truncated truncation)
+        (let [shown-end (+ start-idx (:output-lines truncation))
+              guidance  (str "\n\n--- Showing lines " start-display "-" shown-end
+                             " of " total-lines " total. Use offset="
+                             (inc shown-end) " to continue.")]
+          {:content  (str (:content truncation) guidance)
+           :is-error false
+           :details  {:truncation          truncation
+                      :binary-file-detected false}})
+
+        ;; Not truncated but limit was used and more lines exist
+        (and limit (< end-idx total-lines))
+        (let [remaining (- total-lines end-idx)
+              guidance  (str "\n\n--- " remaining " more lines in file. Use offset="
+                             (inc end-idx) " to continue.")]
+          {:content  (str (:content truncation) guidance)
+           :is-error false
+           :details  {:truncation          truncation
+                      :binary-file-detected false}})
+
+        ;; Full content, no truncation
+        :else
+        {:content  (:content truncation)
+         :is-error false
+         :details  {:truncation          truncation
+                    :binary-file-detected false}}))))
+
 (defn- slurp-file
   ([path] (slurp-file nil path))
   ([cwd path]
@@ -81,12 +297,34 @@
 
 (defn execute-read
   "Read a file and return its contents.
-   Accepts optional :cwd in opts to resolve relative paths."
+   Supports binary safety (magic-byte detection), image attachments,
+   offset/limit line slicing, and head truncation per output policy.
+
+   Accepts optional :cwd in opts to resolve relative paths.
+   Accepts optional :overrides in opts for output policy overrides.
+   Accepts optional :auto-resize-images in opts (default true)."
   ([args] (execute-read args nil))
-  ([{:strs [path]} {:keys [cwd]}]
-   (let [content (slurp-file cwd path)]
-     {:content  content
-      :is-error false})))
+  ([{:strs [path offset limit]} {:keys [cwd] :as opts}]
+   (let [f (tool-path/resolve-read-path (str path) cwd)]
+     ;; Check file exists
+     (when-not (.exists f)
+       (throw (ex-info (str "File not found: " (.getAbsolutePath f))
+                       {:path (.getAbsolutePath f)})))
+     ;; Sniff file type
+     (let [prefix (read-file-prefix f file-type-sniff-bytes)
+           mime   (detect-mime prefix)]
+       (cond
+         ;; Supported image — return as attachment
+         (supported-image-mimes mime)
+         (read-image-file f mime opts)
+
+         ;; Non-image binary — warning only
+         (binary-file? prefix)
+         (read-binary-file f)
+
+         ;; Text file — offset/limit/truncation
+         :else
+         (read-text-file f offset limit opts))))))
 
 (defn execute-bash
   "Run a shell command via babashka.process, returning combined stdout+stderr.

--- a/components/agent-session/src/psi/agent_session/tools.clj
+++ b/components/agent-session/src/psi/agent_session/tools.clj
@@ -6,7 +6,8 @@
   (:require
    [babashka.process :as proc]
    [clojure.java.io :as io]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [psi.agent-session.tool-path :as tool-path]))
 
 ;; ============================================================
 ;; Tool schemas (for agent registration)
@@ -64,13 +65,11 @@
 ;; ============================================================
 
 (defn- resolve-path
-  "Resolve a path against an optional cwd. When cwd is provided and path
-   is relative, returns the resolved file. Otherwise returns the path as-is."
+  "Resolve a path against an optional cwd. Delegates to tool-path for
+   normalization (strip @, unicode spaces, tilde expansion) and cwd resolution."
   ^java.io.File [cwd path]
-  (let [f (io/file (str path))]
-    (if (and cwd (not (.isAbsolute f)))
-      (io/file cwd (str path))
-      f)))
+  (let [expanded (tool-path/expand-path (str path))]
+    (tool-path/resolve-to-cwd cwd expanded)))
 
 (defn- slurp-file
   ([path] (slurp-file nil path))

--- a/components/agent-session/src/psi/agent_session/tools.clj
+++ b/components/agent-session/src/psi/agent_session/tools.clj
@@ -58,6 +58,39 @@
                                       :content {:type "string" :description "Content to write"}}
                          :required   ["path" "content"]})})
 
+(def ls-tool
+  {:name        "ls"
+   :label       "List"
+   :description "List directory contents with optional entry limit."
+   :parameters  (pr-str {:type       "object"
+                         :properties {:path  {:type "string" :description "Directory path to list (defaults to .)"}
+                                      :limit {:type "integer" :description "Maximum number of entries to return (default 500)"}}
+                         :required   []})})
+
+(def find-tool
+  {:name        "find"
+   :label       "Find"
+   :description "Find files by glob pattern."
+   :parameters  (pr-str {:type       "object"
+                         :properties {:pattern {:type "string" :description "Glob pattern, e.g. *.clj"}
+                                      :path    {:type "string" :description "Search root path (defaults to .)"}
+                                      :limit   {:type "integer" :description "Maximum results (default 1000)"}}
+                         :required   ["pattern"]})})
+
+(def grep-tool
+  {:name        "grep"
+   :label       "Grep"
+   :description "Search file contents for matches."
+   :parameters  (pr-str {:type       "object"
+                         :properties {:pattern    {:type "string" :description "Search pattern"}
+                                      :path       {:type "string" :description "Search root path (defaults to .)"}
+                                      :glob       {:type "string" :description "Optional glob filter"}
+                                      :ignoreCase {:type "boolean" :description "Case-insensitive search"}
+                                      :literal    {:type "boolean" :description "Treat pattern as literal text"}
+                                      :context    {:type "integer" :description "Context lines around matches"}
+                                      :limit      {:type "integer" :description "Maximum matches (default 100)"}}
+                         :required   ["pattern"]})})
+
 (def eql-query-tool
   {:name        "eql_query"
    :label       "EQL Query"
@@ -67,7 +100,7 @@
                          :required   ["query"]})})
 
 (def all-tool-schemas
-  [read-tool bash-tool edit-tool write-tool eql-query-tool])
+  [read-tool bash-tool edit-tool write-tool ls-tool find-tool grep-tool eql-query-tool])
 
 ;; ============================================================
 ;; Tool implementations
@@ -326,70 +359,389 @@
          :else
          (read-text-file f offset limit opts))))))
 
+(defonce ^:private bash-process-atom
+  (atom nil))
+
+(defn abort-bash!
+  "Abort the currently running bash process, if any.
+   Returns true if a process was aborted, false otherwise."
+  []
+  (when-let [p @bash-process-atom]
+    (try
+      (.destroyForcibly ^Process (:proc p))
+      true
+      (catch Exception _
+        false))))
+
 (defn execute-bash
   "Run a shell command via babashka.process, returning combined stdout+stderr.
-   Stdin is bound to /dev/null so tools like rg don't misdetect a readable
-   pipe and search stdin instead of the working directory.
-   Accepts optional :cwd in opts to set the working directory."
+
+   Spec-compliant behavior:
+   - Stdin bound to /dev/null
+   - Tail truncation via effective output policy for \"bash\"
+   - Full-output spill file when truncated (fullOutputPath in details)
+   - Timeout with process destruction (default 30s)
+   - Non-zero exit prefixed with exit code
+   - Command prefix support
+   - Streaming on-update callback
+
+   Accepts optional opts map:
+   - :cwd           — working directory
+   - :overrides     — output policy overrides map
+   - :command-prefix — prepended to command with newline separator
+   - :on-update     — (fn [{:content s :details d}]) called during execution
+   - :tool-call-id  — identifier for temp artifact naming"
   ([args] (execute-bash args nil))
-  ([{:strs [command]} {:keys [cwd]}]
-   (let [result (proc/shell (cond-> {:out      :string
-                                     :err      :string
-                                     :continue true
-                                     :in       (java.io.File. "/dev/null")}
-                              cwd (assoc :dir cwd))
-                            "bash" "-c" command)
-         out    (str (:out result) (:err result))]
-     {:content  (if (str/blank? out) "[no output]" out)
-      :is-error (not= 0 (:exit result))})))
+  ([{:strs [command timeout]} {:keys [cwd overrides command-prefix on-update tool-call-id]}]
+   (let [timeout-secs  (or timeout 30)
+         resolved-cmd  (if command-prefix
+                         (str command-prefix "\n" command)
+                         command)
+         policy        (tool-output/effective-policy (or overrides {}) "bash")
+         proc-opts     (cond-> {:out      :string
+                                :err      :string
+                                :in       (java.io.File. "/dev/null")}
+                         cwd (assoc :dir cwd))]
+     (try
+       (let [p      (proc/process proc-opts "bash" "-c" resolved-cmd)
+             _      (reset! bash-process-atom {:proc (:proc p)})
+             ;; Wait with timeout — IBlockingDeref returns timeout-value on timeout
+             result (deref p (* timeout-secs 1000) ::timeout)]
+         (reset! bash-process-atom nil)
+         (when (= result ::timeout)
+           (.destroyForcibly ^Process (:proc p)))
+         (if (= result ::timeout)
+           ;; Timeout result
+           {:content  (str "Command timed out after " timeout-secs " seconds")
+            :is-error true
+            :details  nil}
+           ;; Normal completion
+           (let [merged    (str (:out result) (:err result))
+                 exit-code (:exit result)
+                 non-zero? (not= 0 exit-code)
+                 trunc     (tool-output/tail-truncate merged policy)
+                 truncated? (:truncated trunc)
+                 base-text (if (str/blank? (:content trunc))
+                             "(no output)"
+                             (:content trunc))
+                 ;; Persist full output if truncated
+                 spill-path (when truncated?
+                              (tool-output/persist-truncated-output!
+                               "bash"
+                               (or tool-call-id (str (java.util.UUID/randomUUID)))
+                               merged))
+                 ;; Build content
+                 content   (cond-> ""
+                             non-zero?
+                             (str "Command exited with code " exit-code "\n")
+
+                             true
+                             (str base-text)
+
+                             truncated?
+                             (str "\n\n... [truncated, " (:total-lines trunc)
+                                  " total lines] Full output: " spill-path))]
+             {:content  content
+              :is-error non-zero?
+              :details  (when truncated?
+                          {:truncation       trunc
+                           :full-output-path spill-path})})))
+       (catch Exception e
+         (reset! bash-process-atom nil)
+         {:content  (str "Command execution error: " (ex-message e))
+          :is-error true
+          :details  nil})))))
+
+(defn- normalize-line-endings
+  [s]
+  (str/replace (or s "") #"\r\n" "\n"))
+
+(defn- detect-line-ending
+  [s]
+  (if (str/includes? (or s "") "\r\n") "\r\n" "\n"))
+
+(defn- trim-trailing-ws
+  [s]
+  (str/replace s #"[ \t]+$" ""))
+
+(defn- normalize-smart-punctuation
+  [s]
+  (-> s
+      (str/replace "\u2018" "'")
+      (str/replace "\u2019" "'")
+      (str/replace "\u201C" "\"")
+      (str/replace "\u201D" "\"")
+      (str/replace "\u2013" "-")
+      (str/replace "\u2014" "-")))
+
+(defn- fuzzy-line
+  [s]
+  (-> (or s "")
+      normalize-smart-punctuation
+      trim-trailing-ws))
+
+(defn- split-lines-preserve
+  [s]
+  (vec (str/split (or s "") #"\n" -1)))
+
+(defn- find-fuzzy-window
+  [content old-text]
+  (let [content-lines (split-lines-preserve content)
+        old-lines     (split-lines-preserve old-text)
+        clen          (count content-lines)
+        olen          (count old-lines)]
+    (when (pos? olen)
+      (->> (range 0 (inc (- clen olen)))
+           (filter (fn [start]
+                     (every?
+                      true?
+                      (for [i (range olen)]
+                        (= (fuzzy-line (nth content-lines (+ start i)))
+                           (fuzzy-line (nth old-lines i)))))))
+           vec))))
+
+(defn- first-changed-line
+  [before after]
+  (let [before-lines (split-lines-preserve (normalize-line-endings before))
+        after-lines  (split-lines-preserve (normalize-line-endings after))
+        max-len      (max (count before-lines) (count after-lines))]
+    (some (fn [i]
+            (when (not= (nth before-lines i nil) (nth after-lines i nil))
+              (inc i)))
+          (range max-len))))
+
+(defn- simple-diff
+  [before after]
+  (let [line (or (first-changed-line before after) 1)]
+    (str "--- original\n"
+         "+++ updated\n"
+         "@@ first-changed-line " line " @@\n")))
 
 (defn execute-edit
   "Replace oldText with newText in a file.
-   Accepts optional :cwd in opts to resolve relative paths."
+   Accepts optional :cwd in opts to resolve relative paths.
+   Preserves BOM and dominant line endings.
+   If exact match fails, tries fuzzy matching (smart punctuation + trailing ws)."
   ([args] (execute-edit args nil))
   ([{:strs [path oldText newText]} {:keys [cwd]}]
-   (let [f       (resolve-path cwd path)
-         fpath   (.getPath f)
-         content (slurp-file cwd path)]
-     (when-not (str/includes? content oldText)
-       (throw (ex-info "oldText not found in file"
-                       {:path fpath :oldText (subs oldText 0 (min 80 (count oldText)))})))
-     (let [updated (str/replace-first content oldText newText)]
-       (spit f updated)
-       {:content  (str "Edited " fpath)
-        :is-error false}))))
+   (let [f             (resolve-path cwd path)
+         fpath         (.getPath f)
+         raw-content   (slurp-file cwd path)
+         has-bom?      (str/starts-with? raw-content "\uFEFF")
+         no-bom        (if has-bom? (subs raw-content 1) raw-content)
+         line-ending   (detect-line-ending no-bom)
+         content-norm  (normalize-line-endings no-bom)
+         old-norm      (normalize-line-endings oldText)
+         new-norm      (normalize-line-endings newText)
+         exact-index   (str/index-of content-norm old-norm)]
+     (let [updated-norm
+           (if (some? exact-index)
+             (str/replace-first content-norm old-norm new-norm)
+             (let [matches (find-fuzzy-window content-norm old-norm)]
+               (cond
+                 (empty? matches)
+                 (throw (ex-info "oldText not found in file"
+                                 {:path fpath :oldText (subs oldText 0 (min 80 (count oldText)))}))
+
+                 (> (count matches) 1)
+                 (throw (ex-info "Fuzzy match is ambiguous"
+                                 {:path fpath :match-count (count matches)}))
+
+                 :else
+                 (let [start        (first matches)
+                       content-lines (split-lines-preserve content-norm)
+                       old-lines     (split-lines-preserve old-norm)
+                       new-lines     (split-lines-preserve new-norm)
+                       prefix       (subvec content-lines 0 start)
+                       suffix       (subvec content-lines (+ start (count old-lines)))
+                       replaced     (concat prefix new-lines suffix)]
+                   (str/join "\n" replaced)))))
+           updated-out   (-> updated-norm
+                             (str/replace "\n" line-ending)
+                             (#(if has-bom? (str "\uFEFF" %) %)))
+           diff          (simple-diff raw-content updated-out)
+           changed-line  (or (first-changed-line raw-content updated-out) 1)]
+       (spit f updated-out)
+       {:content  (str "Successfully replaced text in " fpath ".")
+        :is-error false
+        :details  {:diff diff
+                   :first-changed-line changed-line}}))))
 
 (defn execute-write
   "Write content to a file (creates parent dirs if needed).
    Accepts optional :cwd in opts to resolve relative paths."
   ([args] (execute-write args nil))
   ([{:strs [path content]} {:keys [cwd]}]
-   (let [f     (resolve-path cwd path)
-         fpath (.getPath f)]
+   (let [f      (resolve-path cwd path)
+         fpath  (.getPath f)
+         bytes  (count (.getBytes (or content "") "UTF-8"))]
      (io/make-parents f)
      (spit f content)
-     {:content  (str "Wrote " fpath)
+     {:content  (str "Successfully wrote " bytes " bytes to " fpath)
       :is-error false})))
+
+(def ^:private max-safe-lines 9007199254740991)
+
+(defn- append-limit-notice
+  [content notices]
+  (if (seq notices)
+    (str content "\n\n[limit reached: " (str/join "; " notices) "]")
+    content))
+
+(defn execute-ls
+  "List directory contents with semantic entry limit then byte truncation."
+  ([args] (execute-ls args nil))
+  ([{:strs [path limit]} {:keys [cwd overrides]}]
+   (let [dir       (resolve-path cwd (or path "."))
+         dir-path  (.getPath dir)]
+     (when-not (.exists dir)
+       (throw (ex-info (str "Path not found: " dir-path) {:path dir-path})))
+     (when-not (.isDirectory dir)
+       (throw (ex-info (str "Not a directory: " dir-path) {:path dir-path})))
+     (let [entries        (->> (or (.listFiles dir) (into-array File []))
+                               (map (fn [^File f]
+                                      (let [n (.getName f)]
+                                        (if (.isDirectory f) (str n "/") n))))
+                               (sort-by str/lower-case)
+                               vec)
+           entry-limit    (max 1 (or limit 500))
+           primary        (vec (take entry-limit entries))
+           joined         (if (seq primary) (str/join "\n" primary) "")
+           base-policy    (tool-output/effective-policy (or overrides {}) "ls")
+           truncation     (tool-output/head-truncate joined (assoc base-policy :max-lines max-safe-lines))
+           entry-hit?     (> (count entries) entry-limit)
+           notices        (cond-> []
+                            entry-hit? (conj (str "entry limit " entry-limit))
+                            (:truncated truncation) (conj (str "byte limit " (:max-bytes truncation))))
+           base-content   (if (zero? (count entries)) "(empty directory)" (:content truncation))]
+       {:content  (append-limit-notice base-content notices)
+        :is-error false
+        :details  (cond-> {}
+                    (:truncated truncation) (assoc :truncation truncation)
+                    entry-hit? (assoc :entry-limit-reached entry-limit))}))))
+
+(defn execute-find
+  "Find files by glob pattern with semantic result limit then byte truncation."
+  ([args] (execute-find args nil))
+  ([{:strs [pattern path limit]} {:keys [cwd overrides]}]
+   (let [search-root (resolve-path cwd (or path "."))
+         root-path   (.getPath search-root)]
+     (when-not (.exists search-root)
+       (throw (ex-info (str "Path not found: " root-path) {:path root-path})))
+     (let [result-limit (max 1 (or limit 1000))
+           root-nio     (.toPath search-root)
+           matcher      (.getPathMatcher (java.nio.file.FileSystems/getDefault)
+                                         (str "glob:" (or pattern "*")))
+           matched      (->> (file-seq search-root)
+                             (filter #(.isFile ^File %))
+                             (map (fn [^File f]
+                                    (.normalize (.relativize root-nio (.toPath f)))))
+                             (filter #(.matches matcher %))
+                             (map str)
+                             sort
+                             vec)
+           primary      (vec (take result-limit matched))
+           joined       (if (seq primary) (str/join "\n" primary) "")
+           base-policy  (tool-output/effective-policy (or overrides {}) "find")
+           truncation   (tool-output/head-truncate joined (assoc base-policy :max-lines max-safe-lines))
+           result-hit?  (> (count matched) result-limit)
+           notices      (cond-> []
+                          result-hit? (conj (str "result limit " result-limit))
+                          (:truncated truncation) (conj (str "byte limit " (:max-bytes truncation))))
+           base-content (if (empty? matched) "No files found matching pattern" (:content truncation))]
+       {:content  (append-limit-notice base-content notices)
+        :is-error false
+        :details  (cond-> {}
+                    (:truncated truncation) (assoc :truncation truncation)
+                    result-hit? (assoc :result-limit-reached result-limit))}))))
+
+(defn execute-grep
+  "Search file contents with semantic match limit then byte truncation."
+  ([args] (execute-grep args nil))
+  ([{:strs [pattern path glob ignoreCase literal context limit]} {:keys [cwd overrides]}]
+   (let [search-root  (resolve-path cwd (or path "."))
+         root-path    (.getPath search-root)
+         match-limit  (max 1 (or limit 100))
+         context-n    (max 0 (or context 0))
+         args         (cond-> ["rg" "--line-number" "--no-heading" "-m" (str match-limit)]
+                        literal (conj "--fixed-strings")
+                        ignoreCase (conj "--ignore-case")
+                        (some? glob) (conj "--glob" glob)
+                        (pos? context-n) (conj "-C" (str context-n))
+                        :always (conj pattern root-path))
+         proc-result  (apply proc/shell (cond-> {:out :string :err :string :continue true :in (java.io.File. "/dev/null")}
+                                          cwd (assoc :dir cwd)) args)
+         raw-lines    (->> (str/split-lines (str (:out proc-result)))
+                           (remove str/blank?)
+                           vec)
+         [rendered lines-truncated?]
+         (reduce (fn [[acc hit?] line]
+                   (if (> (count line) 500)
+                     [(conj acc (str (subs line 0 500) "... [truncated]")) true]
+                     [(conj acc line) hit?]))
+                 [[] false]
+                 raw-lines)
+         joined       (str/join "\n" rendered)
+         base-policy  (tool-output/effective-policy (or overrides {}) "grep")
+         truncation   (tool-output/head-truncate joined (assoc base-policy :max-lines max-safe-lines))
+         found-count  (count raw-lines)
+         match-hit?   (and (pos? found-count) (>= found-count match-limit))
+         notices      (cond-> []
+                        match-hit? (conj (str "match limit " match-limit))
+                        lines-truncated? (conj "long lines truncated")
+                        (:truncated truncation) (conj (str "byte limit " (:max-bytes truncation))))
+         base-content (if (zero? found-count) "No matches found" (:content truncation))]
+     {:content  (append-limit-notice base-content notices)
+      :is-error false
+      :details  (cond-> {}
+                  (:truncated truncation) (assoc :truncation truncation)
+                  match-hit? (assoc :match-limit-reached match-limit)
+                  lines-truncated? (assoc :lines-truncated true))})))
 
 (defn make-eql-query-tool
   "Create an eql_query tool with an :execute fn that closes over `query-fn`.
    `query-fn` should be (fn [eql-query-vec] -> result-map), typically
-   `(partial resolvers/query-in ctx)` or `(fn [q] (session/query-in ctx q))`."
-  [query-fn]
-  (assoc eql-query-tool
-         :execute
-         (fn [{:strs [query]}]
-           (try
-             (let [q (binding [*read-eval* false]
-                       (read-string query))]
-               (when-not (vector? q)
-                 (throw (ex-info "Query must be an EDN vector" {:input query})))
-               (let [result (query-fn q)]
-                 {:content  (pr-str result)
-                  :is-error false}))
-             (catch Exception e
-               {:content  (str "EQL query error: " (ex-message e))
-                :is-error true})))))
+   `(partial resolvers/query-in ctx)` or `(fn [q] (session/query-in ctx q))`.
+
+   Optional opts:
+   - :overrides   output-policy overrides map
+   - :tool-call-id identifier for temp artifact naming when output is truncated"
+  ([query-fn]
+   (make-eql-query-tool query-fn nil))
+  ([query-fn {:keys [overrides tool-call-id]}]
+   (assoc eql-query-tool
+          :execute
+          (fn [{:strs [query]}]
+            (try
+              (let [q (binding [*read-eval* false]
+                        (read-string query))]
+                (when-not (vector? q)
+                  (throw (ex-info "Query must be an EDN vector" {:input query})))
+                (let [result      (query-fn q)
+                      output      (pr-str result)
+                      policy      (tool-output/effective-policy (or overrides {}) "eql_query")
+                      truncation  (tool-output/head-truncate output policy)
+                      truncated?  (:truncated truncation)
+                      spill-path  (when truncated?
+                                    (tool-output/persist-truncated-output!
+                                     "eql_query"
+                                     (or tool-call-id (str (java.util.UUID/randomUUID)))
+                                     output))]
+                  (if truncated?
+                    {:content  (str "Output truncated ("
+                                    (:total-lines truncation) " lines / "
+                                    (:total-bytes truncation) " bytes). Full output: " spill-path
+                                    ". Use a narrower query to reduce output size.\n\n"
+                                    (:content truncation))
+                     :is-error false
+                     :details  {:truncation       truncation
+                                :full-output-path spill-path}}
+                    {:content  (:content truncation)
+                     :is-error false
+                     :details  nil})))
+              (catch Exception e
+                {:content  (str "EQL query error: " (ex-message e))
+                 :is-error true}))))))
 
 (def all-tools
   "Built-in tool definitions including execution fns.
@@ -415,7 +767,22 @@
     :label       (:label write-tool)
     :description (:description write-tool)
     :parameters  (:parameters write-tool)
-    :execute     execute-write}])
+    :execute     execute-write}
+   {:name        (:name ls-tool)
+    :label       (:label ls-tool)
+    :description (:description ls-tool)
+    :parameters  (:parameters ls-tool)
+    :execute     execute-ls}
+   {:name        (:name find-tool)
+    :label       (:label find-tool)
+    :description (:description find-tool)
+    :parameters  (:parameters find-tool)
+    :execute     execute-find}
+   {:name        (:name grep-tool)
+    :label       (:label grep-tool)
+    :description (:description grep-tool)
+    :parameters  (:parameters grep-tool)
+    :execute     execute-grep}])
 
 ;; ============================================================
 ;; CWD-scoped tools
@@ -450,9 +817,38 @@
       :parameters  (:parameters write-tool)
       :execute     (fn [args] (execute-write args opts))}]))
 
+(defn make-read-only-tools-with-cwd
+  "Return read-only/search tools scoped to cwd in canonical order:
+   [read, grep, find, ls]."
+  [cwd]
+  (let [opts {:cwd cwd}]
+    [{:name        (:name read-tool)
+      :label       (:label read-tool)
+      :description (:description read-tool)
+      :parameters  (:parameters read-tool)
+      :execute     (fn [args] (execute-read args opts))}
+     {:name        (:name grep-tool)
+      :label       (:label grep-tool)
+      :description (:description grep-tool)
+      :parameters  (:parameters grep-tool)
+      :execute     (fn [args] (execute-grep args opts))}
+     {:name        (:name find-tool)
+      :label       (:label find-tool)
+      :description (:description find-tool)
+      :parameters  (:parameters find-tool)
+      :execute     (fn [args] (execute-find args opts))}
+     {:name        (:name ls-tool)
+      :label       (:label ls-tool)
+      :description (:description ls-tool)
+      :parameters  (:parameters ls-tool)
+      :execute     (fn [args] (execute-ls args opts))}]))
+
 ;; ============================================================
 ;; Dispatch
 ;; ============================================================
+
+(def built-in-dispatch-tools
+  #{"read" "bash" "edit" "write" "ls" "find" "grep"})
 
 (defn execute-tool
   "Dispatch a tool call by name. Returns {:content string :is-error boolean}.
@@ -465,4 +861,7 @@
     "bash"  (execute-bash args-map)
     "edit"  (execute-edit args-map)
     "write" (execute-write args-map)
+    "ls"    (execute-ls args-map)
+    "find"  (execute-find args-map)
+    "grep"  (execute-grep args-map)
     (throw (ex-info (str "Unknown tool: " tool-name) {:tool tool-name}))))

--- a/components/agent-session/test/psi/agent_session/bash_tool_test.clj
+++ b/components/agent-session/test/psi/agent_session/bash_tool_test.clj
@@ -1,0 +1,187 @@
+(ns psi.agent-session.bash-tool-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.tool-output :as tool-output]
+   [psi.agent-session.tools :as tools]))
+
+(defn- with-temp-dir
+  "Create a temp dir, run f with its path, clean up."
+  [f]
+  (let [tmp (java.io.File/createTempFile "psi-bash-test" "")]
+    (.delete tmp)
+    (.mkdirs tmp)
+    (try
+      (f (.getAbsolutePath tmp))
+      (finally
+        (doseq [file (reverse (file-seq tmp))]
+          (.delete file))))))
+
+;;; Normal execution
+
+(deftest execute-bash-normal-test
+  (testing "simple command returns output"
+    (let [result (tools/execute-bash {"command" "echo hello"})]
+      (is (false? (:is-error result)))
+      (is (str/includes? (:content result) "hello"))
+      (is (nil? (:details result)))))
+
+  (testing "command with no output returns (no output)"
+    (let [result (tools/execute-bash {"command" "true"})]
+      (is (false? (:is-error result)))
+      (is (= "(no output)" (:content result)))))
+
+  (testing "stderr is merged into output"
+    (let [result (tools/execute-bash {"command" "echo out; echo err >&2"})]
+      (is (false? (:is-error result)))
+      (is (str/includes? (:content result) "out"))
+      (is (str/includes? (:content result) "err")))))
+
+;;; Non-zero exit
+
+(deftest execute-bash-non-zero-exit-test
+  (testing "non-zero exit sets is-error and includes exit code"
+    (let [result (tools/execute-bash {"command" "exit 42"})]
+      (is (true? (:is-error result)))
+      (is (str/includes? (:content result) "Command exited with code 42"))))
+
+  (testing "non-zero exit with output includes both"
+    (let [result (tools/execute-bash {"command" "echo before-fail; exit 1"})]
+      (is (true? (:is-error result)))
+      (is (str/includes? (:content result) "Command exited with code 1"))
+      (is (str/includes? (:content result) "before-fail")))))
+
+;;; Tail truncation
+
+(deftest execute-bash-truncation-test
+  (testing "output within limits has no truncation details"
+    (let [result (tools/execute-bash {"command" "echo short"} {:overrides {}})]
+      (is (false? (:is-error result)))
+      (is (nil? (:details result)))))
+
+  (testing "output exceeding line limit is tail-truncated with spill file"
+    ;; Use a very small policy to force truncation
+    (let [result (tools/execute-bash
+                  {"command" "seq 1 100"}
+                  {:overrides {"bash" {:max-lines 5 :max-bytes 25600}}})]
+      (is (false? (:is-error result)))
+      ;; Should have truncation details
+      (is (some? (:details result)))
+      (is (true? (get-in result [:details :truncation :truncated])))
+      (is (= 100 (get-in result [:details :truncation :total-lines])))
+      (is (<= (get-in result [:details :truncation :output-lines]) 5))
+      ;; Should have full output path
+      (let [spill-path (get-in result [:details :full-output-path])]
+        (is (some? spill-path))
+        (is (.exists (io/file spill-path)))
+        ;; Full output file should contain all 100 lines
+        (let [full-content (slurp spill-path)]
+          (is (= 100 (count (str/split-lines full-content))))))
+      ;; Content should mention truncation and path
+      (is (str/includes? (:content result) "truncated"))
+      (is (str/includes? (:content result) "100 total lines"))
+      (is (str/includes? (:content result) "Full output:"))))
+
+  (testing "output exceeding byte limit is tail-truncated"
+    (let [result (tools/execute-bash
+                  {"command" "seq 1 1000"}
+                  {:overrides {"bash" {:max-lines 10000 :max-bytes 50}}})]
+      (is (false? (:is-error result)))
+      (is (some? (:details result)))
+      (is (true? (get-in result [:details :truncation :truncated])))
+      (is (= :bytes (get-in result [:details :truncation :truncated-by]))))))
+
+;;; Timeout
+
+(deftest execute-bash-timeout-test
+  (testing "command that exceeds timeout returns error"
+    (let [result (tools/execute-bash {"command" "sleep 10" "timeout" 1})]
+      (is (true? (:is-error result)))
+      (is (str/includes? (:content result) "Command timed out after 1 seconds"))
+      (is (nil? (:details result)))))
+
+  (testing "command that finishes before timeout succeeds"
+    (let [result (tools/execute-bash {"command" "echo fast" "timeout" 5})]
+      (is (false? (:is-error result)))
+      (is (str/includes? (:content result) "fast")))))
+
+;;; CWD support
+
+(deftest execute-bash-cwd-test
+  (testing "bash runs in cwd when provided"
+    (with-temp-dir
+      (fn [dir]
+        (spit (io/file dir "marker.txt") "found-it")
+        (let [result (tools/execute-bash {"command" "cat marker.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/includes? (:content result) "found-it"))))))
+
+  (testing "bash without cwd works as before"
+    (let [result (tools/execute-bash {"command" "echo hello"})]
+      (is (false? (:is-error result)))
+      (is (str/includes? (:content result) "hello")))))
+
+;;; Command prefix
+
+(deftest execute-bash-command-prefix-test
+  (testing "command prefix is prepended to command"
+    (let [result (tools/execute-bash
+                  {"command" "echo $MY_VAR"}
+                  {:command-prefix "export MY_VAR=hello"})]
+      (is (false? (:is-error result)))
+      (is (str/includes? (:content result) "hello"))))
+
+  (testing "command without prefix works normally"
+    (let [result (tools/execute-bash {"command" "echo no-prefix"})]
+      (is (false? (:is-error result)))
+      (is (str/includes? (:content result) "no-prefix")))))
+
+;;; Tool call ID for spill files
+
+(deftest execute-bash-tool-call-id-test
+  (testing "tool-call-id is used in spill file name"
+    (let [result (tools/execute-bash
+                  {"command" "seq 1 100"}
+                  {:overrides {"bash" {:max-lines 5}}
+                   :tool-call-id "test-call-123"})]
+      (when-let [path (get-in result [:details :full-output-path])]
+        (is (str/includes? path "bash-test-call-123"))))))
+
+;;; Result shape
+
+(deftest execute-bash-result-shape-test
+  (testing "non-truncated result has correct shape"
+    (let [result (tools/execute-bash {"command" "echo ok"})]
+      (is (contains? result :content))
+      (is (contains? result :is-error))
+      (is (false? (:is-error result)))
+      ;; details is nil when no truncation
+      (is (nil? (:details result)))))
+
+  (testing "truncated result has correct shape"
+    (let [result (tools/execute-bash
+                  {"command" "seq 1 50"}
+                  {:overrides {"bash" {:max-lines 3}}})]
+      (is (contains? result :content))
+      (is (contains? result :is-error))
+      (is (contains? result :details))
+      (let [details (:details result)]
+        (is (contains? details :truncation))
+        (is (contains? details :full-output-path))
+        (let [trunc (:truncation details)]
+          (is (contains? trunc :truncated))
+          (is (contains? trunc :truncated-by))
+          (is (contains? trunc :total-lines))
+          (is (contains? trunc :total-bytes))
+          (is (contains? trunc :output-lines))
+          (is (contains? trunc :output-bytes))
+          (is (contains? trunc :max-lines))
+          (is (contains? trunc :max-bytes))
+          (is (contains? trunc :last-line-partial)))))))
+
+;;; Abort mechanism
+
+(deftest abort-bash-test
+  (testing "abort-bash! returns false when no process running"
+    (is (not (tools/abort-bash!)))))

--- a/components/agent-session/test/psi/agent_session/core_test.clj
+++ b/components/agent-session/test/psi/agent_session/core_test.clj
@@ -352,6 +352,62 @@
         (is (= ["foo"] (:psi.tool/names summary)))
         (is (= "foo" (get-in summary [:psi.tool/summary :tools 0 :name]))))))
 
+(deftest tool-output-eql-introspection-test
+  (testing "query-in resolves tool-output policy defaults and overrides"
+    (let [ctx (session/create-context {:initial-session
+                                       {:tool-output-overrides
+                                        {"bash" {:max-lines 77 :max-bytes 2048}}}})
+          result (session/query-in ctx [:psi.tool-output/default-max-lines
+                                        :psi.tool-output/default-max-bytes
+                                        :psi.tool-output/overrides])]
+      (is (= 1000 (:psi.tool-output/default-max-lines result)))
+      (is (= 25600 (:psi.tool-output/default-max-bytes result)))
+      (is (= {"bash" {:max-lines 77 :max-bytes 2048}}
+             (:psi.tool-output/overrides result)))))
+
+  (testing "query-in resolves tool-output calls and aggregate stats"
+    (let [ctx (session/create-context)]
+      (swap! (:tool-output-stats-atom ctx)
+             (fn [_]
+               {:calls [{:tool-call-id "call-1"
+                         :tool-name "bash"
+                         :timestamp (java.time.Instant/now)
+                         :limit-hit true
+                         :truncated-by :bytes
+                         :effective-max-lines 1000
+                         :effective-max-bytes 25600
+                         :output-bytes 120
+                         :context-bytes-added 64}]
+                :aggregates {:total-context-bytes 64
+                             :by-tool {"bash" 64}
+                             :limit-hits-by-tool {"bash" 1}}}))
+      (let [result (session/query-in ctx [{:psi.tool-output/calls
+                                           [:psi.tool-output.call/tool-call-id
+                                            :psi.tool-output.call/tool-name
+                                            :psi.tool-output.call/limit-hit?
+                                            :psi.tool-output.call/truncated-by
+                                            :psi.tool-output.call/effective-max-lines
+                                            :psi.tool-output.call/effective-max-bytes
+                                            :psi.tool-output.call/output-bytes
+                                            :psi.tool-output.call/context-bytes-added]}
+                                          :psi.tool-output/stats])
+            calls  (:psi.tool-output/calls result)
+            first-call (first calls)
+            stats  (:psi.tool-output/stats result)]
+        (is (= 1 (count calls)))
+        (is (= "call-1" (:psi.tool-output.call/tool-call-id first-call)))
+        (is (= "bash" (:psi.tool-output.call/tool-name first-call)))
+        (is (true? (:psi.tool-output.call/limit-hit? first-call)))
+        (is (= :bytes (:psi.tool-output.call/truncated-by first-call)))
+        (is (= 1000 (:psi.tool-output.call/effective-max-lines first-call)))
+        (is (= 25600 (:psi.tool-output.call/effective-max-bytes first-call)))
+        (is (= 120 (:psi.tool-output.call/output-bytes first-call)))
+        (is (= 64 (:psi.tool-output.call/context-bytes-added first-call)))
+        (is (= {:total-context-bytes 64
+                :by-tool {"bash" 64}
+                :limit-hits-by-tool {"bash" 1}}
+               stats))))))
+
 ;; ── API error diagnostics (hierarchical EQL) ────────────────────────────────
 
 (defn- inject-messages!

--- a/components/agent-session/test/psi/agent_session/executor_test.clj
+++ b/components/agent-session/test/psi/agent_session/executor_test.clj
@@ -1,18 +1,15 @@
 (ns psi.agent-session.executor-test
   "Integration tests for the executor with per-turn statechart.
 
-  Uses with-redefs on the private do-stream! to inject stub provider
-  responses — no HTTP calls, no API keys required."
+  Uses with-redefs on private vars to inject stub provider/tool behavior
+  (no HTTP calls, no API keys required)."
   (:require
    [clojure.test :refer [deftest testing is]]
    [psi.agent-core.core :as agent]
    [psi.agent-session.executor :as executor]
    [psi.agent-session.turn-statechart :as turn-sc]))
 
-;; ── Stub helpers ────────────────────────────────────────────
-
 (defn- stub-text-stream
-  "Return a do-stream! replacement that delivers a text-only response."
   [text]
   (fn [_ai-ctx _conv _model _opts consume-fn]
     (consume-fn {:type :start})
@@ -20,123 +17,154 @@
     (consume-fn {:type :done :reason :stop})))
 
 (defn- stub-error-stream
-  "Return a do-stream! replacement that delivers an error."
   [err-msg]
   (fn [_ai-ctx _conv _model _opts consume-fn]
     (consume-fn {:type :start})
     (consume-fn {:type :error :error-message err-msg})))
 
 (defn- setup-agent-ctx!
-  "Create and initialise an agent-core context for testing."
   []
   (let [ctx (agent/create-context)]
     (agent/create-agent-in! ctx {:system-prompt "test prompt"
                                  :tools []})
     ctx))
 
+(defn- setup-session-ctx!
+  [agent-ctx]
+  {:agent-ctx agent-ctx
+   :session-data-atom (atom {:tool-output-overrides {}})
+   :tool-output-stats-atom (atom {:calls []
+                                  :aggregates {:total-context-bytes 0
+                                               :by-tool {}
+                                               :limit-hits-by-tool {}}})})
+
 (def ^:private stub-model
   {:provider "stub" :id "stub-model"})
 
-;; ── Text-only response ──────────────────────────────────────
-
 (deftest text-only-response-test
-  (testing "run-agent-loop! produces text-only assistant message"
-    (let [agent-ctx    (setup-agent-ctx!)
-          turn-atom    (atom nil)
-          user-msg     {:role    "user"
-                        :content [{:type :text :text "hello"}]}]
-      (with-redefs [psi.agent-session.executor/do-stream!
-                    (stub-text-stream "Hello! I'm here to help.")]
-        (let [result (executor/run-agent-loop!
-                      nil agent-ctx stub-model [user-msg]
-                      {:turn-ctx-atom turn-atom})]
-          (is (= "assistant" (:role result)))
-          (is (= :stop (:stop-reason result)))
-          (let [text (some #(when (= :text (:type %)) (:text %))
-                           (:content result))]
-            (is (= "Hello! I'm here to help." text)))
-          ;; Turn context was stored for introspection
-          (is (some? @turn-atom))
-          ;; Turn statechart reached :done
-          (is (= :done (turn-sc/turn-phase @turn-atom))))))))
-
-;; ── Error response ──────────────────────────────────────────
+  (let [agent-ctx    (setup-agent-ctx!)
+        session-ctx  (setup-session-ctx! agent-ctx)
+        turn-atom    (atom nil)
+        user-msg     {:role "user" :content [{:type :text :text "hello"}]}]
+    (with-redefs [psi.agent-session.executor/do-stream!
+                  (stub-text-stream "Hello! I'm here to help.")]
+      (let [result (executor/run-agent-loop!
+                    nil session-ctx agent-ctx stub-model [user-msg]
+                    {:turn-ctx-atom turn-atom})]
+        (is (= "assistant" (:role result)))
+        (is (= :stop (:stop-reason result)))
+        (is (= "Hello! I'm here to help."
+               (some #(when (= :text (:type %)) (:text %))
+                     (:content result))))
+        (is (some? @turn-atom))
+        (is (= :done (turn-sc/turn-phase @turn-atom)))))))
 
 (deftest error-response-test
-  (testing "run-agent-loop! handles provider error"
-    (let [agent-ctx (setup-agent-ctx!)
-          turn-atom (atom nil)
-          user-msg  {:role "user" :content [{:type :text :text "hello"}]}]
-      (with-redefs [psi.agent-session.executor/do-stream!
-                    (stub-error-stream "Connection refused")]
-        (let [result (executor/run-agent-loop!
-                      nil agent-ctx stub-model [user-msg]
-                      {:turn-ctx-atom turn-atom})]
-          (is (= :error (:stop-reason result)))
-          ;; Turn statechart reached :error
-          (is (= :error (turn-sc/turn-phase @turn-atom)))
-          (is (= "Connection refused"
-                 (:error-message (turn-sc/get-turn-data @turn-atom)))))))))
-
-;; ── Agent-core lifecycle ────────────────────────────────────
+  (let [agent-ctx   (setup-agent-ctx!)
+        session-ctx (setup-session-ctx! agent-ctx)
+        turn-atom   (atom nil)
+        user-msg    {:role "user" :content [{:type :text :text "hello"}]}]
+    (with-redefs [psi.agent-session.executor/do-stream!
+                  (stub-error-stream "Connection refused")]
+      (let [result (executor/run-agent-loop!
+                    nil session-ctx agent-ctx stub-model [user-msg]
+                    {:turn-ctx-atom turn-atom})]
+        (is (= :error (:stop-reason result)))
+        (is (= :error (turn-sc/turn-phase @turn-atom)))
+        (is (= "Connection refused"
+               (:error-message (turn-sc/get-turn-data @turn-atom))))))))
 
 (deftest agent-core-lifecycle-test
-  (testing "executor calls begin-stream, update-stream, end-stream"
-    (let [agent-ctx (setup-agent-ctx!)
-          user-msg  {:role "user" :content [{:type :text :text "hi"}]}]
-      (with-redefs [psi.agent-session.executor/do-stream!
-                    (stub-text-stream "response")]
-        (executor/run-agent-loop! nil agent-ctx stub-model [user-msg])
-        ;; Agent should be back in :idle
-        (is (= :idle (agent/sc-phase-in agent-ctx)))
-        ;; Messages should include user + assistant
-        (let [msgs (:messages (agent/get-data-in agent-ctx))]
-          (is (>= (count msgs) 2))
-          (is (= "user" (:role (first msgs))))
-          (is (= "assistant" (:role (second msgs)))))))))
-
-;; ── Turn context atom ───────────────────────────────────────
+  (let [agent-ctx   (setup-agent-ctx!)
+        session-ctx (setup-session-ctx! agent-ctx)
+        user-msg    {:role "user" :content [{:type :text :text "hi"}]}]
+    (with-redefs [psi.agent-session.executor/do-stream!
+                  (stub-text-stream "response")]
+      (executor/run-agent-loop! nil session-ctx agent-ctx stub-model [user-msg])
+      (is (= :idle (agent/sc-phase-in agent-ctx)))
+      (let [msgs (:messages (agent/get-data-in agent-ctx))]
+        (is (>= (count msgs) 2))
+        (is (= "user" (:role (first msgs))))
+        (is (= "assistant" (:role (second msgs))))))))
 
 (deftest turn-ctx-atom-test
-  (testing "turn-ctx-atom is nil when not provided"
-    (let [agent-ctx (setup-agent-ctx!)
-          user-msg  {:role "user" :content [{:type :text :text "hi"}]}]
-      (with-redefs [psi.agent-session.executor/do-stream!
-                    (stub-text-stream "ok")]
-        ;; Should not throw when turn-ctx-atom is nil
-        (let [result (executor/run-agent-loop!
-                      nil agent-ctx stub-model [user-msg])]
-          (is (= "assistant" (:role result)))))))
+  (let [agent-ctx   (setup-agent-ctx!)
+        session-ctx (setup-session-ctx! agent-ctx)
+        user-msg    {:role "user" :content [{:type :text :text "hi"}]}]
+    (with-redefs [psi.agent-session.executor/do-stream!
+                  (stub-text-stream "ok")]
+      (let [result (executor/run-agent-loop!
+                    nil session-ctx agent-ctx stub-model [user-msg])]
+        (is (= "assistant" (:role result))))))
 
-  (testing "turn-ctx-atom reflects turn data"
-    (let [agent-ctx (setup-agent-ctx!)
-          turn-atom (atom nil)
-          user-msg  {:role "user" :content [{:type :text :text "hi"}]}]
-      (with-redefs [psi.agent-session.executor/do-stream!
-                    (stub-text-stream "hello world")]
-        (executor/run-agent-loop! nil agent-ctx stub-model [user-msg]
-                                  {:turn-ctx-atom turn-atom})
-        (let [td (turn-sc/get-turn-data @turn-atom)]
-          (is (= "hello world" (:text-buffer td)))
-          (is (some? (:final-message td))))))))
-
-;; ── Multiple text deltas ────────────────────────────────────
+  (let [agent-ctx   (setup-agent-ctx!)
+        session-ctx (setup-session-ctx! agent-ctx)
+        turn-atom   (atom nil)
+        user-msg    {:role "user" :content [{:type :text :text "hi"}]}]
+    (with-redefs [psi.agent-session.executor/do-stream!
+                  (stub-text-stream "hello world")]
+      (executor/run-agent-loop! nil session-ctx agent-ctx stub-model [user-msg]
+                                {:turn-ctx-atom turn-atom})
+      (let [td (turn-sc/get-turn-data @turn-atom)]
+        (is (= "hello world" (:text-buffer td)))
+        (is (some? (:final-message td)))))))
 
 (deftest multiple-text-deltas-test
-  (testing "multiple text deltas are accumulated correctly"
-    (let [agent-ctx (setup-agent-ctx!)
-          turn-atom (atom nil)
-          user-msg  {:role "user" :content [{:type :text :text "hi"}]}
-          stream-fn (fn [_ai-ctx _conv _model _opts consume-fn]
+  (let [agent-ctx   (setup-agent-ctx!)
+        session-ctx (setup-session-ctx! agent-ctx)
+        turn-atom   (atom nil)
+        user-msg    {:role "user" :content [{:type :text :text "hi"}]}
+        stream-fn   (fn [_ai-ctx _conv _model _opts consume-fn]
                       (consume-fn {:type :start})
                       (consume-fn {:type :text-delta :delta "Hello"})
                       (consume-fn {:type :text-delta :delta " there"})
                       (consume-fn {:type :text-delta :delta "!"})
                       (consume-fn {:type :done :reason :stop}))]
-      (with-redefs [psi.agent-session.executor/do-stream! stream-fn]
-        (let [result (executor/run-agent-loop!
-                      nil agent-ctx stub-model [user-msg]
-                      {:turn-ctx-atom turn-atom})]
-          (is (= "Hello there!"
-                 (some #(when (= :text (:type %)) (:text %))
-                       (:content result)))))))))
+    (with-redefs [psi.agent-session.executor/do-stream! stream-fn]
+      (let [result (executor/run-agent-loop!
+                    nil session-ctx agent-ctx stub-model [user-msg]
+                    {:turn-ctx-atom turn-atom})]
+        (is (= "Hello there!"
+               (some #(when (= :text (:type %)) (:text %))
+                     (:content result))))))))
+
+(deftest tool-output-accounting-test
+  (testing "captures per-call stats and aggregates, including limit-hit"
+    (let [agent-ctx   (setup-agent-ctx!)
+          session-ctx (setup-session-ctx! agent-ctx)
+          tc          {:id "call-1" :name "bash" :arguments "{}"}]
+      (with-redefs [psi.agent-session.executor/execute-tool-with-registry
+                    (fn [_ _ _]
+                      {:content "trimmed"
+                       :is-error false
+                       :details {:truncation {:truncated true :truncated-by :bytes}}})]
+        (#'psi.agent-session.executor/run-tool-call! session-ctx tc nil)
+        (let [stats @(:tool-output-stats-atom session-ctx)
+              call  (first (:calls stats))]
+          (is (= "call-1" (:tool-call-id call)))
+          (is (= "bash" (:tool-name call)))
+          (is (= true (:limit-hit call)))
+          (is (= :bytes (:truncated-by call)))
+          (is (number? (:effective-max-lines call)))
+          (is (number? (:effective-max-bytes call)))
+          (is (= (:output-bytes call) (:context-bytes-added call)))
+          (is (= (:context-bytes-added call)
+                 (get-in stats [:aggregates :total-context-bytes])))
+          (is (= 1 (get-in stats [:aggregates :limit-hits-by-tool "bash"]))))))))
+
+  (testing "context-bytes-added reflects shaped content"
+    (let [agent-ctx   (setup-agent-ctx!)
+          session-ctx (setup-session-ctx! agent-ctx)
+          tc          {:id "call-2" :name "read" :arguments "{}"}
+          raw         (apply str (repeat 1000 "x"))
+          shaped      (subs raw 0 20)]
+      (with-redefs [psi.agent-session.executor/execute-tool-with-registry
+                    (fn [_ _ _]
+                      {:content shaped
+                       :is-error false
+                       :details {:truncation {:truncated true :truncated-by :bytes}}})]
+        (#'psi.agent-session.executor/run-tool-call! session-ctx tc nil)
+        (let [call (first (:calls @(:tool-output-stats-atom session-ctx)))]
+          (is (= (count (.getBytes shaped "UTF-8"))
+                 (:context-bytes-added call)))
+          (is (= (:context-bytes-added call) (:output-bytes call)))))))

--- a/components/agent-session/test/psi/agent_session/read_tool_test.clj
+++ b/components/agent-session/test/psi/agent_session/read_tool_test.clj
@@ -1,0 +1,362 @@
+(ns psi.agent-session.read-tool-test
+  "Tests for execute-read spec parity: binary safety, image magic-byte
+   detection, offset/limit slicing, head truncation."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.tools :as tools])
+  (:import
+   [java.awt.image BufferedImage]
+   [java.io File]
+   [java.util Base64]
+   [javax.imageio ImageIO]))
+
+;;; Test helpers
+
+(defn- with-temp-dir
+  "Create a temp dir, run f with its path, clean up."
+  [f]
+  (let [tmp (File/createTempFile "psi-read-test" "")]
+    (.delete tmp)
+    (.mkdirs tmp)
+    (try
+      (f (.getAbsolutePath tmp))
+      (finally
+        (doseq [file (reverse (file-seq tmp))]
+          (.delete file))))))
+
+(defn- create-text-file
+  "Create a text file with the given content in dir."
+  [dir filename content]
+  (let [f (io/file dir filename)]
+    (spit f content)
+    f))
+
+(defn- create-binary-file
+  "Create a binary file with null bytes in dir."
+  [dir filename]
+  (let [f (io/file dir filename)
+        bytes (byte-array [0x01 0x02 0x00 0x04 0x05])]
+    (with-open [fos (java.io.FileOutputStream. f)]
+      (.write fos bytes))
+    f))
+
+(defn- create-png-file
+  "Create a minimal valid PNG file in dir."
+  [dir filename width height]
+  (let [f (io/file dir filename)
+        img (BufferedImage. width height BufferedImage/TYPE_INT_ARGB)]
+    (ImageIO/write img "png" f)
+    f))
+
+(defn- create-jpeg-file
+  "Create a minimal valid JPEG file in dir."
+  [dir filename width height]
+  (let [f (io/file dir filename)
+        img (BufferedImage. width height BufferedImage/TYPE_INT_RGB)]
+    (ImageIO/write img "jpg" f)
+    f))
+
+;;; detect-mime tests
+
+(deftest detect-mime-test
+  (testing "detects PNG from magic bytes"
+    (let [buf (byte-array [(unchecked-byte 0x89) 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A])]
+      (is (= "image/png" (tools/detect-mime buf)))))
+
+  (testing "detects JPEG from magic bytes"
+    (let [buf (byte-array [(unchecked-byte 0xFF) (unchecked-byte 0xD8) (unchecked-byte 0xFF) (unchecked-byte 0xE0)])]
+      (is (= "image/jpeg" (tools/detect-mime buf)))))
+
+  (testing "detects GIF from magic bytes"
+    (let [buf (byte-array [0x47 0x49 0x46 0x38 0x39 0x61])]
+      (is (= "image/gif" (tools/detect-mime buf)))))
+
+  (testing "detects WebP from magic bytes"
+    (let [buf (byte-array [0x52 0x49 0x46 0x46 0x00 0x00 0x00 0x00 0x57 0x45 0x42 0x50])]
+      (is (= "image/webp" (tools/detect-mime buf)))))
+
+  (testing "returns nil for plain text"
+    (let [buf (.getBytes "Hello, world!" "UTF-8")]
+      (is (nil? (tools/detect-mime buf)))))
+
+  (testing "returns nil for empty array"
+    (is (nil? (tools/detect-mime (byte-array 0)))))
+
+  (testing "returns nil for nil"
+    (is (nil? (tools/detect-mime nil)))))
+
+;;; Text file reading
+
+(deftest execute-read-text-basic-test
+  (testing "reads a simple text file"
+    (with-temp-dir
+      (fn [dir]
+        (create-text-file dir "hello.txt" "Hello, world!")
+        (let [result (tools/execute-read {"path" "hello.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (= "Hello, world!" (:content result)))
+          (is (some? (:details result)))
+          (is (false? (get-in result [:details :binary-file-detected])))
+          (is (false? (get-in result [:details :truncation :truncated]))))))))
+
+(deftest execute-read-text-multiline-test
+  (testing "reads a multiline file"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" (map #(str "Line " %) (range 1 11)))
+              _ (create-text-file dir "multi.txt" lines)
+              result (tools/execute-read {"path" "multi.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (= lines (:content result)))
+          (is (= 10 (get-in result [:details :truncation :total-lines]))))))))
+
+;;; Offset/limit tests
+
+(deftest execute-read-offset-test
+  (testing "offset reads from the specified 1-indexed line"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" ["line1" "line2" "line3" "line4" "line5"])
+              _ (create-text-file dir "offset.txt" lines)
+              result (tools/execute-read {"path" "offset.txt" "offset" 3} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/starts-with? (:content result) "line3"))
+          (is (str/includes? (:content result) "line4"))
+          (is (str/includes? (:content result) "line5"))))))
+
+  (testing "offset=1 reads from the beginning"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" ["line1" "line2" "line3"])
+              _ (create-text-file dir "offset1.txt" lines)
+              result (tools/execute-read {"path" "offset1.txt" "offset" 1} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/starts-with? (:content result) "line1")))))))
+
+(deftest execute-read-offset-beyond-eof-test
+  (testing "offset beyond EOF throws explicit error"
+    (with-temp-dir
+      (fn [dir]
+        (create-text-file dir "short.txt" "line1\nline2")
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Offset .* is beyond end of file"
+             (tools/execute-read {"path" "short.txt" "offset" 10} {:cwd dir})))))))
+
+(deftest execute-read-limit-test
+  (testing "limit restricts number of lines returned"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" ["line1" "line2" "line3" "line4" "line5"])
+              _ (create-text-file dir "limit.txt" lines)
+              result (tools/execute-read {"path" "limit.txt" "limit" 2} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/includes? (:content result) "line1"))
+          (is (str/includes? (:content result) "line2"))
+          ;; Should have continuation guidance
+          (is (str/includes? (:content result) "more lines in file"))
+          (is (str/includes? (:content result) "Use offset=3")))))))
+
+(deftest execute-read-offset-and-limit-test
+  (testing "offset and limit together select a slice"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" ["line1" "line2" "line3" "line4" "line5"])
+              _ (create-text-file dir "slice.txt" lines)
+              result (tools/execute-read {"path" "slice.txt" "offset" 2 "limit" 2} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/includes? (:content result) "line2"))
+          (is (str/includes? (:content result) "line3"))
+          ;; Should not include line1 or line4
+          (is (not (str/includes? (:content result) "line1\n")))
+          ;; Should have continuation guidance
+          (is (str/includes? (:content result) "more lines in file"))
+          (is (str/includes? (:content result) "Use offset=4")))))))
+
+(deftest execute-read-offset-limit-at-end-test
+  (testing "offset+limit that reaches end of file has no continuation guidance"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" ["line1" "line2" "line3"])
+              _ (create-text-file dir "atend.txt" lines)
+              result (tools/execute-read {"path" "atend.txt" "offset" 2 "limit" 5} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/includes? (:content result) "line2"))
+          (is (str/includes? (:content result) "line3"))
+          ;; No continuation guidance needed
+          (is (not (str/includes? (:content result) "more lines"))))))))
+
+;;; Head truncation tests
+
+(deftest execute-read-truncation-test
+  (testing "large file gets head-truncated with continuation guidance"
+    (with-temp-dir
+      (fn [dir]
+        ;; Create a file larger than default policy (1000 lines)
+        (let [lines (str/join "\n" (map #(str "Line " %) (range 1 1100)))
+              _ (create-text-file dir "big.txt" lines)
+              result (tools/execute-read {"path" "big.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (true? (get-in result [:details :truncation :truncated])))
+          (is (str/includes? (:content result) "Showing lines"))
+          (is (str/includes? (:content result) "Use offset=")))))))
+
+(deftest execute-read-truncation-with-overrides-test
+  (testing "per-tool overrides control truncation limits"
+    (with-temp-dir
+      (fn [dir]
+        (let [lines (str/join "\n" (map #(str "Line " %) (range 1 20)))
+              _ (create-text-file dir "small-limit.txt" lines)
+              ;; Override read policy to 5 lines
+              result (tools/execute-read
+                      {"path" "small-limit.txt"}
+                      {:cwd dir :overrides {"read" {:max-lines 5}}})]
+          (is (false? (:is-error result)))
+          (is (true? (get-in result [:details :truncation :truncated])))
+          (is (= 5 (get-in result [:details :truncation :output-lines])))
+          (is (str/includes? (:content result) "Showing lines"))
+          (is (str/includes? (:content result) "Use offset=")))))))
+
+(deftest execute-read-first-line-exceeds-limit-test
+  (testing "first line exceeding byte limit returns bash hint"
+    (with-temp-dir
+      (fn [dir]
+        ;; Create a file with a very long first line
+        (let [long-line (apply str (repeat 30000 "x"))
+              _ (create-text-file dir "longline.txt" long-line)
+              result (tools/execute-read {"path" "longline.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (true? (get-in result [:details :truncation :first-line-exceeds-limit])))
+          (is (str/includes? (:content result) "Use bash for a bounded slice")))))))
+
+;;; Binary file detection
+
+(deftest execute-read-binary-file-test
+  (testing "binary file returns warning-only content"
+    (with-temp-dir
+      (fn [dir]
+        (create-binary-file dir "data.bin")
+        (let [result (tools/execute-read {"path" "data.bin"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (true? (get-in result [:details :binary-file-detected])))
+          (is (str/includes? (:content result) "Binary file detected"))
+          (is (str/includes? (:content result) "Content omitted")))))))
+
+;;; Image file detection
+
+(deftest execute-read-png-image-test
+  (testing "PNG file is detected by magic bytes and returned as image content"
+    (with-temp-dir
+      (fn [dir]
+        (create-png-file dir "test.png" 100 100)
+        (let [result (tools/execute-read {"path" "test.png"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (nil? (:details result)))
+          ;; Content should be a vector of content blocks
+          (let [content (:content result)]
+            (is (vector? content))
+            (is (= 2 (count content)))
+            (is (= "text" (:type (first content))))
+            (is (str/includes? (:text (first content)) "image"))
+            (is (= "image" (:type (second content))))
+            (is (string? (:data (second content))))
+            (is (string? (:mimeType (second content))))))))))
+
+(deftest execute-read-jpeg-image-test
+  (testing "JPEG file is detected by magic bytes and returned as image content"
+    (with-temp-dir
+      (fn [dir]
+        (create-jpeg-file dir "test.jpg" 100 100)
+        (let [result (tools/execute-read {"path" "test.jpg"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (let [content (:content result)]
+            (is (vector? content))
+            (is (= 2 (count content)))
+            (is (= "image" (:type (second content))))))))))
+
+(deftest execute-read-image-auto-resize-test
+  (testing "large image is auto-resized"
+    (with-temp-dir
+      (fn [dir]
+        ;; Create an image larger than 2000px
+        (create-png-file dir "large.png" 3000 2500)
+        (let [result (tools/execute-read {"path" "large.png"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (let [content (:content result)
+                img-block (second content)
+                ;; Decode the base64 to check dimensions
+                decoded (.decode (Base64/getDecoder) ^String (:data img-block))
+                bais (java.io.ByteArrayInputStream. decoded)
+                img (ImageIO/read bais)]
+            (is (<= (.getWidth img) 2000))
+            (is (<= (.getHeight img) 2000))))))))
+
+(deftest execute-read-image-no-resize-test
+  (testing "auto-resize can be disabled"
+    (with-temp-dir
+      (fn [dir]
+        (create-png-file dir "noresize.png" 100 100)
+        (let [result (tools/execute-read
+                      {"path" "noresize.png"}
+                      {:cwd dir :auto-resize-images false})]
+          (is (false? (:is-error result)))
+          (let [content (:content result)]
+            (is (= "image/png" (:mimeType (second content))))))))))
+
+(deftest execute-read-extension-not-enough-test
+  (testing "file with .png extension but text content is read as text"
+    (with-temp-dir
+      (fn [dir]
+        ;; Create a text file with .png extension
+        (create-text-file dir "fake.png" "This is not really a PNG")
+        (let [result (tools/execute-read {"path" "fake.png"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          ;; Should be read as text, not as image
+          (is (string? (:content result)))
+          (is (= "This is not really a PNG" (:content result))))))))
+
+;;; File not found
+
+(deftest execute-read-file-not-found-test
+  (testing "missing file throws ex-info"
+    (with-temp-dir
+      (fn [dir]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"File not found"
+             (tools/execute-read {"path" "nonexistent.txt"} {:cwd dir})))))))
+
+;;; Path resolution
+
+(deftest execute-read-uses-resolve-read-path-test
+  (testing "read uses resolve-read-path for macOS fallback"
+    (with-temp-dir
+      (fn [dir]
+        ;; Just verify basic path resolution works
+        (create-text-file dir "resolved.txt" "resolved content")
+        (let [result (tools/execute-read {"path" "resolved.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (= "resolved content" (:content result))))))))
+
+(deftest execute-read-absolute-path-test
+  (testing "absolute path ignores cwd"
+    (with-temp-dir
+      (fn [dir]
+        (let [f (create-text-file dir "abs.txt" "absolute content")
+              abs-path (.getAbsolutePath f)
+              result (tools/execute-read {"path" abs-path} {:cwd "/nonexistent"})]
+          (is (false? (:is-error result)))
+          (is (= "absolute content" (:content result))))))))
+
+;;; Empty file
+
+(deftest execute-read-empty-file-test
+  (testing "empty file returns empty string"
+    (with-temp-dir
+      (fn [dir]
+        (create-text-file dir "empty.txt" "")
+        (let [result (tools/execute-read {"path" "empty.txt"} {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (= "" (:content result))))))))

--- a/components/agent-session/test/psi/agent_session/tool_output_integration_test.clj
+++ b/components/agent-session/test/psi/agent_session/tool_output_integration_test.clj
@@ -1,0 +1,123 @@
+(ns psi.agent-session.tool-output-integration-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [cheshire.core :as json]
+   [psi.agent-session.core :as session]
+   [psi.agent-session.executor :as executor]
+   [psi.agent-session.tool-output :as tool-output]))
+
+(defn- delete-recursively!
+  [f]
+  (doseq [child (reverse (file-seq (io/file f)))]
+    (.delete ^java.io.File child)))
+
+(defn- large-bash-command []
+  ;; Guaranteed to exceed default 1000-line/25600-byte policy.
+  "yes line | head -n 50000")
+
+(use-fixtures
+  :each
+  (fn [f]
+    (try
+      (f)
+      (finally
+        (tool-output/cleanup-temp-store!)))))
+
+(deftest bash-limit-hit-eql-telemetry-test
+  (testing "bash truncation persists full output and is queryable via EQL"
+    (let [ctx (session/create-context)
+          tc  {:id "bash-limit-1"
+               :name "bash"
+               :arguments (json/generate-string
+                           {"command" (large-bash-command)})}
+          result (#'psi.agent-session.executor/run-tool-call! ctx tc nil)
+          truncation (get-in result [:details :truncation])
+          full-path  (get-in result [:details :full-output-path])
+          eql-result (session/query-in ctx
+                                       [{:psi.tool-output/calls
+                                         [:psi.tool-output.call/tool-name
+                                          :psi.tool-output.call/limit-hit?
+                                          :psi.tool-output.call/output-bytes
+                                          :psi.tool-output.call/context-bytes-added]}
+                                        :psi.tool-output/stats])
+          calls      (:psi.tool-output/calls eql-result)
+          call       (first calls)]
+      (is (true? (:truncated truncation)))
+      (is (contains? #{:lines :bytes} (:truncated-by truncation)))
+      (is (string? full-path))
+      (is (.exists (io/file full-path)))
+      (is (re-find #"line" (slurp full-path)))
+
+      (is (= 1 (count calls)))
+      (is (= "bash" (:psi.tool-output.call/tool-name call)))
+      (is (true? (:psi.tool-output.call/limit-hit? call)))
+      (is (= (:psi.tool-output.call/output-bytes call)
+             (:psi.tool-output.call/context-bytes-added call)))
+      (is (= (:psi.tool-output.call/context-bytes-added call)
+             (get-in eql-result [:psi.tool-output/stats :total-context-bytes]))))))
+
+(deftest read-within-limits-telemetry-test
+  (testing "read call within limits records no limit-hit and matching byte counts"
+    (let [f   (doto (java.io.File/createTempFile "psi-read-ok" ".txt")
+                (.deleteOnExit))
+          _   (spit f "alpha\nbeta\ngamma\n")
+          ctx (session/create-context)
+          tc  {:id "read-ok-1"
+               :name "read"
+               :arguments (json/generate-string
+                           {"filePath" (.getAbsolutePath f)})}
+          _   (#'psi.agent-session.executor/run-tool-call! ctx tc nil)
+          eql-result (session/query-in ctx
+                                       [{:psi.tool-output/calls
+                                         [:psi.tool-output.call/tool-name
+                                          :psi.tool-output.call/limit-hit?
+                                          :psi.tool-output.call/output-bytes
+                                          :psi.tool-output.call/context-bytes-added]}])
+          call (first (:psi.tool-output/calls eql-result))]
+      (is (= "read" (:psi.tool-output.call/tool-name call)))
+      (is (false? (:psi.tool-output.call/limit-hit? call)))
+      (is (= (:psi.tool-output.call/output-bytes call)
+             (:psi.tool-output.call/context-bytes-added call))))))
+
+(deftest aggregate-stats-across-multiple-tool-calls-test
+  (testing "aggregates reflect multiple calls with limit-hit counts by tool"
+    (let [f   (doto (java.io.File/createTempFile "psi-read-agg" ".txt")
+                (.deleteOnExit))
+          _   (spit f "small\nfile\n")
+          ctx (session/create-context)
+          bash-args (json/generate-string {"command" (large-bash-command)})
+          read-args (json/generate-string {"filePath" (.getAbsolutePath f)})]
+      (#'psi.agent-session.executor/run-tool-call! ctx {:id "b1" :name "bash" :arguments bash-args} nil)
+      (#'psi.agent-session.executor/run-tool-call! ctx {:id "r1" :name "read" :arguments read-args} nil)
+      (#'psi.agent-session.executor/run-tool-call! ctx {:id "b2" :name "bash" :arguments bash-args} nil)
+      (let [eql-result (session/query-in ctx
+                                         [{:psi.tool-output/calls
+                                           [:psi.tool-output.call/tool-name
+                                            :psi.tool-output.call/context-bytes-added
+                                            :psi.tool-output.call/limit-hit?]}
+                                          :psi.tool-output/stats])
+            calls (:psi.tool-output/calls eql-result)
+            total-from-calls (reduce + (map :psi.tool-output.call/context-bytes-added calls))
+            stats (:psi.tool-output/stats eql-result)]
+        (is (= 3 (count calls)))
+        (is (= total-from-calls (:total-context-bytes stats)))
+        (is (contains? (:by-tool stats) "bash"))
+        (is (contains? (:by-tool stats) "read"))
+        (is (= 2 (get-in stats [:limit-hits-by-tool "bash"])))
+        (is (zero? (get-in stats [:limit-hits-by-tool "read"] 0)))))))
+
+(deftest temp-store-cleanup-lifecycle-test
+  (testing "cleanup removes persisted artifacts"
+    (let [root (tool-output/init-temp-store!)
+          p    (tool-output/persist-truncated-output! "bash" "cleanup-1" "full output")]
+      (is (.exists (io/file root)))
+      (is (.exists (io/file p)))
+      (is (true? (tool-output/cleanup-temp-store!)))
+      (is (not (.exists (io/file root))))))
+
+  (testing "cleanup failure path is warning-only and does not throw"
+    (let [root (tool-output/init-temp-store!)]
+      (delete-recursively! root)
+      (is (boolean? (tool-output/cleanup-temp-store!)))
+      (is (nil? (tool-output/temp-store-root))))))

--- a/components/agent-session/test/psi/agent_session/tool_output_test.clj
+++ b/components/agent-session/test/psi/agent_session/tool_output_test.clj
@@ -1,0 +1,302 @@
+(ns psi.agent-session.tool-output-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.tool-output :as tool-output]))
+
+;;; effective-policy tests
+
+(deftest effective-policy-defaults-test
+  ;; Verifies that defaults are returned when no overrides are provided
+  (testing "returns defaults when no overrides exist"
+    (is (= {:max-lines 1000 :max-bytes 25600}
+           (tool-output/effective-policy {} "read"))))
+
+  (testing "returns defaults when tool has no override entry"
+    (is (= {:max-lines 1000 :max-bytes 25600}
+           (tool-output/effective-policy {"bash" {:max-lines 500}} "read")))))
+
+(deftest effective-policy-overrides-test
+  ;; Verifies that per-tool overrides are merged correctly
+  (testing "overrides both fields"
+    (is (= {:max-lines 100 :max-bytes 5000}
+           (tool-output/effective-policy {"read" {:max-lines 100 :max-bytes 5000}} "read"))))
+
+  (testing "overrides only max-lines, max-bytes falls through to default"
+    (is (= {:max-lines 100 :max-bytes 25600}
+           (tool-output/effective-policy {"read" {:max-lines 100}} "read"))))
+
+  (testing "overrides only max-bytes, max-lines falls through to default"
+    (is (= {:max-lines 1000 :max-bytes 5000}
+           (tool-output/effective-policy {"read" {:max-bytes 5000}} "read"))))
+
+  (testing "nil override values fall through to defaults"
+    (is (= {:max-lines 1000 :max-bytes 25600}
+           (tool-output/effective-policy {"read" {:max-lines nil :max-bytes nil}} "read")))))
+
+;;; head-truncate tests
+
+(deftest head-truncate-within-limits-test
+  ;; Verifies no truncation when content is within limits
+  (testing "content within limits returns unchanged"
+    (let [text   "line1\nline2\nline3"
+          result (tool-output/head-truncate text {:max-lines 10 :max-bytes 1000})]
+      (is (= text (:content result)))
+      (is (false? (:truncated result)))
+      (is (= :none (:truncated-by result)))
+      (is (= 3 (:total-lines result)))
+      (is (= 3 (:output-lines result)))
+      (is (false? (:first-line-exceeds-limit result))))))
+
+(deftest head-truncate-empty-text-test
+  ;; Verifies empty text is handled correctly
+  (testing "empty text"
+    (let [result (tool-output/head-truncate "" {:max-lines 10 :max-bytes 1000})]
+      (is (= "" (:content result)))
+      (is (false? (:truncated result)))
+      (is (= :none (:truncated-by result))))))
+
+(deftest head-truncate-by-lines-test
+  ;; Verifies line-based truncation
+  (testing "truncates by line count"
+    (let [text   (str/join "\n" (map #(str "line" %) (range 1 11)))
+          result (tool-output/head-truncate text {:max-lines 3 :max-bytes 100000})]
+      (is (= "line1\nline2\nline3" (:content result)))
+      (is (true? (:truncated result)))
+      (is (= :lines (:truncated-by result)))
+      (is (= 10 (:total-lines result)))
+      (is (= 3 (:output-lines result))))))
+
+(deftest head-truncate-by-bytes-test
+  ;; Verifies byte-based truncation
+  (testing "truncates by byte count"
+    (let [text   "short\nmedium line\nthis is a longer line"
+          result (tool-output/head-truncate text {:max-lines 1000 :max-bytes 16})]
+      ;; "short\nmedium line" = 16 bytes, "short" = 5 bytes
+      ;; "short" alone = 5 bytes, fits
+      ;; "short\nmedium line" = 5 + 1 + 11 = 17 bytes, doesn't fit
+      ;; So only "short" should be kept
+      (is (= "short" (:content result)))
+      (is (true? (:truncated result)))
+      (is (= :bytes (:truncated-by result))))))
+
+(deftest head-truncate-first-line-exceeds-test
+  ;; Verifies first-line-exceeds-limit edge case
+  (testing "first line exceeds max-bytes"
+    (let [text   (apply str (repeat 100 "x"))
+          result (tool-output/head-truncate text {:max-lines 1000 :max-bytes 50})]
+      (is (= "" (:content result)))
+      (is (true? (:truncated result)))
+      (is (= :bytes (:truncated-by result)))
+      (is (true? (:first-line-exceeds-limit result)))
+      (is (= 0 (:output-lines result)))
+      (is (= 0 (:output-bytes result))))))
+
+(deftest head-truncate-lines-then-bytes-test
+  ;; Verifies that line limit is applied first, then byte limit
+  (testing "line limit applied first, then byte limit kicks in"
+    (let [lines  (map #(str "line-" % "-" (apply str (repeat 20 "x"))) (range 1 21))
+          text   (str/join "\n" lines)
+          ;; Each line is ~27 bytes. 5 lines = ~140 bytes
+          result (tool-output/head-truncate text {:max-lines 5 :max-bytes 80})]
+      (is (true? (:truncated result)))
+      ;; Should be truncated by bytes since 5 lines > 80 bytes
+      (is (= :bytes (:truncated-by result)))
+      (is (<= (count (.getBytes (:content result) "UTF-8")) 80)))))
+
+;;; tail-truncate tests
+
+(deftest tail-truncate-within-limits-test
+  ;; Verifies no truncation when content is within limits
+  (testing "content within limits returns unchanged"
+    (let [text   "line1\nline2\nline3"
+          result (tool-output/tail-truncate text {:max-lines 10 :max-bytes 1000})]
+      (is (= text (:content result)))
+      (is (false? (:truncated result)))
+      (is (= :none (:truncated-by result)))
+      (is (= 3 (:total-lines result)))
+      (is (= 3 (:output-lines result)))
+      (is (false? (:last-line-partial result))))))
+
+(deftest tail-truncate-by-lines-test
+  ;; Verifies line-based truncation keeps last N lines
+  (testing "truncates by line count, keeps last lines"
+    (let [text   (str/join "\n" (map #(str "line" %) (range 1 11)))
+          result (tool-output/tail-truncate text {:max-lines 3 :max-bytes 100000})]
+      (is (= "line8\nline9\nline10" (:content result)))
+      (is (true? (:truncated result)))
+      (is (= :lines (:truncated-by result)))
+      (is (= 10 (:total-lines result)))
+      (is (= 3 (:output-lines result))))))
+
+(deftest tail-truncate-by-bytes-test
+  ;; Verifies byte-based truncation keeps last bytes worth of lines
+  (testing "truncates by byte count, keeps last lines that fit"
+    (let [text   "first line\nsecond line\nthird line"
+          ;; "third line" = 10 bytes, fits in 15
+          ;; "second line\nthird line" = 22 bytes, doesn't fit in 15
+          result (tool-output/tail-truncate text {:max-lines 1000 :max-bytes 15})]
+      (is (= "third line" (:content result)))
+      (is (true? (:truncated result)))
+      (is (= :bytes (:truncated-by result))))))
+
+(deftest tail-truncate-empty-text-test
+  ;; Verifies empty text handling
+  (testing "empty text"
+    (let [result (tool-output/tail-truncate "" {:max-lines 10 :max-bytes 1000})]
+      (is (= "" (:content result)))
+      (is (false? (:truncated result))))))
+
+;;; Temp store tests
+
+(deftest temp-store-init-test
+  ;; Verifies temp store initialization creates a directory
+  (testing "init creates a temp directory"
+    (try
+      (let [root-path (tool-output/init-temp-store!)]
+        (is (string? root-path))
+        (is (.exists (io/file root-path)))
+        (is (.isDirectory (io/file root-path)))
+        (is (str/includes? root-path "psi-tool-output-")))
+      (finally
+        (tool-output/cleanup-temp-store!)))))
+
+(deftest temp-store-idempotent-test
+  ;; Verifies init is idempotent
+  (testing "init returns same root on second call"
+    (try
+      (let [root1 (tool-output/init-temp-store!)
+            root2 (tool-output/init-temp-store!)]
+        (is (= root1 root2)))
+      (finally
+        (tool-output/cleanup-temp-store!)))))
+
+(deftest temp-store-persist-test
+  ;; Verifies file persistence in temp store
+  (testing "persist writes file to temp store"
+    (try
+      (let [_    (tool-output/init-temp-store!)
+            path (tool-output/persist-truncated-output! "bash" "call-123" "full output text")]
+        (is (string? path))
+        (is (.exists (io/file path)))
+        (is (= "full output text" (slurp path)))
+        (is (str/ends-with? path "bash-call-123.log")))
+      (finally
+        (tool-output/cleanup-temp-store!)))))
+
+(deftest temp-store-persist-auto-init-test
+  ;; Verifies persist auto-initializes the store
+  (testing "persist initializes store if needed"
+    (try
+      ;; Ensure clean state
+      (tool-output/cleanup-temp-store!)
+      (let [path (tool-output/persist-truncated-output! "read" "call-456" "data")]
+        (is (.exists (io/file path)))
+        (is (= "data" (slurp path))))
+      (finally
+        (tool-output/cleanup-temp-store!)))))
+
+(deftest temp-store-cleanup-test
+  ;; Verifies cleanup removes directory and files
+  (testing "cleanup removes temp directory and contents"
+    (let [_ (tool-output/init-temp-store!)
+          _ (tool-output/persist-truncated-output! "test" "1" "data1")
+          _ (tool-output/persist-truncated-output! "test" "2" "data2")
+          root (tool-output/temp-store-root)]
+      (is (.exists (io/file root)))
+      (is (true? (tool-output/cleanup-temp-store!)))
+      (is (not (.exists (io/file root))))
+      (is (nil? (tool-output/temp-store-root))))))
+
+(deftest temp-store-cleanup-no-store-test
+  ;; Verifies cleanup handles no-store case
+  (testing "cleanup returns false when no store exists"
+    (tool-output/cleanup-temp-store!) ; ensure clean
+    (is (false? (tool-output/cleanup-temp-store!)))))
+
+(deftest temp-store-cleanup-failure-test
+  ;; Verifies cleanup handles failure gracefully (warning-only)
+  (testing "cleanup handles already-deleted directory gracefully"
+    (let [_ (tool-output/init-temp-store!)
+          root (tool-output/temp-store-root)]
+      ;; Manually delete the directory to simulate failure scenario
+      (doseq [f (reverse (file-seq (io/file root)))]
+        (.delete f))
+      ;; Cleanup should not throw — the dir is already gone
+      ;; The atom should be reset regardless
+      (let [result (tool-output/cleanup-temp-store!)]
+        ;; May return true (delete on non-existent is ok) or false
+        (is (boolean? result))
+        (is (nil? (tool-output/temp-store-root)))))))
+
+(deftest temp-store-root-nil-when-uninit-test
+  ;; Verifies temp-store-root returns nil when not initialized
+  (testing "temp-store-root returns nil when not initialized"
+    (tool-output/cleanup-temp-store!)
+    (is (nil? (tool-output/temp-store-root)))))
+
+;;; Edge cases
+
+(deftest head-truncate-single-line-within-limits-test
+  ;; Single line within limits
+  (testing "single line within limits"
+    (let [result (tool-output/head-truncate "hello" {:max-lines 10 :max-bytes 100})]
+      (is (= "hello" (:content result)))
+      (is (false? (:truncated result))))))
+
+(deftest head-truncate-exact-line-limit-test
+  ;; Exactly at line limit
+  (testing "exactly at line limit"
+    (let [text   "a\nb\nc"
+          result (tool-output/head-truncate text {:max-lines 3 :max-bytes 100000})]
+      (is (= text (:content result)))
+      (is (false? (:truncated result))))))
+
+(deftest head-truncate-exact-byte-limit-test
+  ;; Exactly at byte limit
+  (testing "exactly at byte limit"
+    (let [text   "hello"  ; 5 bytes
+          result (tool-output/head-truncate text {:max-lines 100 :max-bytes 5})]
+      (is (= "hello" (:content result)))
+      (is (false? (:truncated result))))))
+
+(deftest tail-truncate-exact-line-limit-test
+  ;; Exactly at line limit
+  (testing "exactly at line limit"
+    (let [text   "a\nb\nc"
+          result (tool-output/tail-truncate text {:max-lines 3 :max-bytes 100000})]
+      (is (= text (:content result)))
+      (is (false? (:truncated result))))))
+
+(deftest head-truncate-metadata-completeness-test
+  ;; Verifies all metadata fields are present
+  (testing "all metadata fields present in truncated result"
+    (let [text   (str/join "\n" (repeat 100 "line"))
+          result (tool-output/head-truncate text {:max-lines 5 :max-bytes 25600})]
+      (is (contains? result :content))
+      (is (contains? result :truncated))
+      (is (contains? result :truncated-by))
+      (is (contains? result :total-lines))
+      (is (contains? result :total-bytes))
+      (is (contains? result :output-lines))
+      (is (contains? result :output-bytes))
+      (is (contains? result :max-lines))
+      (is (contains? result :max-bytes))
+      (is (contains? result :first-line-exceeds-limit)))))
+
+(deftest tail-truncate-metadata-completeness-test
+  ;; Verifies all metadata fields are present
+  (testing "all metadata fields present in truncated result"
+    (let [text   (str/join "\n" (repeat 100 "line"))
+          result (tool-output/tail-truncate text {:max-lines 5 :max-bytes 25600})]
+      (is (contains? result :content))
+      (is (contains? result :truncated))
+      (is (contains? result :truncated-by))
+      (is (contains? result :total-lines))
+      (is (contains? result :total-bytes))
+      (is (contains? result :output-lines))
+      (is (contains? result :output-bytes))
+      (is (contains? result :max-lines))
+      (is (contains? result :max-bytes))
+      (is (contains? result :last-line-partial)))))

--- a/components/agent-session/test/psi/agent_session/tool_path_test.clj
+++ b/components/agent-session/test/psi/agent_session/tool_path_test.clj
@@ -1,0 +1,190 @@
+(ns psi.agent-session.tool-path-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.tool-path :as tool-path])
+  (:import
+   [java.io File]
+   [java.text Normalizer Normalizer$Form]))
+
+;;; expand-path tests
+
+(deftest expand-path-at-prefix-test
+  ;; Verifies that leading @ is stripped from paths
+  (testing "strips leading @ from path"
+    (is (= "/foo/bar" (tool-path/expand-path "@/foo/bar"))))
+
+  (testing "does not strip @ in middle of path"
+    (is (= "/foo/@bar" (tool-path/expand-path "/foo/@bar"))))
+
+  (testing "strips @ from relative path"
+    (is (= "foo/bar" (tool-path/expand-path "@foo/bar"))))
+
+  (testing "leaves path without @ unchanged"
+    (is (= "/foo/bar" (tool-path/expand-path "/foo/bar")))))
+
+(deftest expand-path-unicode-spaces-test
+  ;; Verifies that unicode space characters are normalized to ASCII space
+  (testing "replaces narrow no-break space (U+202F)"
+    (is (= "foo bar" (tool-path/expand-path "foo\u202Fbar"))))
+
+  (testing "replaces no-break space (U+00A0)"
+    (is (= "foo bar" (tool-path/expand-path "foo\u00A0bar"))))
+
+  (testing "replaces thin space (U+2009)"
+    (is (= "foo bar" (tool-path/expand-path "foo\u2009bar"))))
+
+  (testing "replaces ideographic space (U+3000)"
+    (is (= "foo bar" (tool-path/expand-path "foo\u3000bar"))))
+
+  (testing "replaces multiple unicode spaces"
+    (is (= "a b c" (tool-path/expand-path "a\u202Fb\u00A0c"))))
+
+  (testing "leaves ASCII spaces unchanged"
+    (is (= "foo bar" (tool-path/expand-path "foo bar")))))
+
+(deftest expand-path-tilde-test
+  ;; Verifies that ~ and ~/ are expanded to user home directory
+  (let [home (System/getProperty "user.home")]
+    (testing "expands bare ~"
+      (is (= home (tool-path/expand-path "~"))))
+
+    (testing "expands ~/ prefix"
+      (is (= (str home "/Documents") (tool-path/expand-path "~/Documents"))))
+
+    (testing "does not expand ~ in middle of path"
+      (is (= "/foo/~/bar" (tool-path/expand-path "/foo/~/bar"))))
+
+    (testing "does not expand ~user (no user expansion)"
+      (is (= "~user/foo" (tool-path/expand-path "~user/foo"))))))
+
+(deftest expand-path-combined-test
+  ;; Verifies that all expansions compose correctly
+  (let [home (System/getProperty "user.home")]
+    (testing "strips @ then expands ~"
+      (is (= (str home "/foo") (tool-path/expand-path "@~/foo"))))
+
+    (testing "strips @ then normalizes unicode space"
+      (is (= "foo bar" (tool-path/expand-path "@foo\u202Fbar"))))))
+
+;;; resolve-to-cwd tests
+
+(deftest resolve-to-cwd-absolute-path-test
+  ;; Verifies that absolute paths are returned as-is regardless of cwd
+  (testing "absolute path ignores cwd"
+    (let [f (tool-path/resolve-to-cwd "/tmp/cwd" "/absolute/path")]
+      (is (= "/absolute/path" (.getPath f)))))
+
+  (testing "absolute path with nil cwd"
+    (let [f (tool-path/resolve-to-cwd nil "/absolute/path")]
+      (is (= "/absolute/path" (.getPath f))))))
+
+(deftest resolve-to-cwd-relative-path-test
+  ;; Verifies that relative paths are joined with cwd
+  (testing "relative path joined with cwd"
+    (let [f (tool-path/resolve-to-cwd "/tmp/cwd" "relative/path")]
+      (is (= (str "/tmp/cwd" File/separator "relative/path") (.getPath f)))))
+
+  (testing "relative path with nil cwd returns relative"
+    (let [f (tool-path/resolve-to-cwd nil "relative/path")]
+      (is (= "relative/path" (.getPath f))))))
+
+;;; resolve-read-path tests
+
+(deftest resolve-read-path-existing-file-test
+  ;; Verifies that existing files are returned directly
+  (let [tmp (File/createTempFile "tool-path-test" ".txt")
+        _   (.deleteOnExit tmp)
+        cwd (.getParent tmp)
+        name (.getName tmp)]
+    (testing "returns existing file directly"
+      (let [result (tool-path/resolve-read-path name cwd)]
+        (is (.exists result))
+        (is (= (.getAbsolutePath tmp) (.getAbsolutePath result)))))))
+
+(deftest resolve-read-path-at-prefix-test
+  ;; Verifies that @ prefix is stripped before resolution
+  (let [tmp (File/createTempFile "tool-path-test" ".txt")
+        _   (.deleteOnExit tmp)
+        path (.getAbsolutePath tmp)]
+    (testing "strips @ and resolves to existing file"
+      (let [result (tool-path/resolve-read-path (str "@" path) nil)]
+        (is (.exists result))
+        (is (= (.getAbsolutePath tmp) (.getAbsolutePath result)))))))
+
+(deftest resolve-read-path-nonexistent-test
+  ;; Verifies that non-existent files return the original resolved path
+  (testing "returns original resolved path when no variant exists"
+    (let [result (tool-path/resolve-read-path "/nonexistent/file.txt" nil)]
+      (is (= "/nonexistent/file.txt" (.getAbsolutePath result)))
+      (is (not (.exists result))))))
+
+(deftest resolve-read-path-nfd-variant-test
+  ;; Verifies that NFD-normalized variant is found when it exists on disk
+  ;; This simulates macOS HFS+ behavior where filenames are NFD-normalized
+  (let [dir     (doto (io/file (System/getProperty "java.io.tmpdir") "tool-path-nfd-test")
+                  (.mkdirs))
+        ;; Create a file with NFD-normalized name (e.g., é decomposed as e + combining accent)
+        nfd-name (Normalizer/normalize "café.txt" Normalizer$Form/NFD)
+        nfd-file (io/file dir nfd-name)
+        _        (spit nfd-file "test content")
+        ;; Query with NFC (composed) name
+        nfc-name (Normalizer/normalize "café.txt" Normalizer$Form/NFC)]
+    (try
+      (testing "finds NFD variant when NFC path does not exist"
+        ;; Only test if the filesystem actually distinguishes NFC/NFD
+        ;; On macOS HFS+, both may resolve to the same file
+        (let [nfc-file (io/file dir nfc-name)]
+          (if (.exists nfc-file)
+            ;; Filesystem normalizes — both exist, test passes trivially
+            (let [result (tool-path/resolve-read-path nfc-name (.getAbsolutePath dir))]
+              (is (.exists result)))
+            ;; Filesystem distinguishes — should find NFD variant
+            (let [result (tool-path/resolve-read-path nfc-name (.getAbsolutePath dir))]
+              (is (.exists result))
+              (is (= (.getAbsolutePath nfd-file) (.getAbsolutePath result)))))))
+      (finally
+        (.delete nfd-file)
+        (.delete dir)))))
+
+(deftest resolve-read-path-am-pm-variant-test
+  ;; Verifies that AM/PM narrow-no-break-space variant is tried
+  (let [dir      (doto (io/file (System/getProperty "java.io.tmpdir") "tool-path-ampm-test")
+                   (.mkdirs))
+        ;; Create file with narrow no-break space before AM
+        nnbsp    "\u202F"
+        am-file  (io/file dir (str "log 10" nnbsp "AM.txt"))
+        _        (spit am-file "test content")]
+    (try
+      (testing "finds AM/PM variant with narrow no-break space"
+        ;; Query with regular space before AM
+        (let [result (tool-path/resolve-read-path "log 10 AM.txt" (.getAbsolutePath dir))]
+          (is (.exists result))
+          (is (= (.getAbsolutePath am-file) (.getAbsolutePath result)))))
+      (finally
+        (.delete am-file)
+        (.delete dir)))))
+
+(deftest resolve-read-path-curly-quote-variant-test
+  ;; Verifies that curly quote variant is tried
+  (let [dir        (doto (io/file (System/getProperty "java.io.tmpdir") "tool-path-curly-test")
+                     (.mkdirs))
+        ;; Create file with curly apostrophe
+        curly-file (io/file dir "it\u2019s.txt")
+        _          (spit curly-file "test content")]
+    (try
+      (testing "finds curly quote variant"
+        ;; Query with straight apostrophe
+        (let [result (tool-path/resolve-read-path "it's.txt" (.getAbsolutePath dir))]
+          (is (.exists result))
+          (is (= (.getAbsolutePath curly-file) (.getAbsolutePath result)))))
+      (finally
+        (.delete curly-file)
+        (.delete dir)))))
+
+(deftest resolve-read-path-tilde-expansion-test
+  ;; Verifies that ~ is expanded in read path resolution
+  (let [home (System/getProperty "user.home")]
+    (testing "expands ~ in read path"
+      (let [result (tool-path/resolve-read-path "~" nil)]
+        (is (= home (.getAbsolutePath result)))))))

--- a/components/agent-session/test/psi/agent_session/tools_test.clj
+++ b/components/agent-session/test/psi/agent_session/tools_test.clj
@@ -16,9 +16,21 @@
   (testing "eql_query appears in all-tool-schemas"
     (is (some #(= "eql_query" (:name %)) tools/all-tool-schemas))))
 
+(deftest search-tools-in-all-schemas-test
+  (testing "ls/find/grep appear in all-tool-schemas"
+    (is (some #(= "ls" (:name %)) tools/all-tool-schemas))
+    (is (some #(= "find" (:name %)) tools/all-tool-schemas))
+    (is (some #(= "grep" (:name %)) tools/all-tool-schemas))))
+
 (deftest eql-query-tool-not-in-all-tools-test
   (testing "eql_query is excluded from all-tools (requires context)"
     (is (not (some #(= "eql_query" (:name %)) tools/all-tools)))))
+
+(deftest search-tools-in-all-tools-test
+  (testing "ls/find/grep are included in all-tools"
+    (is (some #(= "ls" (:name %)) tools/all-tools))
+    (is (some #(= "find" (:name %)) tools/all-tools))
+    (is (some #(= "grep" (:name %)) tools/all-tools))))
 
 (deftest make-eql-query-tool-valid-query-test
   (testing "valid EQL query returns EDN result"
@@ -62,6 +74,20 @@
       (is (true? (:is-error result)))
       (is (re-find #"resolver failed" (:content result))))))
 
+(deftest make-eql-query-tool-truncation-test
+  (testing "truncated eql_query output includes spill path and narrowing guidance"
+    (let [tool   (tools/make-eql-query-tool
+                  (fn [_q] {:big (apply str (repeat 500 "x"))})
+                  {:overrides {"eql_query" {:max-lines 1000 :max-bytes 80}}
+                   :tool-call-id "test-call-id"})
+          result ((:execute tool) {"query" "[:big]"})
+          spill  (get-in result [:details :full-output-path])]
+      (is (false? (:is-error result)))
+      (is (re-find #"Output truncated" (:content result)))
+      (is (re-find #"Use a narrower query" (:content result)))
+      (is (string? spill))
+      (is (.exists (io/file spill))))))
+
 (deftest make-eql-query-tool-read-eval-disabled-test
   (testing "read-eval is disabled for safety"
     (let [tool   (tools/make-eql-query-tool (fn [_q] {}))
@@ -69,6 +95,27 @@
       (is (true? (:is-error result))))))
 
 (deftest execute-tool-dispatch-test
+  (testing "built-in dispatch handles ls/find/grep"
+    (let [tmp (java.io.File/createTempFile "psi-dispatch-test" "")]
+      (.delete tmp)
+      (.mkdirs tmp)
+      (try
+        (spit (io/file tmp "a.txt") "alpha")
+        (spit (io/file tmp "b.clj") "(ns b)")
+        (let [dir         (.getAbsolutePath tmp)
+              ls-result   (tools/execute-tool "ls" {"path" dir})
+              find-result (tools/execute-tool "find" {"path" dir "pattern" "*.txt"})
+              grep-result (tools/execute-tool "grep" {"path" dir "pattern" "alpha"})]
+          (is (false? (:is-error ls-result)))
+          (is (str/includes? (:content ls-result) "a.txt"))
+          (is (false? (:is-error find-result)))
+          (is (str/includes? (:content find-result) "a.txt"))
+          (is (false? (:is-error grep-result)))
+          (is (str/includes? (:content grep-result) "alpha")))
+        (finally
+          (doseq [file (reverse (file-seq tmp))]
+            (.delete file))))))
+
   (testing "built-in dispatch does not handle eql_query"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown tool"
                           (tools/execute-tool "eql_query" {"query" "[:foo]"})))))
@@ -159,7 +206,33 @@
                       {"path" "edit-me.txt" "oldText" "old text" "newText" "new text"}
                       {:cwd dir})]
           (is (false? (:is-error result)))
+          (is (re-find #"Successfully replaced text" (:content result)))
+          (is (string? (get-in result [:details :diff])))
+          (is (pos-int? (get-in result [:details :first-changed-line])))
           (is (= "new text here" (slurp (io/file dir "edit-me.txt"))))))))
+
+  (testing "edit fuzzy fallback handles smart quotes and trailing whitespace"
+    (with-temp-dir
+      (fn [dir]
+        (spit (io/file dir "fuzzy.txt") "hello ‘world’   \nnext")
+        (let [result (tools/execute-edit
+                      {"path" "fuzzy.txt" "oldText" "hello 'world'" "newText" "hello everyone"}
+                      {:cwd dir})]
+          (is (false? (:is-error result)))
+          (is (str/includes? (slurp (io/file dir "fuzzy.txt")) "hello everyone"))))))
+
+  (testing "edit preserves UTF-8 BOM"
+    (with-temp-dir
+      (fn [dir]
+        (let [p (io/file dir "bom.txt")]
+          (spit p (str "\uFEFF" "before"))
+          (let [result (tools/execute-edit
+                        {"path" "bom.txt" "oldText" "before" "newText" "after"}
+                        {:cwd dir})
+                updated (slurp p)]
+            (is (false? (:is-error result)))
+            (is (str/starts-with? updated "\uFEFF"))
+            (is (str/includes? updated "after")))))))
 
   (testing "edit without cwd works as before"
     (with-temp-dir
@@ -179,6 +252,7 @@
                       {"path" "sub/output.txt" "content" "written"}
                       {:cwd dir})]
           (is (false? (:is-error result)))
+          (is (re-find #"Successfully wrote 7 bytes" (:content result)))
           (is (= "written" (slurp (io/file dir "sub" "output.txt"))))))))
 
   (testing "write without cwd works as before"
@@ -188,6 +262,7 @@
               result   (tools/execute-write
                         {"path" abs-path "content" "abs-written"})]
           (is (false? (:is-error result)))
+          (is (re-find #"Successfully wrote" (:content result)))
           (is (= "abs-written" (slurp abs-path))))))))
 
 (deftest make-tools-with-cwd-test
@@ -224,3 +299,81 @@
           (let [r ((:execute edit-tool) {"path" "new.txt" "oldText" "new-content" "newText" "edited"})]
             (is (false? (:is-error r)))
             (is (= "edited" (slurp (io/file dir "new.txt"))))))))))
+
+(deftest execute-ls-find-grep-test
+  (testing "ls lists sorted entries with directory suffix and empty-directory message"
+    (with-temp-dir
+      (fn [dir]
+        (let [empty-res (tools/execute-ls {"path" dir})]
+          (is (= "(empty directory)" (:content empty-res))))
+        (spit (io/file dir "b.txt") "b")
+        (spit (io/file dir "A.txt") "a")
+        (.mkdirs (io/file dir "zdir"))
+        (let [res (tools/execute-ls {"path" dir})]
+          (is (false? (:is-error res)))
+          (is (str/includes? (:content res) "A.txt"))
+          (is (str/includes? (:content res) "b.txt"))
+          (is (str/includes? (:content res) "zdir/"))))))
+
+  (testing "ls applies semantic entry limit before byte truncation"
+    (with-temp-dir
+      (fn [dir]
+        (doseq [i (range 10)]
+          (spit (io/file dir (str "f" i ".txt")) "x"))
+        (let [limit-res (tools/execute-ls {"path" dir "limit" 3})
+              bytes-res (tools/execute-ls {"path" dir "limit" 10}
+                                          {:overrides {"ls" {:max-bytes 8}}})]
+          (is (= 3 (get-in limit-res [:details :entry-limit-reached])))
+          (is (str/includes? (:content limit-res) "limit reached"))
+          (is (true? (get-in bytes-res [:details :truncation :truncated])))))))
+
+  (testing "find supports glob pattern, no-results, and result limit metadata"
+    (with-temp-dir
+      (fn [dir]
+        (spit (io/file dir "a.clj") "(ns a)")
+        (spit (io/file dir "b.txt") "hello")
+        (spit (io/file dir "c.clj") "(ns c)")
+        (let [res       (tools/execute-find {"path" dir "pattern" "*.clj"})
+              none-res  (tools/execute-find {"path" dir "pattern" "*.md"})
+              limit-res (tools/execute-find {"path" dir "pattern" "*" "limit" 1})]
+          (is (false? (:is-error res)))
+          (is (str/includes? (:content res) ".clj"))
+          (is (= "No files found matching pattern" (:content none-res)))
+          (is (= 1 (get-in limit-res [:details :result-limit-reached])))
+          (is (str/includes? (:content limit-res) "limit reached"))))))
+
+  (testing "grep supports literal/ignore-case/context, no-match, and truncation metadata"
+    (with-temp-dir
+      (fn [dir]
+        (spit (io/file dir "g.txt") "Alpha\nBeta\nalpha\n")
+        (let [res      (tools/execute-grep {"path" dir "pattern" "alpha" "ignoreCase" true})
+              lit-res  (tools/execute-grep {"path" dir "pattern" "Alpha" "literal" true})
+              none-res (tools/execute-grep {"path" dir "pattern" "zzz"})
+              line-res (tools/execute-grep {"path" dir "pattern" "A"}
+                                           {:overrides {"grep" {:max-bytes 30}}})]
+          (is (false? (:is-error res)))
+          (is (str/includes? (:content res) "alpha"))
+          (is (false? (:is-error lit-res)))
+          (is (= "No matches found" (:content none-res)))
+          (is (true? (get-in line-res [:details :truncation :truncated]))))))))
+
+(deftest make-read-only-tools-with-cwd-test
+  (testing "returns read-only/search tools in canonical order"
+    (with-temp-dir
+      (fn [dir]
+        (let [tools-vec (tools/make-read-only-tools-with-cwd dir)]
+          (is (= ["read" "grep" "find" "ls"] (mapv :name tools-vec)))))))
+
+  (testing "read-only/search tools execute in scoped cwd"
+    (with-temp-dir
+      (fn [dir]
+        (spit (io/file dir "notes.txt") "hello alpha")
+        (let [tools-vec  (tools/make-read-only-tools-with-cwd dir)
+              read-tool  (first (filter #(= "read" (:name %)) tools-vec))
+              grep-tool  (first (filter #(= "grep" (:name %)) tools-vec))
+              find-tool  (first (filter #(= "find" (:name %)) tools-vec))
+              ls-tool    (first (filter #(= "ls" (:name %)) tools-vec))]
+          (is (str/includes? (:content ((:execute read-tool) {"path" "notes.txt"})) "hello alpha"))
+          (is (str/includes? (:content ((:execute grep-tool) {"path" "." "pattern" "alpha"})) "alpha"))
+          (is (str/includes? (:content ((:execute find-tool) {"path" "." "pattern" "*.txt"})) "notes.txt"))
+          (is (str/includes? (:content ((:execute ls-tool) {"path" "."})) "notes.txt")))))))


### PR DESCRIPTION
## Summary
Implements runtime parity foundations for tool-output handling and path/read behavior, plus tool-output accounting instrumentation in executor/session.

Story: #25

## Included work
- Add shared tool-output foundation ()
  - effective policy resolution (defaults + per-tool overrides)
  - head/tail truncation helpers with metadata
  - process temp store lifecycle for truncated output artifacts
- Add shared path resolution namespace ()
  - normalization, cwd resolution, and macOS read-path fallback variants
- Update  tool toward spec parity
  - magic-byte image detection
  - non-image binary safety behavior
  - offset/limit slicing + truncation guidance
- Instrument executor/session tool-output accounting
  - per-call telemetry fields
  - aggregate totals/by-tool/limit-hit counters

## Commits
- 2eefb1f ⚒ Add shared output-policy resolution, truncation helpers, and process temp store
- b6d752f ⚒ Add shared path resolution with macOS fallback variants (#27)
- f929698 ⚒ Update read tool for spec parity: binary safety, image magic-byte detection, offset/limit slicing, head truncation
- 3d8c02e ⚒ Instrument tool-output accounting in executor/session λ

## Notes
- Branch targets .
- PR opened from story branch .