### PR TITLE
feat: Implement tool-output display parity with spec in Psi TUI

### DIFF
--- a/components/agent-session/src/psi/agent_session/executor.clj
+++ b/components/agent-session/src/psi/agent_session/executor.clj
@@ -332,12 +332,44 @@
   [s]
   (count (.getBytes (str (or s "")) "UTF-8")))
 
+(defn- tool-content->text
+  [content]
+  (cond
+    (string? content)
+    content
+
+    (sequential? content)
+    (->> content
+         (keep (fn [block]
+                 (when (= :text (:type block))
+                   (:text block))))
+         (str/join "\n"))
+
+    :else
+    (str (or content ""))))
+
+(defn- normalize-tool-content
+  [content]
+  (cond
+    (sequential? content)
+    (vec content)
+
+    (string? content)
+    [{:type :text :text content}]
+
+    (nil? content)
+    [{:type :text :text ""}]
+
+    :else
+    [{:type :text :text (str content)}]))
+
 (defn- record-tool-output-stat!
   [agent-session-ctx {:keys [tool-call-id tool-name content details effective-policy]}]
   (let [truncation          (:truncation details)
         limit-hit?          (boolean (:truncated truncation))
         truncated-by        (or (:truncated-by truncation) :none)
-        output-bytes        (utf8-bytes content)
+        content-text        (tool-content->text content)
+        output-bytes        (utf8-bytes content-text)
         context-bytes-added output-bytes
         stat                {:tool-call-id         tool-call-id
                              :tool-name            tool-name
@@ -361,13 +393,18 @@
   "Execute a tool by name, preferring an :execute fn from the current
    agent tool registry when present. Falls back to built-in tools.
 
-   Tool contract: (fn [args-map] -> {:content string :is-error boolean})"
-  [agent-ctx tool-name args]
-  (let [tool-def (some #(when (= tool-name (:name %)) %) (:tools (agent/get-data-in agent-ctx)))
+   Tool contract:
+   - preferred: (fn [args-map opts-map] -> {:content string|blocks :is-error boolean})
+   - legacy:    (fn [args-map] -> {:content string|blocks :is-error boolean})"
+  [agent-ctx tool-name args opts]
+  (let [tool-def   (some #(when (= tool-name (:name %)) %) (:tools (agent/get-data-in agent-ctx)))
         execute-fn (:execute tool-def)]
     (if (fn? execute-fn)
-      (execute-fn args)
-      (tools/execute-tool tool-name args))))
+      (try
+        (execute-fn args opts)
+        (catch clojure.lang.ArityException _
+          (execute-fn args)))
+      (tools/execute-tool tool-name args opts))))
 
 (defn- run-tool-call!
   "Execute one tool call, record the result in agent-core, return the result map."
@@ -375,7 +412,21 @@
   (let [agent-ctx (:agent-ctx agent-session-ctx)
         call-id  (:id tool-call)
         name     (:name tool-call)
-        args     (parse-args (:arguments tool-call))]
+        args     (parse-args (:arguments tool-call))
+        opts     {:cwd         (:cwd agent-session-ctx)
+                  :overrides   (:tool-output-overrides @(:session-data-atom agent-session-ctx))
+                  :tool-call-id call-id
+                  :on-update   (fn [{:keys [content details is-error]}]
+                                 (let [content-blocks (normalize-tool-content content)
+                                       text-fallback  (tool-content->text content)]
+                                   (emit-progress! progress-queue
+                                                   {:event-kind   :tool-execution-update
+                                                    :tool-id      call-id
+                                                    :tool-name    name
+                                                    :content      content-blocks
+                                                    :result-text  text-fallback
+                                                    :details      details
+                                                    :is-error     (boolean is-error)})))}]
     (agent/emit-tool-start-in! agent-ctx tool-call)
     (emit-progress! progress-queue
                     {:event-kind  :tool-executing
@@ -384,33 +435,35 @@
                      :parsed-args args})
     (let [{:keys [content is-error details] :as tool-result}
           (try
-            (execute-tool-with-registry agent-ctx name args)
+            (execute-tool-with-registry agent-ctx name args opts)
             (catch Exception e
               {:content  (str "Error: " (ex-message e))
                :is-error true}))
+          content-blocks (normalize-tool-content content)
+          text-fallback  (tool-content->text content)
           policy         (effective-tool-output-policy agent-session-ctx name)
-          content-blocks (if (vector? content)
-                           content
-                           [{:type :text :text content}])
           result-msg     {:role         "toolResult"
                           :tool-call-id call-id
                           :tool-name    name
                           :content      content-blocks
                           :is-error     is-error
                           :details      details
+                          :result-text  text-fallback
                           :timestamp    (java.time.Instant/now)}]
       (emit-progress! progress-queue
                       {:event-kind  :tool-result
                        :tool-id     call-id
                        :tool-name   name
-                       :result-text content
+                       :content     content-blocks
+                       :result-text text-fallback
+                       :details     details
                        :is-error    is-error})
       (record-tool-output-stat!
        agent-session-ctx
-       {:tool-call-id    call-id
-        :tool-name       name
-        :content         content
-        :details         details
+       {:tool-call-id     call-id
+        :tool-name        name
+        :content          content
+        :details          details
         :effective-policy policy})
       (agent/emit-tool-end-in! agent-ctx tool-call tool-result is-error)
       (agent/record-tool-result-in! agent-ctx result-msg)

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -222,22 +222,81 @@
       :else
       "")))
 
-(defn- agent-messages->tui-messages
-  "Convert agent-core history to TUI display messages.
-   Keeps user/assistant roles, skips toolResult messages."
+(defn- tool-result->display-text
+  "Best-effort display text for a toolResult message content vector."
+  [msg]
+  (let [text (message->display-text msg)]
+    (when-not (str/blank? text)
+      text)))
+
+(defn- agent-messages->tui-resume-state
+  "Convert agent-core history to TUI resume state.
+   Returns {:messages [...], :tool-calls {...}, :tool-order [...]}.
+   Tool rows are reconstructed by correlating assistant tool-call blocks
+   with toolResult messages by tool-call-id."
   [messages]
-  (->> messages
-       (keep (fn [msg]
-               (when-let [role (case (:role msg)
-                                 "user"      :user
-                                 "assistant" :assistant
-                                 nil)]
-                 (let [text (message->display-text msg)]
-                   {:role role
-                    :text (if (str/blank? text)
-                            (str "[" (:role msg) "]")
-                            text)}))))
-       vec))
+  (reduce
+   (fn [{:keys [messages tool-calls tool-order] :as acc} msg]
+     (case (:role msg)
+       "user"
+       (let [text (message->display-text msg)]
+         (update acc :messages conj {:role :user
+                                     :text (if (str/blank? text) "[user]" text)}))
+
+       "assistant"
+       (let [text (message->display-text msg)
+             content (:content msg)
+             tool-blocks (filter #(= :tool-call (:type %)) content)
+             acc' (if (str/blank? text)
+                    acc
+                    (update acc :messages conj {:role :assistant :text text}))]
+         (reduce
+          (fn [a block]
+            (let [id (:id block)
+                  tc {:name      (:name block)
+                      :args      (or (:arguments block) "")
+                      :status    :pending
+                      :result    nil
+                      :is-error  false
+                      :expanded? false}]
+              (-> a
+                  (update :tool-calls #(if (contains? % id) % (assoc % id tc)))
+                  (update :tool-order #(if (some #{id} %) % (conj % id))))))
+          acc'
+          tool-blocks))
+
+       "toolResult"
+       (let [id      (:tool-call-id msg)
+             text    (tool-result->display-text msg)
+             content (:content msg)
+             details (:details msg)
+             err?    (boolean (:is-error msg))
+             fallback {:name      (:tool-name msg)
+                       :args      ""
+                       :status    (if err? :error :success)
+                       :result    text
+                       :content   content
+                       :details   details
+                       :is-error  err?
+                       :expanded? false}]
+         (-> acc
+             (update :tool-calls
+                     (fn [m]
+                       (if-let [tc (get m id)]
+                         (assoc m id
+                                (-> tc
+                                    (assoc :status (if err? :error :success)
+                                           :content content
+                                           :details details
+                                           :is-error err?)
+                                    (cond-> text (assoc :result text))))
+                         (assoc m id fallback))))
+             (update :tool-order #(if (some #{id} %) % (conj % id)))))
+
+       ;; unknown roles — ignore
+       acc))
+   {:messages [] :tool-calls {} :tool-order []}
+   messages))
 
 ;; select-login-provider moved to psi.agent-session.commands
 
@@ -500,16 +559,18 @@
                                           :content [{:type :text :text text}]}}))
 
         ;; Resume callback used by the TUI /resume selector.
-        ;; Returns TUI message maps to display immediately after loading.
+        ;; Returns TUI resume state maps to display immediately after loading.
         resume-fn! (fn [session-path]
                      (try
                        (session/resume-session-in! ctx session-path)
                        (let [messages (:messages (agent/get-data-in (:agent-ctx ctx)))]
-                         (agent-messages->tui-messages messages))
+                         (agent-messages->tui-resume-state messages))
                        (catch Exception e
                          (timbre/error e "Resume failed:" session-path)
-                         [{:role :assistant
-                           :text (str "✗ Resume failed: " (ex-message e))}])))
+                         {:messages [{:role :assistant
+                                      :text (str "✗ Resume failed: " (ex-message e))}]
+                          :tool-calls {}
+                          :tool-order []})))
 
         cmd-opts  {:oauth-ctx oauth-ctx :ai-model ai-model}
 

--- a/components/agent-session/src/psi/agent_session/tools.clj
+++ b/components/agent-session/src/psi/agent_session/tools.clj
@@ -441,11 +441,16 @@
                              truncated?
                              (str "\n\n... [truncated, " (:total-lines trunc)
                                   " total lines] Full output: " spill-path))]
-             {:content  content
-              :is-error non-zero?
-              :details  (when truncated?
-                          {:truncation       trunc
-                           :full-output-path spill-path})})))
+             (let [result {:content  content
+                           :is-error non-zero?
+                           :details  (when truncated?
+                                       {:truncation       trunc
+                                        :full-output-path spill-path})}]
+               (when on-update
+                 (try
+                   (on-update result)
+                   (catch Exception _ nil)))
+               result))))
        (catch Exception e
          (reset! bash-process-atom nil)
          {:content  (str "Command execution error: " (ex-message e))
@@ -851,17 +856,19 @@
   #{"read" "bash" "edit" "write" "ls" "find" "grep"})
 
 (defn execute-tool
-  "Dispatch a tool call by name. Returns {:content string :is-error boolean}.
+  "Dispatch a tool call by name. Returns {:content string|blocks :is-error boolean}.
   Throws ex-info for unknown tools.
   Note: eql_query is not dispatched here — it requires a session context
   and is handled via the tool registry's :execute fn."
-  [tool-name args-map]
-  (case tool-name
-    "read"  (execute-read args-map)
-    "bash"  (execute-bash args-map)
-    "edit"  (execute-edit args-map)
-    "write" (execute-write args-map)
-    "ls"    (execute-ls args-map)
-    "find"  (execute-find args-map)
-    "grep"  (execute-grep args-map)
-    (throw (ex-info (str "Unknown tool: " tool-name) {:tool tool-name}))))
+  ([tool-name args-map]
+   (execute-tool tool-name args-map nil))
+  ([tool-name args-map opts]
+   (case tool-name
+     "read"  (execute-read args-map opts)
+     "bash"  (execute-bash args-map opts)
+     "edit"  (execute-edit args-map opts)
+     "write" (execute-write args-map opts)
+     "ls"    (execute-ls args-map opts)
+     "find"  (execute-find args-map opts)
+     "grep"  (execute-grep args-map opts)
+     (throw (ex-info (str "Unknown tool: " tool-name) {:tool tool-name})))))

--- a/components/agent-session/test/psi/agent_session/executor_test.clj
+++ b/components/agent-session/test/psi/agent_session/executor_test.clj
@@ -7,7 +7,9 @@
    [clojure.test :refer [deftest testing is]]
    [psi.agent-core.core :as agent]
    [psi.agent-session.executor :as executor]
-   [psi.agent-session.turn-statechart :as turn-sc]))
+   [psi.agent-session.turn-statechart :as turn-sc])
+  (:import
+   [java.util.concurrent LinkedBlockingQueue TimeUnit]))
 
 (defn- stub-text-stream
   [text]
@@ -134,7 +136,7 @@
           session-ctx (setup-session-ctx! agent-ctx)
           tc          {:id "call-1" :name "bash" :arguments "{}"}]
       (with-redefs [psi.agent-session.executor/execute-tool-with-registry
-                    (fn [_ _ _]
+                    (fn [_ _ _ _]
                       {:content "trimmed"
                        :is-error false
                        :details {:truncation {:truncated true :truncated-by :bytes}}})]
@@ -159,7 +161,7 @@
           raw         (apply str (repeat 1000 "x"))
           shaped      (subs raw 0 20)]
       (with-redefs [psi.agent-session.executor/execute-tool-with-registry
-                    (fn [_ _ _]
+                    (fn [_ _ _ _]
                       {:content shaped
                        :is-error false
                        :details {:truncation {:truncated true :truncated-by :bytes}}})]
@@ -167,37 +169,36 @@
         (let [call (first (:calls @(:tool-output-stats-atom session-ctx)))]
           (is (= (count (.getBytes shaped "UTF-8"))
                  (:context-bytes-added call)))
-          (is (= (:context-bytes-added call) (:output-bytes call))))))))
+          (is (= (:context-bytes-added call) (:output-bytes call)))))))
 
