### PR TITLE
Update executor run-tool-call! to handle vector content from image reads

### DIFF
--- a/components/agent-session/src/psi/agent_session/executor.clj
+++ b/components/agent-session/src/psi/agent_session/executor.clj
@@ -388,14 +388,17 @@
             (catch Exception e
               {:content  (str "Error: " (ex-message e))
                :is-error true}))
-          policy     (effective-tool-output-policy agent-session-ctx name)
-          result-msg {:role         "toolResult"
-                      :tool-call-id call-id
-                      :tool-name    name
-                      :content      [{:type :text :text content}]
-                      :is-error     is-error
-                      :details      details
-                      :timestamp    (java.time.Instant/now)}]
+          policy         (effective-tool-output-policy agent-session-ctx name)
+          content-blocks (if (vector? content)
+                           content
+                           [{:type :text :text content}])
+          result-msg     {:role         "toolResult"
+                          :tool-call-id call-id
+                          :tool-name    name
+                          :content      content-blocks
+                          :is-error     is-error
+                          :details      details
+                          :timestamp    (java.time.Instant/now)}]
       (emit-progress! progress-queue
                       {:event-kind  :tool-result
                        :tool-id     call-id

--- a/components/agent-session/test/psi/agent_session/executor_test.clj
+++ b/components/agent-session/test/psi/agent_session/executor_test.clj
@@ -150,7 +150,7 @@
           (is (= (:output-bytes call) (:context-bytes-added call)))
           (is (= (:context-bytes-added call)
                  (get-in stats [:aggregates :total-context-bytes])))
-          (is (= 1 (get-in stats [:aggregates :limit-hits-by-tool "bash"]))))))))
+          (is (= 1 (get-in stats [:aggregates :limit-hits-by-tool "bash"])))))))
 
   (testing "context-bytes-added reflects shaped content"
     (let [agent-ctx   (setup-agent-ctx!)
@@ -167,4 +167,37 @@
         (let [call (first (:calls @(:tool-output-stats-atom session-ctx)))]
           (is (= (count (.getBytes shaped "UTF-8"))
                  (:context-bytes-added call)))
-          (is (= (:context-bytes-added call) (:output-bytes call)))))))
+          (is (= (:context-bytes-added call) (:output-bytes call))))))))
+
+(deftest run-tool-call-content-shaping-test
+  (testing "passes through vector content blocks unchanged"
+    (let [agent-ctx       (setup-agent-ctx!)
+          session-ctx     (setup-session-ctx! agent-ctx)
+          tc              {:id "call-v" :name "read" :arguments "{}"}
+          vector-content  [{:type :text :text "Found image"}
+                           {:type :image :source {:type :base64 :media-type "image/png" :data "abc123"}}]
+          result          (with-redefs [psi.agent-session.executor/execute-tool-with-registry
+                                        (fn [_ _ _]
+                                          {:content vector-content
+                                           :is-error false
+                                           :details {:truncation {:truncated false :truncated-by :none}}})]
+                            (#'psi.agent-session.executor/run-tool-call! session-ctx tc nil))
+          recorded-result (last (:messages (agent/get-data-in agent-ctx)))]
+      (is (= vector-content (:content result)))
+      (is (= vector-content (:content recorded-result)))))
+
+  (testing "wraps string content as a single text block"
+    (let [agent-ctx       (setup-agent-ctx!)
+          session-ctx     (setup-session-ctx! agent-ctx)
+          tc              {:id "call-s" :name "bash" :arguments "{}"}
+          string-content  "trimmed"
+          expected-blocks [{:type :text :text string-content}]
+          result          (with-redefs [psi.agent-session.executor/execute-tool-with-registry
+                                        (fn [_ _ _]
+                                          {:content string-content
+                                           :is-error false
+                                           :details {:truncation {:truncated false :truncated-by :none}}})]
+                            (#'psi.agent-session.executor/run-tool-call! session-ctx tc nil))
+          recorded-result (last (:messages (agent/get-data-in agent-ctx)))]
+      (is (= expected-blocks (:content result)))
+      (is (= expected-blocks (:content recorded-result))))))


### PR DESCRIPTION
## Summary
Update `run-tool-call!` to preserve structured vector content blocks from tool outputs (e.g. image reads) while keeping existing text fallback behavior.

## Story
- #35 Update executor run-tool-call! to handle vector content from image reads

## What changed
- Normalize tool result content blocks in `run-tool-call!`:
  - pass through vector `:content` unchanged
  - wrap non-vector/string content as `[{:type :text :text content}]`
- Add executor tests covering:
  - vector content block pass-through (including image-style block shape)
  - string fallback wrapping behavior

## Design notes
- Scope limited to toolResult content shaping in executor.
- Existing error/details/stat/accounting/event flow remains unchanged.
- No provider serialization changes.

## Commits
- f387cdd ⚒ Normalize run-tool-call! toolResult content block shaping
- 569323f ⚒ Add executor tests for run-tool-call! vector pass-through and string fallback

## Additional context
- Story context token: `35`