### PR TITLE
feat: Allow concurrent mcp-tasks-run workflows

### DIFF
--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -202,8 +202,22 @@
   (let [sid (str id)]
     (some #(when (= sid (:psi.extension.workflow/id %)) %) (mcp-run-workflows))))
 
-(defn- active-running-workflow []
-  (first (filter #(= :running (phase-of %)) (mcp-run-workflows))))
+(defn- workflow-task-id
+  [wf]
+  (let [data (:psi.extension.workflow/data wf)]
+    (or (parse-int (:run/task-id data))
+        (parse-int (get-in wf [:psi.extension.workflow/input :task-id]))
+        (parse-int (get-in wf [:psi.extension.workflow/meta :task-id])))))
+
+(defn- active-workflow-for-task
+  [task-id]
+  (let [task-id* (parse-int task-id)]
+    (some (fn [wf]
+            (let [phase (phase-of wf)]
+              (when (and (= task-id* (workflow-task-id wf))
+                         (#{:running :paused} phase))
+                wf)))
+          (mcp-run-workflows))))
 
 (defn- run-id->n [run-id]
   (some->> (re-find #"run-(\\d+)$" (str run-id)) second parse-int))
@@ -1012,9 +1026,10 @@
           current-ids (into #{} (map #(str "mcp-run-" (:psi.extension.workflow/id %)) wfs))
           old-ids     (:widget-ids @state)
           removed     (set/difference old-ids current-ids)
-          running     (count (filter :psi.extension.workflow/running? wfs))
-          paused      (count (filter #(= :paused (phase-of %)) wfs))
-          errors      (count (filter :psi.extension.workflow/error? wfs))]
+          phases      (map phase-of wfs)
+          running     (count (filter #{:running} phases))
+          paused      (count (filter #{:paused} phases))
+          errors      (count (filter #{:error} phases))]
       (doseq [wid removed]
         ((:clear-widget ui) wid))
       (doseq [wf wfs]
@@ -1648,24 +1663,27 @@
 
 (defn- start-run!
   [task-id]
-  (if (active-running-workflow)
-    (println "A run is already in progress. Pause/cancel it first.")
-    (let [run-id      (next-run-id!)
-          project-dir (System/getProperty "user.dir")
-          created     (mutate! 'psi.extension.workflow/create
-                               {:type  run-workflow-type
-                                :id    run-id
-                                :meta  {:task-id task-id}
-                                :input {:run-id run-id
-                                        :task-id task-id
-                                        :project-dir project-dir
-                                        :max-steps max-steps-default}})]
-      (if (:psi.extension.workflow/created? created)
-        (do
-          (println (str "Started mcp-tasks run " run-id " for task #" task-id "."))
-          (refresh-widgets-later!))
-        (println (str "Failed to start run: "
-                      (or (:psi.extension.workflow/error created) "unknown error")))))))
+  (let [task-id* (parse-int task-id)]
+    (if-let [existing (active-workflow-for-task task-id*)]
+      (println (str "Task #" task-id* " already has active run "
+                    (:psi.extension.workflow/id existing)
+                    " (" (name (phase-of existing)) ")."))
+      (let [run-id      (next-run-id!)
+            project-dir (System/getProperty "user.dir")
+            created     (mutate! 'psi.extension.workflow/create
+                                 {:type  run-workflow-type
+                                  :id    run-id
+                                  :meta  {:task-id task-id*}
+                                  :input {:run-id run-id
+                                          :task-id task-id*
+                                          :project-dir project-dir
+                                          :max-steps max-steps-default}})]
+        (if (:psi.extension.workflow/created? created)
+          (do
+            (println (str "Started mcp-tasks run " run-id " for task #" task-id* "."))
+            (refresh-widgets-later!))
+          (println (str "Failed to start run: "
+                        (or (:psi.extension.workflow/error created) "unknown error"))))))))
 
 (defn- list-runs!
   []

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -446,6 +446,91 @@
             (is (re-find #"already running" out)
                 "running run should not be resumable")))))))
 
+(deftest run-controls-remain-run-id-scoped-with-concurrency-test
+  (testing "pause updates only targeted run control"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})]
+      (sut/init api)
+      (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+        (with-out-str (handler "42"))
+        (with-out-str (handler "99"))
+        (#'sut/ensure-control! "run-1")
+        (#'sut/ensure-control! "run-2")
+        (swap! state update-in [:workflows "run-1"]
+               assoc
+               :psi.extension.workflow/running? true
+               :psi.extension.workflow/phase :running)
+        (swap! state update-in [:workflows "run-2"]
+               assoc
+               :psi.extension.workflow/running? true
+               :psi.extension.workflow/phase :running)
+        (with-out-str (handler "pause run-1"))
+        (is (= true (:pause? @(#'sut/control-for "run-1"))))
+        (is (= false (:pause? @(#'sut/control-for "run-2")))))))
+
+  (testing "cancel updates only targeted running run control"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})]
+      (sut/init api)
+      (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+        (with-out-str (handler "42"))
+        (with-out-str (handler "99"))
+        (#'sut/ensure-control! "run-1")
+        (#'sut/ensure-control! "run-2")
+        (swap! state update-in [:workflows "run-1"]
+               assoc
+               :psi.extension.workflow/running? true
+               :psi.extension.workflow/phase :running)
+        (swap! state update-in [:workflows "run-2"]
+               assoc
+               :psi.extension.workflow/running? true
+               :psi.extension.workflow/phase :running)
+        (with-out-str (handler "cancel run-1"))
+        (is (= true (:cancel? @(#'sut/control-for "run-1"))))
+        (is (= false (:cancel? @(#'sut/control-for "run-2")))))))
+
+  (testing "resume and retry send events only for targeted run-id"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})
+          send-events (fn []
+                        (->> (:mutations @state)
+                             (filter #(= 'psi.extension.workflow/send-event (:op %)))
+                             vec))]
+      (sut/init api)
+      (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+        (with-out-str (handler "42"))
+        (with-out-str (handler "99"))
+
+        (swap! state update-in [:workflows "run-1"]
+               assoc
+               :psi.extension.workflow/running? false
+               :psi.extension.workflow/phase :paused
+               :psi.extension.workflow/data {:run/pause-reason :wait-user-confirmation})
+        (swap! state update-in [:workflows "run-2"]
+               assoc
+               :psi.extension.workflow/running? false
+               :psi.extension.workflow/phase :paused
+               :psi.extension.workflow/data {:run/pause-reason :wait-user-confirmation})
+        (let [before (count (send-events))]
+          (with-out-str (handler "resume run-1 yes"))
+          (let [events (drop before (send-events))]
+            (is (= 1 (count events)))
+            (is (= "run-1" (get-in (first events) [:params :id])))))
+
+        (swap! state update-in [:workflows "run-1"]
+               assoc
+               :psi.extension.workflow/running? false
+               :psi.extension.workflow/phase :error)
+        (swap! state update-in [:workflows "run-2"]
+               assoc
+               :psi.extension.workflow/running? false
+               :psi.extension.workflow/phase :error)
+        (let [before (count (send-events))]
+          (with-out-str (handler "retry run-1"))
+          (let [events (drop before (send-events))]
+            (is (= 1 (count events)))
+            (is (= "run-1" (get-in (first events) [:params :id])))))))))
+
 (deftest workflow-user-confirmation-requires-answer-test
   (testing "run-loop-job remains paused when confirmation answer is missing"
     (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -72,7 +72,41 @@
           (is (contains? (:workflows @state) "run-1")))
 
         (let [out-list (with-out-str (handler "list"))]
-          (is (re-find #"run-1" out-list)))))))
+          (is (re-find #"run-1" out-list))))))
+
+  (testing "widget status aggregates mixed phases across multiple runs"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})]
+      (sut/init api)
+      (let [wf-running {:psi.extension.workflow/id "run-1"
+                        :psi.extension.workflow/phase :running
+                        :psi.extension.workflow/running? true
+                        :psi.extension.workflow/error? false
+                        :psi.extension.workflow/data {:run/task-id 42
+                                                      :run/entity-type :task
+                                                      :run/current-state :refined
+                                                      :run/last-step "execute-task"}}
+            wf-paused {:psi.extension.workflow/id "run-2"
+                       :psi.extension.workflow/phase :paused
+                       :psi.extension.workflow/running? false
+                       :psi.extension.workflow/error? false
+                       :psi.extension.workflow/data {:run/task-id 99
+                                                     :run/entity-type :story
+                                                     :run/current-state :wait-user-confirmation
+                                                     :run/last-step "execute-story-child"
+                                                     :run/pause-reason :wait-user-confirmation}}
+            wf-error {:psi.extension.workflow/id "run-3"
+                      :psi.extension.workflow/phase :error
+                      :psi.extension.workflow/running? false
+                      :psi.extension.workflow/error? true
+                      :psi.extension.workflow/data {:run/task-id 100
+                                                    :run/entity-type :task
+                                                    :run/current-state :derive-state
+                                                    :run/last-step "execute-task"}}]
+        (with-redefs [sut/mcp-run-workflows (fn [] [wf-running wf-paused wf-error])]
+          (#'sut/refresh-widgets!))
+        (is (= "mcp-tasks-run: 3 run(s) · 1 running · 1 paused · 1 error"
+               (last (:status-lines @state))))))))
 
 (deftest workflow-native-step-progression-test
   (testing "run-loop-job advances a single orchestration unit per invocation"
@@ -338,25 +372,50 @@
           (is (= :wait-user-confirmation (:pause-reason res)))
           (is (= "Continue?" (get-in res [:user-confirmation :question]))))))))
 
-(deftest active-running-excludes-paused-test
-  ;; active-running-workflow only gates start-run!; resume/retry check own phase.
-  (testing "active-running-workflow"
-    (testing "does not match a paused workflow"
-      (let [{:keys [api state]} (nullable/create-nullable-extension-api
-                                 {:path "/test/mcp_tasks_run.clj"})]
-        (sut/init api)
-        (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
-          ;; Start a run, then mark it paused (running? true, phase :paused)
-          (with-out-str (handler "42"))
-          (swap! state update-in [:workflows "run-1"]
-                 assoc
-                 :psi.extension.workflow/running? true
-                 :psi.extension.workflow/phase :paused)
-          ;; Starting a second run should succeed, not be blocked
-          (let [out (with-out-str (handler "99"))]
-            (is (re-find #"Started mcp-tasks run run-2" out)
-                "paused run should not block starting a new run"))))))
+(deftest start-run-admission-policy-test
+  (testing "allows concurrent runs for distinct task IDs"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})]
+      (sut/init api)
+      (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+        (let [out-1 (with-out-str (handler "42"))
+              out-2 (with-out-str (handler "99"))]
+          (is (re-find #"Started mcp-tasks run run-1" out-1))
+          (is (re-find #"Started mcp-tasks run run-2" out-2))
+          (is (contains? (:workflows @state) "run-1"))
+          (is (contains? (:workflows @state) "run-2"))))))
 
+  (testing "rejects duplicate active run for same task when existing run is running"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})]
+      (sut/init api)
+      (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+        (with-out-str (handler "42"))
+        (swap! state update-in [:workflows "run-1"]
+               assoc
+               :psi.extension.workflow/running? true
+               :psi.extension.workflow/phase :running)
+        (let [out (with-out-str (handler "42"))]
+          (is (re-find #"Task #42 already has active run run-1 \(running\)\." out))
+          (is (= #{"run-1"}
+                 (set (keys (:workflows @state)))))))))
+
+  (testing "rejects duplicate active run for same task when existing run is paused"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/mcp_tasks_run.clj"})]
+      (sut/init api)
+      (let [handler (get-in @state [:commands "mcp-tasks-run" :handler])]
+        (with-out-str (handler "42"))
+        (swap! state update-in [:workflows "run-1"]
+               assoc
+               :psi.extension.workflow/running? false
+               :psi.extension.workflow/phase :paused)
+        (let [out (with-out-str (handler "42"))]
+          (is (re-find #"Task #42 already has active run run-1 \(paused\)\." out))
+          (is (= #{"run-1"}
+                 (set (keys (:workflows @state))))))))))
+
+(deftest resume-run-phase-guard-test
   (testing "resume checks only its own run phase"
     (testing "allows resuming a paused run"
       (let [{:keys [api state]} (nullable/create-nullable-extension-api
@@ -617,7 +676,29 @@
           (is (re-find #"A\) fast path" output)
               "should print second question line")
           (is (re-find #"B\) safe path" output)
-              "should print third question line"))))))
+              "should print third question line")))))
+
+  (testing "list-runs! prints multiple runs with task IDs and phases"
+    (let [wf-running {:psi.extension.workflow/id "run-1"
+                      :psi.extension.workflow/phase :running
+                      :psi.extension.workflow/running? true
+                      :psi.extension.workflow/data {:run/task-id 42
+                                                    :run/entity-type :task
+                                                    :run/current-state :refined
+                                                    :run/last-step "execute-task"}}
+          wf-paused {:psi.extension.workflow/id "run-2"
+                     :psi.extension.workflow/phase :paused
+                     :psi.extension.workflow/running? false
+                     :psi.extension.workflow/data {:run/task-id 99
+                                                   :run/entity-type :story
+                                                   :run/current-state :wait-user-confirmation
+                                                   :run/last-step "execute-story-child"
+                                                   :run/pause-reason :wait-user-confirmation}}]
+      (with-redefs [sut/mcp-run-workflows (fn [] [wf-running wf-paused])
+                    sut/elapsed-seconds (fn [_] 10)]
+        (let [output (with-out-str (#'sut/list-runs!))]
+          (is (re-find #"run-1 \[RUNNING\] task #42" output))
+          (is (re-find #"run-2 \[PAUSED\] story #99" output)))))))
 
 (deftest resolve-category-for-step-non-matching-step-test
   (testing "resolve-category-for-step returns nil for non-matching step names"


### PR DESCRIPTION
## Summary
Allow `/mcp-tasks-run` workflows to run concurrently for distinct task/story IDs while preventing duplicate active runs for the same task ID.

## Story
- #45 — Allow concurrent mcp-tasks-run workflows

## What changed
- Updated run admission policy in `start-run!`:
  - removed single-active-run global gate
  - added duplicate-task guard for active `:running`/`:paused` runs
  - preserved run-id scoped control behavior
- Updated concurrent run visibility:
  - widget status aggregates running/paused/error across multiple runs
  - list output includes run-id, phase, entity type, and task-id for multiple active runs
- Added regression tests for:
  - concurrent starts for distinct task IDs
  - duplicate-task start rejection for running/paused phases
  - run-id scoped pause/resume/cancel/retry correctness under concurrency

## Verification
- `extensions.mcp-tasks-run-test` passes with concurrent admission + visibility + control coverage.

## Commits
- a80aca0 ⚒ Add run-id scoped control regression coverage for concurrent mcp-tasks-run workflows
- 17cad70 ⚒ Task 47: fix concurrent run status aggregation and list coverage