-(deftest run-tool-call-content-shaping-test
-  (testing "passes through vector content blocks unchanged"
-    (let [agent-ctx       (setup-agent-ctx!)
-          session-ctx     (setup-session-ctx! agent-ctx)
-          tc              {:id "call-v" :name "read" :arguments "{}"}
-          vector-content  [{:type :text :text "Found image"}
-                           {:type :image :source {:type :base64 :media-type "image/png" :data "abc123"}}]
-          result          (with-redefs [psi.agent-session.executor/execute-tool-with-registry
-                                        (fn [_ _ _]
-                                          {:content vector-content
-                                           :is-error false
-                                           :details {:truncation {:truncated false :truncated-by :none}}})]
-                            (#'psi.agent-session.executor/run-tool-call! session-ctx tc nil))
-          recorded-result (last (:messages (agent/get-data-in agent-ctx)))]
-      (is (= vector-content (:content result)))
-      (is (= vector-content (:content recorded-result)))))
-
-  (testing "wraps string content as a single text block"
-    (let [agent-ctx       (setup-agent-ctx!)
-          session-ctx     (setup-session-ctx! agent-ctx)
-          tc              {:id "call-s" :name "bash" :arguments "{}"}
-          string-content  "trimmed"
-          expected-blocks [{:type :text :text string-content}]
-          result          (with-redefs [psi.agent-session.executor/execute-tool-with-registry
-                                        (fn [_ _ _]
-                                          {:content string-content
-                                           :is-error false
-                                           :details {:truncation {:truncated false :truncated-by :none}}})]
-                            (#'psi.agent-session.executor/run-tool-call! session-ctx tc nil))
-          recorded-result (last (:messages (agent/get-data-in agent-ctx)))]
-      (is (= expected-blocks (:content result)))
-      (is (= expected-blocks (:content recorded-result))))))
+  (testing "structured content blocks are preserved and progress events include rich payload"
+    (let [agent-ctx   (setup-agent-ctx!)
+          session-ctx (setup-session-ctx! agent-ctx)
+          tc          {:id "call-3" :name "read" :arguments "{}"}
+          q           (LinkedBlockingQueue.)
+          blocks      [{:type :text :text "hello"}
+                       {:type :image :mime-type "image/png" :data "<base64>"}]
+          results     (atom nil)]
+      (with-redefs [psi.agent-session.executor/execute-tool-with-registry
+                    (fn [_ _ _ opts]
+                      ((:on-update opts) {:content "partial" :details {:phase :running}})
+                      {:content blocks
+                       :is-error false
+                       :details {:truncation {:truncated false}}})
+                    agent/record-tool-result-in!
+                    (fn [_ msg]
+                      (reset! results msg)
+                      nil)]
+        (#'psi.agent-session.executor/run-tool-call! session-ctx tc q)
+        (let [events   (loop [acc []]
+                         (if-let [e (.poll q 5 TimeUnit/MILLISECONDS)]
+                           (recur (conj acc e))
+                           acc))
+              update-e (some #(when (= :tool-execution-update (:event-kind %)) %) events)
+              result-e (some #(when (= :tool-result (:event-kind %)) %) events)]
+          (is (= blocks (:content @results)))
+          (is (= "hello" (:result-text @results)))
+          (is (= [{:type :text :text "partial"}] (:content update-e)))
+          (is (= "partial" (:result-text update-e)))
+          (is (= blocks (:content result-e)))
+          (is (= "hello" (:result-text result-e))))))))

--- a/components/agent-session/test/psi/agent_session/main_test.clj
+++ b/components/agent-session/test/psi/agent_session/main_test.clj
@@ -10,6 +10,7 @@
    [psi.agent-session.prompt-templates :as pt]
    [psi.agent-session.skills :as skills]
    [psi.agent-session.system-prompt :as sys-prompt]
+   [psi.agent-session.executor :as executor]
    [psi.tui.app :as tui-app]))
 
 (deftest select-login-provider-test
@@ -107,3 +108,32 @@
         (is (fn? (:dispatch-fn @captured))))
       (finally
         (reset! main/session-state orig-state)))))
+
+(deftest agent-messages->tui-resume-state-rehydrates-tool-rows-test
+  (let [messages [{:role "user"
+                   :content [{:type :text :text "read file"}]}
+                  {:role "assistant"
+                   :content [{:type :text :text "Sure"}
+                             {:type :tool-call :id "call-1" :name "read"
+                              :arguments "{\"path\":\"a.txt\"}"}]}
+                  {:role "toolResult"
+                   :tool-call-id "call-1"
+                   :tool-name "read"
+                   :content [{:type :text :text "hello"}
+                             {:type :image :mime-type "image/png" :data "<base64>"}]
+                   :details {:full-output-path "/tmp/all.log"}
+                   :is-error false}
+                  {:role "assistant"
+                   :content [{:type :text :text "done"}]}]
+        {:keys [messages tool-calls tool-order]}
+        (#'main/agent-messages->tui-resume-state messages)]
+    (is (= [{:role :user :text "read file"}
+            {:role :assistant :text "Sure"}
+            {:role :assistant :text "done"}]
+           messages))
+    (is (= ["call-1"] tool-order))
+    (is (= "read" (get-in tool-calls ["call-1" :name])))
+    (is (= :success (get-in tool-calls ["call-1" :status])))
+    (is (= "hello" (get-in tool-calls ["call-1" :result])))
+    (is (= {:full-output-path "/tmp/all.log"}
+           (get-in tool-calls ["call-1" :details])))))

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -470,7 +470,8 @@
            ;; Live turn progress
            :stream-text           nil
            :tool-calls            {}
-           :tool-order            []}
+           :tool-order            []
+           :tools-expanded?       false}
           (poll-cmd queue)])))))
 
 ;; ── Update helpers ──────────────────────────────────────────
@@ -628,9 +629,7 @@
                 :error         nil
                 :input         (charm/text-input-reset (:input state))
                 :spinner-frame 0
-                :stream-text   nil
-                :tool-calls    {}
-                :tool-order    []))
+                :stream-text   nil))
      (poll-cmd queue)]))
 
 (defn- submit-input
@@ -699,11 +698,12 @@
 
       :tool-start
       (let [id   (:tool-id event)
-            tc   {:name   (:tool-name event)
-                  :args   ""
-                  :status :pending
-                  :result nil
-                  :is-error false}]
+            tc   {:name      (:tool-name event)
+                  :args      ""
+                  :status    :pending
+                  :result    nil
+                  :is-error  false
+                  :expanded? (boolean (:tools-expanded? state))}]
         [(-> state
              (assoc-in [:tool-calls id] tc)
              (update :tool-order conj id))
@@ -721,14 +721,39 @@
                      (:parsed-args event)))
        nil]
 
+      :tool-execution-update
+      [(-> state
+           (assoc-in [:tool-calls (:tool-id event) :status] :running)
+           (assoc-in [:tool-calls (:tool-id event) :content] (:content event))
+           (assoc-in [:tool-calls (:tool-id event) :details] (:details event))
+           (assoc-in [:tool-calls (:tool-id event) :result]
+                     (or (:result-text event)
+                         (some->> (:content event)
+                                  (keep (fn [block]
+                                          (when (= :text (:type block))
+                                            (:text block))))
+                                  (str/join "\n"))))
+           (assoc-in [:tool-calls (:tool-id event) :is-error]
+                     (boolean (:is-error event))))
+       nil]
+
       :tool-result
       [(-> state
            (assoc-in [:tool-calls (:tool-id event) :status]
                      (if (:is-error event) :error :success))
+           (assoc-in [:tool-calls (:tool-id event) :content] (:content event))
+           (assoc-in [:tool-calls (:tool-id event) :details] (:details event))
            (assoc-in [:tool-calls (:tool-id event) :result]
-                     (:result-text event))
+                     (or (:result-text event)
+                         (some->> (:content event)
+                                  (keep (fn [block]
+                                          (when (= :text (:type block))
+                                            (:text block))))
+                                  (str/join "\n"))))
            (assoc-in [:tool-calls (:tool-id event) :is-error]
-                     (:is-error event)))
+                     (boolean (:is-error event)))
+           (assoc-in [:tool-calls (:tool-id event) :expanded?]
+                     (boolean (:tools-expanded? state))))
        nil]
 
       ;; unknown event-kind — ignore
@@ -748,9 +773,7 @@
          (update :messages conj {:role :assistant :text display})
          (assoc :phase       :idle
                 :error       error
-                :stream-text nil
-                :tool-calls  {}
-                :tool-order  []))
+                :stream-text nil))
      (poll-cmd (:queue state))]))
 
 (defn- handle-agent-poll
@@ -833,9 +856,7 @@
         [(-> state
              (assoc :phase       :idle
                     :error       (:error m)
-                    :stream-text nil
-                    :tool-calls  {}
-                    :tool-order  []))
+                    :stream-text nil))
          (poll-cmd (:queue state))]
 
       ;; Agent poll timeout → keep polling (and animate spinner while streaming)
@@ -847,6 +868,11 @@
       ;; Session selector active — route all key input to selector handler
         (= :selecting-session (:phase state))
         (handle-selector-key state m)
+
+      ;; Ctrl+O toggles global tool expansion state.
+        (and (= :idle (:phase state))
+             (msg/key-match? m "ctrl+o"))
+        [(update state :tools-expanded? not) nil]
 
       ;; Alt/Meta+Backspace delete previous word.
       ;; (Explicit handling to avoid charm's binding-order issue.)
@@ -1384,7 +1410,13 @@
 
 ;; ── Tool progress rendering ──────────────────────────────────
 
-(def ^:private tool-result-preview-lines 5)
+(def ^:private default-preview-lines 5)
+(def ^:private read-preview-lines 10)
+(def ^:private write-preview-lines 10)
+(def ^:private ls-preview-lines 20)
+(def ^:private find-preview-lines 20)
+(def ^:private grep-preview-lines 15)
+(def ^:private bash-preview-lines 5)
 
 (defn- tool-header
   "Format tool name and key argument for display."
@@ -1409,18 +1441,6 @@
     :error   (charm/render tool-err-style "✗")
     ""))
 
-(defn- truncate-result
-  "Truncate tool result to N lines."
-  [text max-lines]
-  (when (and text (not (str/blank? text)))
-    (let [lines (str/split-lines text)
-          n     (count lines)]
-      (if (<= n max-lines)
-        text
-        (str (str/join "\n" (take max-lines lines))
-             "\n" (charm/render dim-style
-                                (str "… (" (- n max-lines) " more lines)")))))))
-
 (defn- wrap-tool-result-line
   "Wrap a single tool result line to fit within `avail`
    visible columns. Returns a seq of wrapped strings."
@@ -1429,10 +1449,107 @@
     [line]
     (ansi/word-wrap-ansi line avail)))
 
+(defn- tool-expanded?
+  [tools-expanded? _tc]
+  (boolean tools-expanded?))
+
+(defn- content-block->text
+  [block]
+  (let [t (:type block)
+        t-label (cond
+                  (keyword? t) (name t)
+                  (string? t)  t
+                  :else        "unknown")]
+    (case t
+      :text  (:text block)
+      :image (str "[image " (or (:mime-type block) "unknown") "]")
+      (str "[unsupported content block: " t-label "]"))))
+
+(defn- tool-content->text
+  [content]
+  (when (seq content)
+    (str/join "\n" (map content-block->text content))))
+
+(defn- preview-lines-for-tool
+  [tool-name]
+  (case tool-name
+    "read" read-preview-lines
+    "write" write-preview-lines
+    "ls" ls-preview-lines
+    "find" find-preview-lines
+    "grep" grep-preview-lines
+    "bash" bash-preview-lines
+    default-preview-lines))
+
+(defn- tool-preview
+  [tool-name text expanded?]
+  (when (and text (not (str/blank? text)))
+    (let [lines (str/split-lines text)
+          total (count lines)]
+      (if expanded?
+        {:lines lines :hidden? false :bash-tail? false :hidden-count 0}
+        (let [limit (preview-lines-for-tool tool-name)]
+          (if (<= total limit)
+            {:lines lines :hidden? false :bash-tail? false :hidden-count 0}
+            (if (= "bash" tool-name)
+              {:lines (vec (take-last limit lines))
+               :hidden? true
+               :bash-tail? true
+               :hidden-count (- total limit)}
+              {:lines (vec (take limit lines))
+               :hidden? true
+               :bash-tail? false
+               :hidden-count (- total limit)})))))))
+
+(defn- detail-warning-lines
+  [details]
+  (let [truncation (or (:truncation details)
+                       (get details "truncation"))
+        full-output-path (or (:full-output-path details)
+                             (:fullOutputPath details)
+                             (get details "full-output-path")
+                             (get details "fullOutputPath"))
+        entry-limit (or (:entry-limit-reached details)
+                        (:entryLimitReached details)
+                        (get details "entry-limit-reached")
+                        (get details "entryLimitReached"))
+        result-limit (or (:result-limit-reached details)
+                         (:resultLimitReached details)
+                         (get details "result-limit-reached")
+                         (get details "resultLimitReached"))
+        match-limit (or (:match-limit-reached details)
+                        (:matchLimitReached details)
+                        (get details "match-limit-reached")
+                        (get details "matchLimitReached"))
+        lines-truncated? (boolean (or (:lines-truncated details)
+                                      (:linesTruncated details)
+                                      (get details "lines-truncated")
+                                      (get details "linesTruncated")))]
+    (cond-> []
+      (and (map? truncation) (:truncated truncation))
+      (conj (str "Truncated output"
+                 (when-let [by (:truncated-by truncation)]
+                   (str " (" by ")"))))
+
+      full-output-path
+      (conj (str "Full output: " full-output-path))
+
+      entry-limit
+      (conj (str "Entry limit reached: " entry-limit))
+
+      result-limit
+      (conj (str "Result limit reached: " result-limit))
+
+      match-limit
+      (conj (str "Match limit reached: " match-limit))
+
+      lines-truncated?
+      (conj "Long lines truncated"))))
+
 (defn- render-tool-calls
   "Render all tool calls for the current turn.
    `width` is the terminal column count."
-  [tool-calls tool-order spinner-char width]
+  [tool-calls tool-order spinner-char width tools-expanded?]
   (when (seq tool-order)
     (let [;; "  ✓ " prefix = 4 visible cols for header
           header-avail (when (and width (> width 4))
@@ -1445,35 +1562,50 @@
        (for [id tool-order
              :let [tc (get tool-calls id)]
              :when tc]
-         (let [status-icon (tool-status-indicator
-                            (:status tc) spinner-char)
-               header      (tool-header (:name tc)
-                                        (:parsed-args tc)
-                                        (:args tc))
-               header      (if header-avail
-                             (ansi/truncate-to-width
-                              header header-avail)
-                             header)
-               result      (truncate-result
-                            (:result tc)
-                            tool-result-preview-lines)
-               result-style (if (:is-error tc)
-                              tool-err-style
-                              tool-dim-style)]
+         (let [status-icon   (tool-status-indicator
+                              (:status tc) spinner-char)
+               header        (tool-header (:name tc)
+                                          (:parsed-args tc)
+                                          (:args tc))
+               header        (if header-avail
+                               (ansi/truncate-to-width
+                                header header-avail)
+                               header)
+               expanded?     (tool-expanded? tools-expanded? tc)
+               raw-result    (or (:result tc)
+                                 (tool-content->text (:content tc)))
+               {:keys [lines hidden? bash-tail? hidden-count]}
+               (or (tool-preview (:name tc) raw-result expanded?)
+                   {:lines [] :hidden? false :bash-tail? false :hidden-count 0})
+               hint-line      (when hidden?
+                                (if bash-tail?
+                                  (str "… (" hidden-count " earlier lines hidden, ctrl+o to expand)")
+                                  (str "… (" hidden-count " more lines, ctrl+o to expand)")))
+               warning-lines  (into [] (concat (detail-warning-lines (:details tc))
+                                               (when hint-line [hint-line])))
+               result-style   (if (:is-error tc)
+                                tool-err-style
+                                tool-dim-style)]
            (str "  " status-icon " " header
-                (when result
+                (when (or (seq lines) (seq warning-lines))
                   (str "\n"
                        (str/join
                         "\n"
-                        (mapcat
-                         (fn [line]
-                           (let [wrapped (wrap-tool-result-line
-                                          line result-avail)]
-                             (map #(str "    "
-                                        (charm/render
-                                         result-style %))
-                                  wrapped)))
-                         (str/split-lines result))))))))))))
+                        (concat
+                         (mapcat
+                          (fn [line]
+                            (let [wrapped (wrap-tool-result-line line result-avail)]
+                              (map #(str "    "
+                                         (charm/render result-style %))
+                                   wrapped)))
+                          lines)
+                         (mapcat
+                          (fn [line]
+                            (let [wrapped (wrap-tool-result-line line result-avail)]
+                              (map #(str "    "
+                                         (charm/render dim-style %))
+                                   wrapped)))
+                          warning-lines))))))))))))
 
 (defn- render-stream-text
   "Render accumulated streaming text from the LLM
@@ -1495,7 +1627,7 @@
   [state]
   (let [{:keys [messages phase error input spinner-frame model-name
                 prompt-templates skills extension-summary ui-state-atom
-                stream-text tool-calls tool-order
+                stream-text tool-calls tool-order tools-expanded?
                 session-selector current-session-file width force-clear?]} state
         spinner-char   (nth spinner-frames (mod spinner-frame (count spinner-frames)))
         dialog-active? (has-active-dialog? state)
@@ -1528,7 +1660,7 @@
             (when (= :streaming phase)
               (if has-progress?
                 (str (render-stream-text stream-text term-width)
-                     (render-tool-calls tool-calls tool-order spinner-char term-width)
+                     (render-tool-calls tool-calls tool-order spinner-char term-width tools-expanded?)
                      "\n")
                 (str "\n" (charm/render assist-style "ψ: ")
                      spinner-char " thinking…\n")))

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -471,7 +471,7 @@
            :stream-text           nil
            :tool-calls            {}
            :tool-order            []
-           :tools-expanded?       false}
+           :tools-expanded?       (ext-ui/get-tools-expanded ui-state-atom)}
           (poll-cmd queue)])))))
 
 ;; ── Update helpers ──────────────────────────────────────────
@@ -796,6 +796,10 @@
     ;; One-shot render flag used by view for explicit full-screen clears.
     (let [state (if (:force-clear? state)
                   (assoc state :force-clear? false)
+                  state)
+          ;; Keep app state in sync with extension-controlled tools-expanded state.
+          state (if-let [ui-atom (:ui-state-atom state)]
+                  (assoc state :tools-expanded? (ext-ui/get-tools-expanded ui-atom))
                   state)]
       ;; Dismiss expired notifications on every tick
       (when-let [ui-atom (:ui-state-atom state)]
@@ -872,7 +876,10 @@
       ;; Ctrl+O toggles global tool expansion state.
         (and (= :idle (:phase state))
              (msg/key-match? m "ctrl+o"))
-        [(update state :tools-expanded? not) nil]
+        (let [new-expanded? (not (:tools-expanded? state))]
+          (when-let [ui-atom (:ui-state-atom state)]
+            (ext-ui/set-tools-expanded! ui-atom new-expanded?))
+          [(assoc state :tools-expanded? new-expanded?) nil])
 
       ;; Alt/Meta+Backspace delete previous word.
       ;; (Explicit handling to avoid charm's binding-order issue.)
@@ -1418,12 +1425,16 @@
 (def ^:private grep-preview-lines 15)
 (def ^:private bash-preview-lines 5)
 
+(defn- parse-tool-args
+  [parsed-args args-str]
+  (or parsed-args
+      (try (json/parse-string args-str)
+           (catch Exception _ nil))))
+
 (defn- tool-header
   "Format tool name and key argument for display."
   [tool-name parsed-args args-str]
-  (let [args (or parsed-args
-                 (try (json/parse-string args-str)
-                      (catch Exception _ nil)))]
+  (let [args (parse-tool-args parsed-args args-str)]
     (case tool-name
       "read"  (str (charm/render tool-style "read")  " " (get args "path" "…"))
       "bash"  (str (charm/render tool-style "$")      " " (get args "command" "…"))
@@ -1546,10 +1557,30 @@
       lines-truncated?
       (conj "Long lines truncated"))))
 
+(defn- extension-call-render
+  [ui-state-atom tc]
+  (when-let [render-fn (some-> (ext-ui/get-tool-renderer ui-state-atom (:name tc))
+                               :render-call-fn)]
+    (try
+      (some-> (render-fn (parse-tool-args (:parsed-args tc) (:args tc))) str)
+      (catch Exception e
+        (timbre/warn "Tool call renderer failed for" (:name tc) "- falling back:" (ex-message e))
+        nil))))
+
+(defn- extension-result-render
+  [ui-state-atom tc opts]
+  (when-let [render-fn (some-> (ext-ui/get-tool-renderer ui-state-atom (:name tc))
+                               :render-result-fn)]
+    (try
+      (some-> (render-fn tc opts) str)
+      (catch Exception e
+        (timbre/warn "Tool result renderer failed for" (:name tc) "- falling back:" (ex-message e))
+        nil))))
+
 (defn- render-tool-calls
   "Render all tool calls for the current turn.
    `width` is the terminal column count."
-  [tool-calls tool-order spinner-char width tools-expanded?]
+  [tool-calls tool-order spinner-char width tools-expanded? ui-state-atom]
   (when (seq tool-order)
     (let [;; "  ✓ " prefix = 4 visible cols for header
           header-avail (when (and width (> width 4))
@@ -1564,9 +1595,12 @@
              :when tc]
          (let [status-icon   (tool-status-indicator
                               (:status tc) spinner-char)
-               header        (tool-header (:name tc)
-                                          (:parsed-args tc)
-                                          (:args tc))
+               call-render   (extension-call-render ui-state-atom tc)
+               header        (if (seq call-render)
+                               call-render
+                               (tool-header (:name tc)
+                                            (:parsed-args tc)
+                                            (:args tc)))
                header        (if header-avail
                                (ansi/truncate-to-width
                                 header header-avail)
@@ -1583,11 +1617,22 @@
                                   (str "… (" hidden-count " more lines, ctrl+o to expand)")))
                warning-lines  (into [] (concat (detail-warning-lines (:details tc))
                                                (when hint-line [hint-line])))
+               result-render  (extension-result-render ui-state-atom tc
+                                                      {:expanded? expanded?
+                                                       :width width
+                                                       :tool-id id
+                                                       :tool-name (:name tc)})
+               result-lines   (if (seq result-render)
+                                (str/split-lines result-render)
+                                lines)
+               warning-lines  (if (seq result-render)
+                                []
+                                warning-lines)
                result-style   (if (:is-error tc)
                                 tool-err-style
                                 tool-dim-style)]
            (str "  " status-icon " " header
-                (when (or (seq lines) (seq warning-lines))
+                (when (or (seq result-lines) (seq warning-lines))
                   (str "\n"
                        (str/join
                         "\n"
@@ -1598,7 +1643,7 @@
                               (map #(str "    "
                                          (charm/render result-style %))
                                    wrapped)))
-                          lines)
+                          result-lines)
                          (mapcat
                           (fn [line]
                             (let [wrapped (wrap-tool-result-line line result-avail)]
@@ -1660,7 +1705,7 @@
             (when (= :streaming phase)
               (if has-progress?
                 (str (render-stream-text stream-text term-width)
-                     (render-tool-calls tool-calls tool-order spinner-char term-width tools-expanded?)
+                     (render-tool-calls tool-calls tool-order spinner-char term-width tools-expanded? ui-state-atom)
                      "\n")
                 (str "\n" (charm/render assist-style "ψ: ")
                      spinner-char " thinking…\n")))

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -431,7 +431,8 @@
    `opts` map:
      :cwd                  — working directory string (for /resume)
      :current-session-file — current session file path (highlighted in selector)
-     :resume-fn!           — (fn [session-path]) called when user selects a session
+     :resume-fn!           — (fn [session-path]) called when user selects a session;
+                              returns {:messages [...], :tool-calls {...}, :tool-order [...]}
      :dispatch-fn          — (fn [text]) → command result map or nil; central command dispatch
      :event-queue          — shared LinkedBlockingQueue for agent + extension events"
   ([model-name] (make-init model-name nil))
@@ -595,19 +596,24 @@
       (let [filtered (selector-filtered sel)
             chosen   (nth filtered (:selected sel) nil)]
         (if chosen
-          (let [path      (:path chosen)
-                resume-fn (:resume-fn! state)
-                ;; resume-fn! returns [{:role :user/:assistant :text "..."}...]
-                ;; or nil if it fails
-                restored  (when resume-fn (resume-fn path))
-                new-state (-> state
-                              (assoc :phase            :idle
-                                     :session-selector nil
-                                     :current-session-file path
-                                     :messages         (or restored [])
-                                     :stream-text      nil
-                                     :tool-calls       {}
-                                     :tool-order       []))]
+          (let [path         (:path chosen)
+                resume-fn    (:resume-fn! state)
+                ;; resume-fn! returns {:messages [...]
+                ;;                      :tool-calls {...}
+                ;;                      :tool-order [...]}.
+                ;; Fallback keeps older callback shape ([{:role ... :text ...} ...]).
+                restored     (when resume-fn (resume-fn path))
+                restored-msgs (if (map? restored) (:messages restored) restored)
+                restored-tool-calls (if (map? restored) (:tool-calls restored) nil)
+                restored-tool-order (if (map? restored) (:tool-order restored) nil)
+                new-state    (-> state
+                                 (assoc :phase            :idle
+                                        :session-selector nil
+                                        :current-session-file path
+                                        :messages         (or restored-msgs [])
+                                        :stream-text      nil
+                                        :tool-calls       (or restored-tool-calls {})
+                                        :tool-order       (or restored-tool-order [])))]
             [new-state nil])
           ;; Nothing selected — just close
           [(assoc state :phase :idle :session-selector nil) nil]))
@@ -1748,7 +1754,10 @@
                        :ui-state-atom       — extension UI state atom
                        :cwd                 — working directory for /resume filtering
                        :current-session-file — current session file path for highlight
-                       :resume-fn!          — (fn [session-path]) => [{:role :user/:assistant :text ...}]
+                       :resume-fn!          — (fn [session-path]) =>
+                                              {:messages [...]
+                                               :tool-calls {...}
+                                               :tool-order [...]}
                        :alt-screen          — true/false (default true)"
   ([model-name run-agent-fn!]
    (start! model-name run-agent-fn! {}))

--- a/components/tui/src/psi/tui/extension_ui.clj
+++ b/components/tui/src/psi/tui/extension_ui.clj
@@ -31,14 +31,16 @@
      :statuses       {ext-id StatusEntry ...}
      :notifications  [Notification ...]
      :tool-renderers {tool-name {:render-call-fn f :render-result-fn f :extension-path s}}
-     :message-renderers {custom-type {:render-fn f :extension-path s}}"
+     :message-renderers {custom-type {:render-fn f :extension-path s}}
+     :tools-expanded? boolean"
   []
   (atom {:dialog-queue      {:pending [] :active nil}
          :widgets           {}
          :statuses          {}
          :notifications     []
          :tool-renderers    {}
-         :message-renderers {}}))
+         :message-renderers {}
+         :tools-expanded?   false}))
 
 ;; ============================================================
 ;; Dialog data
@@ -357,6 +359,21 @@
   (when ui-state-atom
     (vec (vals (:message-renderers @ui-state-atom)))))
 
+(defn get-tools-expanded
+  "Return global tools-expanded flag.
+   Headless fallback: false."
+  [ui-state-atom]
+  (if ui-state-atom
+    (boolean (:tools-expanded? @ui-state-atom))
+    false))
+
+(defn set-tools-expanded!
+  "Set global tools-expanded flag.
+   No-op when ui-state-atom is nil (headless)."
+  [ui-state-atom expanded?]
+  (when ui-state-atom
+    (swap! ui-state-atom assoc :tools-expanded? (boolean expanded?))))
+
 ;; ============================================================
 ;; Clear all (for extension reload)
 ;; ============================================================
@@ -377,7 +394,8 @@
                :statuses          {}
                :notifications     []
                :tool-renderers    {}
-               :message-renderers {}})
+               :message-renderers {}
+               :tools-expanded?   false})
       ;; Deliver nil to all dialog promises
       (when active (deliver (:promise active) nil))
       (doseq [d pending]
@@ -401,7 +419,9 @@
      :clear-status (fn [])
      :notify      (fn [message level])
      :register-tool-renderer    (fn [tool-name render-call-fn render-result-fn])
-     :register-message-renderer (fn [custom-type render-fn])"
+     :register-message-renderer (fn [custom-type render-fn])
+     :get-tools-expanded (fn [] → boolean)
+     :set-tools-expanded (fn [expanded?])"
   [ui-state-atom ext-id]
   (when ui-state-atom
     {:confirm
@@ -443,7 +463,15 @@
 
      :register-message-renderer
      (fn [custom-type render-fn]
-       (register-message-renderer! ui-state-atom custom-type ext-id render-fn))}))
+       (register-message-renderer! ui-state-atom custom-type ext-id render-fn))
+
+     :get-tools-expanded
+     (fn []
+       (get-tools-expanded ui-state-atom))
+
+     :set-tools-expanded
+     (fn [expanded?]
+       (set-tools-expanded! ui-state-atom expanded?))}))
 
 ;; ============================================================
 ;; EQL snapshot (for resolvers — excludes fns and promises)

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -10,7 +10,8 @@
    [charm.input.keymap :as keymap]
    [charm.message :as msg]
    [psi.agent-session.persistence :as persist]
-   [psi.tui.app :as app])
+   [psi.tui.app :as app]
+   [psi.tui.extension-ui :as ext-ui])
   (:import
    [java.util.concurrent LinkedBlockingQueue]))
 
@@ -33,9 +34,11 @@
   ([] (init-state "test-model" {}))
   ([model-name] (init-state model-name {}))
   ([model-name opts]
-   (let [init-fn (app/make-init model-name nil nil
-                                (merge {:dispatch-fn default-dispatch-fn} opts))
-         [state _cmd] (init-fn)]
+   (let [ui-state-atom (:ui-state-atom opts)
+         opts'         (dissoc opts :ui-state-atom)
+         init-fn       (app/make-init model-name nil ui-state-atom
+                                      (merge {:dispatch-fn default-dispatch-fn} opts'))
+         [state _cmd]  (init-fn)]
      state)))
 
 (defn- type-text
@@ -435,6 +438,27 @@ clojure-lsp"}]})
       (is (true? (:tools-expanded? s1)))
       (is (false? (:tools-expanded? s2))))))
 
+(deftest ctrl-o-updates-extension-tools-expanded-state-test
+  (testing "ctrl+o updates extension ui tools-expanded state"
+    (let [ui        (ext-ui/create-ui-state)
+          update-fn (app/make-update (stub-agent-fn ""))
+          state     (init-state "test-model" {:ui-state-atom ui})
+          [s1 _]    (update-fn state (msg/key-press "o" :ctrl true))]
+      (is (true? (:tools-expanded? s1)))
+      (is (true? (ext-ui/get-tools-expanded ui)))
+      (let [[s2 _] (update-fn s1 (msg/key-press "o" :ctrl true))]
+        (is (false? (:tools-expanded? s2)))
+        (is (false? (ext-ui/get-tools-expanded ui)))))))
+
+(deftest app-syncs-tools-expanded-from-extension-ui-state-test
+  (testing "update loop syncs tools-expanded from extension ui state"
+    (let [ui       (ext-ui/create-ui-state)
+          update-fn (app/make-update (stub-agent-fn ""))
+          state    (init-state "test-model" {:ui-state-atom ui})]
+      (ext-ui/set-tools-expanded! ui true)
+      (let [[s1 _] (update-fn state {:type :agent-poll})]
+        (is (true? (:tools-expanded? s1)))))))
+
 (deftest tool-start-inherits-tools-expanded-test
   (testing "new tool rows inherit current tools-expanded setting"
     (let [update-fn (app/make-update (stub-agent-fn ""))
@@ -554,6 +578,49 @@ clojure-lsp"}]})
           out   (app/view state)]
       (is (str/includes? out "[image image/png]"))
       (is (str/includes? out "[unsupported content block: custom]")))))
+
+(deftest extension-tool-renderers-override-builtins-test
+  (testing "registered extension renderer output is used for call + result"
+    (let [ui (ext-ui/create-ui-state)]
+      (ext-ui/register-tool-renderer! ui
+                                      "read"
+                                      "ext-a"
+                                      (fn [_args] "EXT call render")
+                                      (fn [_tc _opts] "EXT result render"))
+      (let [state (-> (init-state "test-model" {:ui-state-atom ui})
+                      (assoc :phase :streaming
+                             :stream-text ""
+                             :tool-order ["t1"]
+                             :tool-calls {"t1" {:name "read"
+                                                :args "{\"path\":\"foo.txt\"}"
+                                                :status :success
+                                                :result "ignored builtin"
+                                                :is-error false}}))
+            out   (app/view state)]
+        (is (str/includes? out "EXT call render"))
+        (is (str/includes? out "EXT result render"))
+        (is (not (str/includes? out "foo.txt")))))))
+
+(deftest extension-tool-renderer-exception-falls-back-to-builtin-test
+  (testing "renderer exceptions fall back to built-in tool rendering"
+    (let [ui (ext-ui/create-ui-state)]
+      (ext-ui/register-tool-renderer! ui
+                                      "read"
+                                      "ext-a"
+                                      (fn [_args] (throw (ex-info "boom-call" {})))
+                                      (fn [_tc _opts] (throw (ex-info "boom-result" {}))))
+      (let [state (-> (init-state "test-model" {:ui-state-atom ui})
+                      (assoc :phase :streaming
+                             :stream-text ""
+                             :tool-order ["t1"]
+                             :tool-calls {"t1" {:name "read"
+                                                :args "{\"path\":\"foo.txt\"}"
+                                                :status :success
+                                                :result "line-1"
+                                                :is-error false}}))
+            out   (app/view state)]
+        (is (str/includes? out "foo.txt"))
+        (is (str/includes? out "line-1"))))))
 
 (deftest view-shows-error-test
   (testing "view shows error message"

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -425,6 +425,136 @@ clojure-lsp"}]})
       (is (str/includes? out "(waiting for response…)"))
       (is (not (str/includes? out "⠋ waiting for response…"))))))
 
+(deftest ctrl-o-toggles-tools-expanded-test
+  (testing "ctrl+o toggles global tools-expanded state"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (init-state)
+          [s1 _]    (update-fn state (msg/key-press "o" :ctrl true))
+          [s2 _]    (update-fn s1 (msg/key-press "o" :ctrl true))]
+      (is (false? (:tools-expanded? state)))
+      (is (true? (:tools-expanded? s1)))
+      (is (false? (:tools-expanded? s2))))))
+
+(deftest tool-start-inherits-tools-expanded-test
+  (testing "new tool rows inherit current tools-expanded setting"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state) :tools-expanded? true)
+          [s1 _]    (update-fn state {:type :agent-event
+                                      :event-kind :tool-start
+                                      :tool-id "t1"
+                                      :tool-name "bash"})]
+      (is (true? (get-in s1 [:tool-calls "t1" :expanded?]))))))
+
+(deftest completed-tool-rows-are-retained-after-result-test
+  (testing "tool rows remain after final agent result"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (-> (init-state)
+                        (assoc :phase :streaming
+                               :tool-order ["t1"]
+                               :tool-calls {"t1" {:name "bash"
+                                                  :args "{\"command\":\"echo hi\"}"
+                                                  :status :success
+                                                  :result "ok"
+                                                  :is-error false}}))
+          result    {:role "assistant" :content [{:type :text :text "done"}]}
+          [s1 _]    (update-fn state {:type :agent-result :result result})]
+      (is (= :idle (:phase s1)))
+      (is (= ["t1"] (:tool-order s1)))
+      (is (= "ok" (get-in s1 [:tool-calls "t1" :result]))))))
+
+(deftest collapsed-tool-render-truncates-and-expanded-renders-full-test
+  (testing "tool rendering honors collapsed vs expanded modes"
+    (let [base-state (-> (init-state)
+                         (assoc :phase :streaming
+                                :stream-text ""
+                                :tool-order ["t1"]
+                                :tool-calls {"t1" {:name "read"
+                                                   :args "{\"path\":\"foo.txt\"}"
+                                                   :status :success
+                                                   :result (str/join "\n" (map str (range 1 13)))
+                                                   :is-error false
+                                                   :expanded? false}}))
+          collapsed (app/view base-state)
+          expanded  (app/view (assoc base-state :tools-expanded? true))]
+      (is (str/includes? collapsed "… (2 more lines, ctrl+o to expand)"))
+      (is (not (str/includes? expanded "ctrl+o to expand")))
+      (is (str/includes? expanded "12")))))
+
+(deftest bash-collapsed-renders-tail-preview-test
+  (testing "bash collapsed mode shows tail with earlier-lines hint"
+    (let [state (-> (init-state)
+                    (assoc :phase :streaming
+                           :stream-text ""
+                           :tool-order ["t1"]
+                           :tool-calls {"t1" {:name "bash"
+                                              :args "{\"command\":\"echo hi\"}"
+                                              :status :success
+                                              :result "1\n2\n3\n4\n5\n6\n7"
+                                              :is-error false}}))
+          out   (app/view state)]
+      (is (str/includes? out "7"))
+      (is (nil? (re-find #"(?m)^\s+1$" out)))
+      (is (str/includes? out "earlier lines hidden, ctrl+o to expand")))))
+
+(deftest tool-details-warnings-are-rendered-test
+  (testing "tool details metadata appears in warning lines"
+    (let [state (-> (init-state)
+                    (assoc :phase :streaming
+                           :stream-text ""
+                           :tool-order ["t1"]
+                           :tool-calls {"t1" {:name "grep"
+                                              :args "{\"pattern\":\"foo\"}"
+                                              :status :success
+                                              :result "a.clj:1:foo"
+                                              :details {:truncation {:truncated true :truncated-by :bytes}
+                                                        :full-output-path "/tmp/full.log"
+                                                        :match-limit-reached 100
+                                                        :lines-truncated true}
+                                              :is-error false}}))
+          out   (app/view state)]
+      (is (str/includes? out "Truncated output"))
+      (is (str/includes? out "Full output: /tmp/full.log"))
+      (is (str/includes? out "Match limit reached: 100"))
+      (is (str/includes? out "Long lines truncated")))))
+
+(deftest tool-result-event-preserves-content-and-details-test
+  (testing "tool-result event stores structured content/details for rendering"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          base      (-> (init-state)
+                        (assoc :phase :streaming)
+                        (assoc :tool-order ["t1"]
+                               :tool-calls {"t1" {:name "bash" :status :running}}))
+          event     {:type :agent-event
+                     :event-kind :tool-result
+                     :tool-id "t1"
+                     :content [{:type :text :text "ok"}
+                               {:type :image :mime-type "image/png" :data "abc"}]
+                     :details {:full-output-path "/tmp/all.log"}
+                     :is-error false}
+          [s1 _]    (update-fn base event)]
+      (is (= "ok" (get-in s1 [:tool-calls "t1" :result])))
+      (is (= [{:type :text :text "ok"}
+              {:type :image :mime-type "image/png" :data "abc"}]
+             (get-in s1 [:tool-calls "t1" :content])))
+      (is (= {:full-output-path "/tmp/all.log"}
+             (get-in s1 [:tool-calls "t1" :details]))))))
+
+(deftest non-text-content-fallback-is-safe-test
+  (testing "non-text/unknown content blocks render safe fallback"
+    (let [state (-> (init-state)
+                    (assoc :phase :streaming
+                           :stream-text ""
+                           :tool-order ["t1"]
+                           :tool-calls {"t1" {:name "write"
+                                              :args "{\"path\":\"/tmp/x\"}"
+                                              :status :success
+                                              :content [{:type :image :mime-type "image/png" :data "abc"}
+                                                        {:type :custom :payload "x"}]
+                                              :is-error false}}))
+          out   (app/view state)]
+      (is (str/includes? out "[image image/png]"))
+      (is (str/includes? out "[unsupported content block: custom]")))))
+
 (deftest view-shows-error-test
   (testing "view shows error message"
     (let [state (assoc (init-state) :error "something broke")]

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -186,8 +186,15 @@
 (deftest resume-selection-restores-messages-test
   (testing "selecting a session calls resume-fn! and loads returned messages"
     (let [selected-path (atom nil)
-          restored      [{:role :user :text "restored user"}
-                         {:role :assistant :text "restored assistant"}]]
+          restored      {:messages [{:role :user :text "restored user"}
+                                    {:role :assistant :text "restored assistant"}]
+                         :tool-calls {"t1" {:name "read"
+                                             :args "{\"path\":\"foo.txt\"}"
+                                             :status :success
+                                             :result "ok"
+                                             :is-error false
+                                             :expanded? false}}
+                         :tool-order ["t1"]}]
       (with-redefs [persist/session-dir-for (fn [_cwd] "/tmp/psi-test")
                     persist/list-sessions
                     (fn [_dir]
@@ -207,7 +214,9 @@
               [s1 _]    (update-fn typed (msg/key-press :enter))
               [s2 _]    (update-fn s1 (msg/key-press :enter))]
           (is (= :idle (:phase s2)))
-          (is (= restored (:messages s2)))
+          (is (= (:messages restored) (:messages s2)))
+          (is (= (:tool-order restored) (:tool-order s2)))
+          (is (= "ok" (get-in s2 [:tool-calls "t1" :result])))
           (is (= "/tmp/psi-test/a.ndedn" @selected-path))
           (is (= "/tmp/psi-test/a.ndedn" (:current-session-file s2))))))))
 

--- a/components/tui/test/psi/tui/extension_ui_test.clj
+++ b/components/tui/test/psi/tui/extension_ui_test.clj
@@ -14,7 +14,8 @@
       (is (= {} (:statuses s)))
       (is (= [] (:notifications s)))
       (is (= {} (:tool-renderers s)))
-      (is (= {} (:message-renderers s))))))
+      (is (= {} (:message-renderers s)))
+      (is (false? (:tools-expanded? s))))))
 
 ;; ── Widgets ─────────────────────────────────────────────────
 
@@ -243,6 +244,25 @@
     (let [ui (ui/create-ui-state)]
       (is (nil? (ui/get-tool-renderer ui "nope"))))))
 
+(deftest tools-expanded-api-test
+  (testing "headless access uses safe defaults"
+    (is (false? (ui/get-tools-expanded nil)))
+    (is (nil? (ui/set-tools-expanded! nil true))))
+
+  (testing "get/set tools-expanded toggles state"
+    (let [ui (ui/create-ui-state)]
+      (is (false? (ui/get-tools-expanded ui)))
+      (ui/set-tools-expanded! ui true)
+      (is (true? (ui/get-tools-expanded ui)))
+      (ui/set-tools-expanded! ui false)
+      (is (false? (ui/get-tools-expanded ui)))))
+
+  (testing "clear-all resets tools-expanded to false"
+    (let [ui (ui/create-ui-state)]
+      (ui/set-tools-expanded! ui true)
+      (ui/clear-all! ui)
+      (is (false? (ui/get-tools-expanded ui))))))
+
 (deftest message-renderer-test
   (testing "register and retrieve message renderer"
     (let [ui    (ui/create-ui-state)
@@ -310,7 +330,9 @@
       (is (fn? (:clear-status ctx)))
       (is (fn? (:notify ctx)))
       (is (fn? (:register-tool-renderer ctx)))
-      (is (fn? (:register-message-renderer ctx)))))
+      (is (fn? (:register-message-renderer ctx)))
+      (is (fn? (:get-tools-expanded ctx)))
+      (is (fn? (:set-tools-expanded ctx)))))
 
   (testing "context methods delegate to ui-state"
     (let [ui  (ui/create-ui-state)
@@ -333,7 +355,14 @@
       (is (some? (ui/get-tool-renderer ui "my-tool")))
 
       ((:register-message-renderer ctx) "my-type" identity)
-      (is (some? (ui/get-message-renderer ui "my-type"))))))
+      (is (some? (ui/get-message-renderer ui "my-type")))
+
+      ;; Tools-expanded API
+      (is (false? ((:get-tools-expanded ctx))))
+      ((:set-tools-expanded ctx) true)
+      (is (true? ((:get-tools-expanded ctx))))
+      ((:set-tools-expanded ctx) false)
+      (is (false? ((:get-tools-expanded ctx)))))))
 
 ;; ── Snapshot ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Implement tool-output display parity with the spec in Psi TUI (story #36).

## Story
- **Title:** Implement tool-output display parity with spec in Psi TUI
- **Description:** Close the tool-output display gap between spec and implementation, including expansion controls, renderer parity, details/warnings, rich content preservation, and resume/rehydration parity.

## Design Notes
- Added persistent tool-row state and global Ctrl+O expansion toggle behavior.
- Implemented built-in tool renderer parity with tool-specific previews and details/warnings.
- Added extension renderer overrides with exception-safe fallback and tools-expanded extension UI API.
- Rehydrated tool rows on resume by correlating tool-call and toolResult history.

## Commits in this PR
- 45fd4bc ⚒ Rehydrate toolResult rows on /resume in TUI (task #44)
- c8172af ⚒ Task 43: add extension tool render overrides + tools-expanded UI API
- 02b224d ⚒ Δ Task 42: built-in tool renderer parity in TUI

## Additional Context
- Story child tasks #40–#44 are closed.
- Story is code-reviewed and currently awaiting PR linkage.
