### PR TITLE
feat: Implement TUI prompt-input handling parity with distilled specs

### DIFF
--- a/components/agent-session/src/psi/agent_session/core.clj
+++ b/components/agent-session/src/psi/agent_session/core.clj
@@ -53,6 +53,7 @@
    use `register-resolvers-in!` with a QueryContext from psi.query.core."
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [com.wsscode.pathom3.connect.operation :as pco]
    [psi.agent-core.core :as agent]
    [psi.agent-session.compaction :as compaction]
@@ -257,9 +258,9 @@
                             :sc-session-id         sc-session-id
                             :session-data-atom     session-data-atom
                             :tool-output-stats-atom (atom {:calls []
-                                                            :aggregates {:total-context-bytes 0
-                                                                         :by-tool {}
-                                                                         :limit-hits-by-tool {}}})
+                                                           :aggregates {:total-context-bytes 0
+                                                                        :by-tool {}
+                                                                        :limit-hits-by-tool {}}})
                             :agent-ctx             agent-ctx
                             :extension-registry    ext-reg
                             :workflow-registry     wf-reg
@@ -522,6 +523,32 @@
   "Abort the current agent run."
   [ctx]
   (sc/send-event! (:sc-env ctx) (:sc-session-id ctx) :session/abort))
+
+(defn consume-queued-input-text-in!
+  "Return queued steering/follow-up text (joined by newlines) and clear queues.
+   This is used by TUI interrupt flows to restore deferred input into the editor."
+  [ctx]
+  (let [agent-data       (agent/get-data-in (:agent-ctx ctx))
+        queued-agent-msgs (concat (:steering-queue agent-data)
+                                  (:follow-up-queue agent-data))
+        queued-agent-texts (keep (fn [msg]
+                                   (some (fn [block]
+                                           (when (= :text (:type block))
+                                             (:text block)))
+                                         (:content msg)))
+                                 queued-agent-msgs)
+        sd               (get-session-data-in ctx)
+        queued-session-texts (concat (:steering-messages sd)
+                                     (:follow-up-messages sd))
+        all-texts        (->> (concat queued-agent-texts queued-session-texts)
+                              (keep #(when (string? %) (str/trim %)))
+                              (remove str/blank?)
+                              distinct)
+        merged           (str/join "\n" all-texts)]
+    (swap-session! ctx assoc :steering-messages [] :follow-up-messages [])
+    (agent/clear-steering-queue-in! (:agent-ctx ctx))
+    (agent/clear-follow-up-queue-in! (:agent-ctx ctx))
+    merged))
 
 ;; ============================================================
 ;; Model and thinking level

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -17,7 +17,8 @@
      4. Optionally starts an nREPL server for live introspection
      5. Drops into a REPL-style prompt loop — type a message, get a response
         OR (with --tui) renders an interactive TUI session
-     6. /quit or EOF exits (plain mode); Escape or Ctrl+C exits (TUI mode)
+     6. /quit or EOF exits (plain mode); TUI uses Escape interrupt/cancel,
+        Ctrl+C clear-then-quit, Ctrl+D exit-when-empty
 
    Environment variables:
      ANTHROPIC_API_KEY   — required for Anthropic models
@@ -505,7 +506,7 @@
 
 (defn run-tui-session
   "Create a session and run it as a full-screen TUI via charm.clj.
-  Blocks until the user exits (Escape or Ctrl+C while idle)."
+  Blocks until the user exits (Ctrl+C second press or Ctrl+D on empty input)."
   [model-key]
   (let [ai-model  (resolve-model model-key)
         ai-ctx    nil
@@ -596,6 +597,14 @@
                                       :login-state   (:login-state result)})))
                           result)))
 
+        ;; Called by TUI Escape during active work.
+        ;; Aborts current run and returns queued steering/follow-up text
+        ;; so input can be restored in the editor.
+        on-interrupt-fn! (fn [_state]
+                           (session/abort-in! ctx)
+                           {:queued-text (session/consume-queued-input-text-in! ctx)
+                            :message "Interrupted active work."})
+
         ;; run-agent-fn! — called by the TUI for non-command input.
         ;; Handles pending-login step 2 and agent execution.
         run-agent-fn! (fn [text ^java.util.concurrent.LinkedBlockingQueue queue]
@@ -640,6 +649,9 @@
                     {:query-fn             (fn [q] (session/query-in ctx q))
                      :ui-state-atom        (:ui-state-atom ctx)
                      :dispatch-fn          dispatch-fn
+                     :on-interrupt-fn!     on-interrupt-fn!
+                     :double-press-window-ms 500
+                     :double-escape-action :none
                      :cwd                  cwd
                      :current-session-file (:session-file (session/get-session-data-in ctx))
                      :resume-fn!           resume-fn!

--- a/components/agent-session/test/psi/agent_session/main_test.clj
+++ b/components/agent-session/test/psi/agent_session/main_test.clj
@@ -105,7 +105,8 @@
                                      :ok)]
         (is (= :ok (main/run-tui-session :ignored)))
         (is (string? (:current-session-file @captured)))
-        (is (fn? (:dispatch-fn @captured))))
+        (is (fn? (:dispatch-fn @captured)))
+        (is (fn? (:on-interrupt-fn! @captured))))
       (finally
         (reset! main/session-state orig-state)))))
 

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -227,6 +227,33 @@
       (assoc :input input)
       clear-history-browse))
 
+(defn- now-ms [] (System/currentTimeMillis))
+
+(defn- double-press-window-ms
+  [state]
+  (or (:double-press-window-ms state) 500))
+
+(defn- within-double-press-window?
+  [last-ms now-ms window-ms]
+  (and (some? last-ms)
+       (<= (- now-ms last-ms) window-ms)))
+
+(defn- append-assistant-status
+  [state text]
+  (if (str/blank? text)
+    state
+    (update state :messages conj {:role :assistant :text text})))
+
+(defn- merge-queued-and-draft
+  [queued-text draft-text]
+  (let [queued (str/trim (or queued-text ""))
+        draft  (str/trim (or draft-text ""))]
+    (cond
+      (and (str/blank? queued) (str/blank? draft)) ""
+      (str/blank? queued) draft
+      (str/blank? draft) queued
+      :else (str queued "\n" draft))))
+
 (defn- history-entries
   [state]
   (vec (get-in state [:prompt-input-state :history :entries] [])))
@@ -318,8 +345,8 @@
         token-start (or (some->> (keep-indexed (fn [i ch]
                                                  (when (whitespace-char? ch) i))
                                                before)
-                                  last
-                                  inc)
+                                 last
+                                 inc)
                         0)
         token       (subs before token-start)
         context     (cond
@@ -770,11 +797,12 @@
 (defn poll-cmd
   "Command that polls the shared event queue with a short timeout.
    Returns :agent-result, :agent-error, :agent-event, :external-message,
-   or :agent-poll.
+   :agent-aborted, or :agent-poll.
 
    Queue payloads accepted:
    - {:kind :done  :result ...}
    - {:kind :error :message ...}
+   - {:kind :aborted :message ... :queued-text ...}
    - {:type :agent-event ...}       ; progress events
    - {:type :external-message ...}  ; async extension transcript message
    "
@@ -788,6 +816,11 @@
 
          (= :error (:kind event))
          {:type :agent-error :error (:message event)}
+
+         (= :aborted (:kind event))
+         {:type :agent-aborted
+          :message (:message event)
+          :queued-text (:queued-text event)}
 
          (= :agent-event (:type event))
          event
@@ -820,6 +853,9 @@
      :resume-fn!           — (fn [session-path]) called when user selects a session;
                               returns {:messages [...], :tool-calls {...}, :tool-order [...]}
      :dispatch-fn          — (fn [text]) → command result map or nil; central command dispatch
+     :on-interrupt-fn!     — (fn [state]) -> {:queued-text str? :message str?} | nil
+     :double-press-window-ms — ctrl+c / escape timing window (default 500)
+     :double-escape-action — :tree | :fork | :none (default :none)
      :event-queue          — shared LinkedBlockingQueue for agent + extension events"
   ([model-name] (make-init model-name nil))
   ([model-name query-fn] (make-init model-name query-fn nil))
@@ -848,6 +884,9 @@
            :query-fn              query-fn
            :ui-state-atom         ui-state-atom
            :dispatch-fn           (:dispatch-fn opts)
+           :on-interrupt-fn!      (:on-interrupt-fn! opts)
+           :double-press-window-ms (or (:double-press-window-ms opts) 500)
+           :double-escape-action  (or (:double-escape-action opts) :none)
            :cwd                   (or (:cwd opts) (System/getProperty "user.dir"))
            :current-session-file  (or (:current-session-file opts)
                                       (:psi.agent-session/session-file introspected))
@@ -1179,6 +1218,77 @@
     [(update state :spinner-frame #(mod (inc %) n))
      (poll-cmd (:queue state))]))
 
+(defn- handle-ctrl-c
+  [state]
+  (let [now          (now-ms)
+        window-ms    (double-press-window-ms state)
+        last-clear   (get-in state [:prompt-input-state :timing :last-ctrl-c-ms])]
+    (if (within-double-press-window? last-clear now window-ms)
+      [(assoc-in state [:prompt-input-state :timing :last-ctrl-c-ms] nil)
+       charm/quit-cmd]
+      [(-> state
+           (set-input-value "")
+           (assoc-in [:prompt-input-state :timing :last-ctrl-c-ms] now))
+       nil])))
+
+(defn- handle-ctrl-d
+  [state]
+  (if (str/blank? (input-value state))
+    [state charm/quit-cmd]
+    [state nil]))
+
+(defn- handle-idle-escape
+  [state]
+  (let [current-text   (input-value state)
+        now            (now-ms)
+        window-ms      (double-press-window-ms state)
+        action         (:double-escape-action state :none)
+        last-escape    (get-in state [:prompt-input-state :timing :last-escape-ms])
+        second-escape? (within-double-press-window? last-escape now window-ms)]
+    (cond
+      (not (str/blank? current-text))
+      [state nil]
+
+      (= action :none)
+      [state nil]
+
+      second-escape?
+      (case action
+        :tree
+        [(-> state
+             (assoc-in [:prompt-input-state :timing :last-escape-ms] nil)
+             (append-assistant-status "Double Escape action '/tree' is not available in this runtime."))
+         nil]
+
+        :fork
+        [(-> state
+             (assoc-in [:prompt-input-state :timing :last-escape-ms] nil)
+             (append-assistant-status "Double Escape action '/fork' is not available in this runtime."))
+         nil]
+
+        [(-> state
+             (assoc-in [:prompt-input-state :timing :last-escape-ms] nil)
+             (append-assistant-status (str "Unsupported double Escape action: " (pr-str action))))
+         nil])
+
+      :else
+      [(assoc-in state [:prompt-input-state :timing :last-escape-ms] now) nil])))
+
+(defn- handle-streaming-escape
+  [state]
+  (if-let [interrupt-fn (:on-interrupt-fn! state)]
+    (let [{:keys [queued-text message]} (or (interrupt-fn state) {})
+          merged-text (merge-queued-and-draft queued-text (input-value state))
+          next-state  (-> state
+                          (set-input-value merged-text)
+                          (assoc :phase :idle
+                                 :stream-text nil)
+                          (clear-autocomplete)
+                          (assoc-in [:prompt-input-state :timing :last-escape-ms] (now-ms))
+                          (append-assistant-status (or message "Interrupted.")))]
+      [next-state (poll-cmd (:queue state))])
+    [(append-assistant-status state "Interrupt unavailable in this runtime.") nil]))
+
 ;; ── Update ──────────────────────────────────────────────────
 
 (defn make-update
@@ -1209,9 +1319,14 @@
                       " shift=" (boolean (:shift m)))))
 
       (cond
-      ;; Quit: ctrl+c always (legacy; interrupt semantics handled in later task)
+      ;; Ctrl+C — clear first, then quit on second press within window.
         (msg/key-match? m "ctrl+c")
-        [state charm/quit-cmd]
+        (handle-ctrl-c state)
+
+      ;; Ctrl+D — exit only when input is empty.
+        (and (= :idle (:phase state))
+             (msg/key-match? m "ctrl+d"))
+        (handle-ctrl-d state)
 
       ;; Escape closes autocomplete first.
         (and (= :idle (:phase state))
@@ -1219,10 +1334,16 @@
              (msg/key-match? m "escape"))
         [(clear-autocomplete state) nil]
 
+      ;; Escape in streaming interrupts active work.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "escape"))
+        (handle-streaming-escape state)
+
+      ;; Escape while idle delegates to interrupt/double-escape behavior.
         (and (= :idle (:phase state))
              (not (has-active-dialog? state))
              (msg/key-match? m "escape"))
-        [state charm/quit-cmd]
+        (handle-idle-escape state)
 
       ;; Window resize
         (msg/window-size? m)
@@ -1264,6 +1385,18 @@
                     :error       (:error m)
                     :stream-text nil))
          (poll-cmd (:queue state))]
+
+      ;; Agent aborted via interrupt
+        (= :agent-aborted (:type m))
+        (let [queued-text (:queued-text m)
+              merged-text (merge-queued-and-draft queued-text (input-value state))
+              status-msg  (or (:message m) "Interrupted.")]
+          [(-> state
+               (set-input-value merged-text)
+               (assoc :phase :idle
+                      :stream-text nil)
+               (append-assistant-status status-msg))
+           (poll-cmd (:queue state))])
 
       ;; Agent poll timeout → keep polling (and animate spinner while streaming)
         (agent-poll? m)
@@ -1413,7 +1546,7 @@
            (str (charm/render dim-style
                               (str "  Exts: " ext-count " loaded"))
                 "\n"))
-         (charm/render dim-style "  ESC to quit") "\n")))
+         (charm/render dim-style "  ESC=interrupt  Ctrl+C=clear/quit  Ctrl+D=exit-empty") "\n")))
 
 (def ^:private subagent-title-style (charm/style :fg charm/yellow :bold true))
 (def ^:private subagent-head-style (charm/style :fg charm/cyan :bold true))
@@ -2082,10 +2215,10 @@
                warning-lines  (into [] (concat (detail-warning-lines (:details tc))
                                                (when hint-line [hint-line])))
                result-render  (extension-result-render ui-state-atom tc
-                                                      {:expanded? expanded?
-                                                       :width width
-                                                       :tool-id id
-                                                       :tool-name (:name tc)})
+                                                       {:expanded? expanded?
+                                                        :width width
+                                                        :tool-id id
+                                                        :tool-name (:name tc)})
                result-lines   (if (seq result-render)
                                 (str/split-lines result-render)
                                 lines)
@@ -2216,6 +2349,9 @@
                                               {:messages [...]
                                                :tool-calls {...}
                                                :tool-order [...]}
+                       :on-interrupt-fn!    — (fn [state]) -> {:queued-text str? :message str?}
+                       :double-press-window-ms — ctrl+c / escape timing window (default 500)
+                       :double-escape-action — :tree | :fork | :none (default :none)
                        :alt-screen          — true/false (default true)"
   ([model-name run-agent-fn!]
    (start! model-name run-agent-fn! {}))

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -217,6 +217,92 @@
   [state s]
   (assoc state :input (charm/text-input-set-value (:input state) s)))
 
+(defn- clear-history-browse
+  [state]
+  (assoc-in state [:prompt-input-state :history :browse-index] nil))
+
+(defn- set-input-model
+  [state input]
+  (-> state
+      (assoc :input input)
+      clear-history-browse))
+
+(defn- history-entries
+  [state]
+  (vec (get-in state [:prompt-input-state :history :entries] [])))
+
+(defn- history-max-entries
+  [state]
+  (or (get-in state [:prompt-input-state :history :max-entries])
+      prompt-history-max-entries))
+
+(defn- record-history-entry
+  [state text]
+  (let [entry (str/trim (or text ""))]
+    (if (str/blank? entry)
+      state
+      (let [entries      (history-entries state)
+            last-entry   (peek entries)
+            max-entries  (history-max-entries state)
+            next-entries (if (= last-entry entry)
+                           entries
+                           (let [appended (conj entries entry)
+                                 extra    (max 0 (- (count appended) max-entries))]
+                             (if (pos? extra)
+                               (vec (subvec appended extra))
+                               appended)))]
+        (-> state
+            (assoc-in [:prompt-input-state :history :entries] next-entries)
+            (assoc-in [:prompt-input-state :history :browse-index] nil))))))
+
+(defn- history-current-entry
+  [state idx]
+  (let [entries (history-entries state)]
+    (when (and (some? idx)
+               (<= 0 idx)
+               (< idx (count entries)))
+      (nth entries idx))))
+
+(defn- browse-history
+  [state direction]
+  (let [entries (history-entries state)
+        n       (count entries)
+        idx     (get-in state [:prompt-input-state :history :browse-index])
+        input   (input-value state)]
+    (if (zero? n)
+      state
+      (case direction
+        :up
+        (cond
+          (and (nil? idx) (str/blank? input))
+          (let [new-idx (dec n)]
+            (-> state
+                (assoc-in [:prompt-input-state :history :browse-index] new-idx)
+                (set-input-value (history-current-entry state new-idx))))
+
+          (some? idx)
+          (let [new-idx (max 0 (dec idx))]
+            (-> state
+                (assoc-in [:prompt-input-state :history :browse-index] new-idx)
+                (set-input-value (history-current-entry state new-idx))))
+
+          :else
+          state)
+
+        :down
+        (if (some? idx)
+          (if (>= idx (dec n))
+            (-> state
+                (assoc-in [:prompt-input-state :history :browse-index] nil)
+                (set-input-value ""))
+            (let [new-idx (min (dec n) (inc idx))]
+              (-> state
+                  (assoc-in [:prompt-input-state :history :browse-index] new-idx)
+                  (set-input-value (history-current-entry state new-idx)))))
+          state)
+
+        state))))
+
 (defn- whitespace-char?
   [^Character c]
   (Character/isWhitespace c))
@@ -784,10 +870,10 @@
   "Enter session-selector phase."
   [state]
   (let [sel (session-selector-init (:cwd state) (:current-session-file state))]
-    [(assoc state
-            :phase            :selecting-session
-            :session-selector sel
-            :input            (charm/text-input-reset (:input state)))
+    [(-> state
+         (assoc :phase :selecting-session
+                :session-selector sel)
+         (set-input-model (charm/text-input-reset (:input state))))
      nil]))
 
 (defn- handle-dispatch-result
@@ -806,20 +892,20 @@
       [(-> state
            (assoc :messages []
                   :error    nil
-                  :input    (charm/text-input-reset (:input state))
                   :force-clear? true)
+           (set-input-model (charm/text-input-reset (:input state)))
            (update :messages conj {:role :assistant :text (:message result)}))
        nil]
 
       :text
       [(-> state
-           (assoc :input (charm/text-input-reset (:input state)))
+           (set-input-model (charm/text-input-reset (:input state)))
            (update :messages conj {:role :assistant :text (:message result)}))
        nil]
 
       (:login-error :logout)
       [(-> state
-           (assoc :input (charm/text-input-reset (:input state)))
+           (set-input-model (charm/text-input-reset (:input state)))
            (update :messages conj {:role :assistant :text (:message result)}))
        nil]
 
@@ -832,7 +918,7 @@
                      (catch Exception e
                        (timbre/warn "Extension command error:" (ex-message e))
                        (str "[command error: " (ex-message e) "]")))]
-        [(cond-> (assoc state :input (charm/text-input-reset (:input state)))
+        [(cond-> (set-input-model state (charm/text-input-reset (:input state)))
            output (update :messages conj {:role :assistant :text output}))
          nil])
 
@@ -841,7 +927,7 @@
       ;; providers, the next input will be treated as the auth code.
       :login-start
       [(-> state
-           (assoc :input (charm/text-input-reset (:input state)))
+           (set-input-model (charm/text-input-reset (:input state)))
            (update :messages conj
                    {:role :assistant
                     :text (str "🔑 Login to " (get-in result [:provider :name])
@@ -853,7 +939,7 @@
 
       ;; Fallback — treat as text
       [(-> state
-           (assoc :input (charm/text-input-reset (:input state)))
+           (set-input-model (charm/text-input-reset (:input state)))
            (update :messages conj {:role :assistant :text (str result)}))
        nil])))
 
@@ -936,9 +1022,9 @@
          (update :messages conj {:role :user :text text})
          (assoc :phase         :streaming
                 :error         nil
-                :input         (charm/text-input-reset (:input state))
                 :spinner-frame 0
-                :stream-text   nil))
+                :stream-text   nil)
+         (set-input-model (charm/text-input-reset (:input state))))
      (poll-cmd queue)]))
 
 (defn- submit-input
@@ -953,7 +1039,8 @@
 
       ;; Dispatch commands via central dispatcher
       :else
-      (let [dispatch-fn (:dispatch-fn state)
+      (let [state       (record-history-entry state text)
+            dispatch-fn (:dispatch-fn state)
             result      (when dispatch-fn (dispatch-fn text))]
         (if result
           (handle-dispatch-result state result)
@@ -970,7 +1057,7 @@
                       (subs value 0 (dec (count value)))
                       value)
         next-input  (charm/text-input-set-value (:input state) (str value' "\n"))]
-    [(assoc state :input next-input) nil]))
+    [(set-input-model state next-input) nil]))
 
 (defn- delete-prev-word
   "Delete previous word from charm text input state.
@@ -1220,6 +1307,17 @@
              (msg/key-match? m "down"))
         [(move-autocomplete-selection state 1) nil]
 
+      ;; Up/Down browse prompt history when autocomplete is closed.
+        (and (= :idle (:phase state))
+             (not (autocomplete-open? state))
+             (msg/key-match? m "up"))
+        [(browse-history state :up) nil]
+
+        (and (= :idle (:phase state))
+             (not (autocomplete-open? state))
+             (msg/key-match? m "down"))
+        [(browse-history state :down) nil]
+
       ;; Tab accepts selected autocomplete suggestion.
         (and (= :idle (:phase state))
              (autocomplete-open? state)
@@ -1262,7 +1360,7 @@
         (and (= :idle (:phase state))
              (msg/key-match? m "backspace"))
         (let [[new-input cmd] (charm/text-input-update (:input state) m)
-              next-state      (assoc state :input new-input)
+              next-state      (set-input-model state new-input)
               next-state      (if (autocomplete-open? state)
                                 (refresh-autocomplete next-state (get-in state [:prompt-input-state :autocomplete :trigger-mode]))
                                 next-state)]
@@ -1273,7 +1371,7 @@
         (and (= :idle (:phase state))
              (msg/key-match? m "space"))
         (let [[new-input cmd] (charm/text-input-update (:input state) (msg/key-press " "))
-              next-state      (assoc state :input new-input)
+              next-state      (set-input-model state new-input)
               next-state      (if (autocomplete-open? state)
                                 (refresh-autocomplete next-state (get-in state [:prompt-input-state :autocomplete :trigger-mode]))
                                 (maybe-auto-open-autocomplete next-state :space))]
@@ -1284,7 +1382,7 @@
              (msg/key-press? m))
         (let [key-token       (:key m)
               [new-input cmd] (charm/text-input-update (:input state) m)
-              next-state      (assoc state :input new-input)
+              next-state      (set-input-model state new-input)
               next-state      (if (autocomplete-open? state)
                                 (refresh-autocomplete next-state (get-in state [:prompt-input-state :autocomplete :trigger-mode]))
                                 (maybe-auto-open-autocomplete next-state key-token))]

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -28,6 +28,7 @@
    [charm.render.core]  ; loaded so we can patch enter-alt-screen!
    [charm.terminal :as charm-term]
    [cheshire.core :as json]
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [taoensso.timbre :as timbre]
    [psi.agent-session.persistence :as persist]
@@ -186,6 +187,305 @@
 
 (def ^:private spinner-frames
   ["⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"])
+
+(def ^:private prompt-history-max-entries 100)
+
+(defn- initial-prompt-input-state
+  []
+  {:autocomplete {:prefix ""
+                  :candidates []
+                  :selected-index 0
+                  :context nil
+                  :trigger-mode nil}
+   :history {:entries []
+             :browse-index nil
+             :max-entries prompt-history-max-entries}
+   :timing {:last-ctrl-c-ms nil
+            :last-escape-ms nil}})
+
+(def ^:private builtin-slash-commands
+  ["/quit" "/exit" "/resume" "/new" "/status" "/help"])
+
+(defn- input-value [state]
+  (charm/text-input-value (:input state)))
+
+(defn- input-pos [state]
+  (let [v (input-value state)]
+    (min (max 0 (or (get-in state [:input :pos]) (count v))) (count v))))
+
+(defn- set-input-value
+  [state s]
+  (assoc state :input (charm/text-input-set-value (:input state) s)))
+
+(defn- whitespace-char?
+  [^Character c]
+  (Character/isWhitespace c))
+
+(defn- token-context-at-cursor
+  "Derive token context at cursor.
+   Returns {:text :pos :before :after :token :token-start :token-end :context :prefix}"
+  [state]
+  (let [text        (input-value state)
+        pos         (input-pos state)
+        before      (subs text 0 pos)
+        after       (subs text pos)
+        token-start (or (some->> (keep-indexed (fn [i ch]
+                                                 (when (whitespace-char? ch) i))
+                                               before)
+                                  last
+                                  inc)
+                        0)
+        token       (subs before token-start)
+        context     (cond
+                      (and (= token-start 0)
+                           (str/starts-with? token "/"))
+                      :slash_command
+
+                      (str/starts-with? token "@")
+                      :file_reference
+
+                      :else
+                      :file_path)]
+    {:text text
+     :pos pos
+     :before before
+     :after after
+     :token token
+     :token-start token-start
+     :token-end pos
+     :context context
+     :prefix token}))
+
+(defn- slash-candidates
+  [state prefix]
+  (let [templates  (mapv (fn [{:keys [name]}] (str "/" name)) (:prompt-templates state))
+        skills     (mapv (fn [{:keys [name]}] (str "/skill:" name)) (:skills state))
+        ext-cmds   (vec (:extension-command-names state))
+        all        (->> (concat builtin-slash-commands templates skills ext-cmds)
+                        (remove str/blank?)
+                        distinct
+                        sort)
+        pfx        (or prefix "/")
+        lowered    (str/lower-case pfx)]
+    (->> all
+         (filter #(str/starts-with? (str/lower-case %) lowered))
+         (mapv (fn [cmd]
+                 {:value cmd
+                  :label cmd
+                  :description nil
+                  :kind :slash_command
+                  :is-directory false})))))
+
+(defn- rel-path
+  [cwd ^java.io.File f]
+  (let [cwd-path (.toPath (io/file cwd))
+        file-path (.toPath f)]
+    (-> (.relativize cwd-path file-path)
+        (.normalize)
+        (.toString))))
+
+(defn- hidden-or-git-path?
+  [rel]
+  (or (= ".git" rel)
+      (str/starts-with? rel ".git/")
+      (str/includes? rel "/.git/")
+      (str/ends-with? rel "/.git")))
+
+(defn- quote-if-needed [s]
+  (if (str/includes? s " ")
+    (str "\"" s "\"")
+    s))
+
+(defn- file-reference-candidates
+  [state prefix]
+  (let [cwd        (:cwd state)
+        token      (or prefix "@")
+        typed      (subs token (min 1 (count token)))
+        typed      (str/replace typed #"^\"" "")
+        query      (str/lower-case typed)
+        root       (io/file cwd)]
+    (->> (file-seq root)
+         (remove #(.equals root %))
+         (map (fn [^java.io.File f]
+                (let [rel (rel-path cwd f)]
+                  {:file f :rel rel :dir? (.isDirectory f)})))
+         (remove #(hidden-or-git-path? (:rel %)))
+         (filter (fn [{:keys [rel]}]
+                   (or (str/blank? query)
+                       (str/includes? (str/lower-case rel) query))))
+         (sort-by (juxt (fn [{:keys [dir?]}] (if dir? 0 1)) :rel))
+         (take 100)
+         (mapv (fn [{:keys [rel dir?]}]
+                 (let [v (cond-> rel
+                           dir? (str "/"))
+                       v (quote-if-needed v)]
+                   {:value v
+                    :label v
+                    :description nil
+                    :kind :file_reference
+                    :is-directory dir?}))))))
+
+(defn- path-completion-candidates
+  [state prefix]
+  (let [cwd          (:cwd state)
+        token        (or prefix "")
+        slash-idx    (str/last-index-of token "/")
+        [dir-part name-part] (if slash-idx
+                               [(subs token 0 (inc slash-idx))
+                                (subs token (inc slash-idx))]
+                               ["" token])
+        base         (io/file cwd dir-part)
+        dir-exists?  (.isDirectory base)]
+    (if-not dir-exists?
+      []
+      (->> (.listFiles base)
+           (filter some?)
+           (map (fn [^java.io.File f]
+                  (let [nm (.getName f)
+                        rel (str dir-part nm)]
+                    {:name nm
+                     :rel rel
+                     :dir? (.isDirectory f)})))
+           (remove #(hidden-or-git-path? (:rel %)))
+           (filter (fn [{:keys [name]}]
+                     (str/starts-with? (str/lower-case name)
+                                       (str/lower-case name-part))))
+           (sort-by (juxt (fn [{:keys [dir?]}] (if dir? 0 1)) :rel))
+           (mapv (fn [{:keys [rel dir?]}]
+                   (let [v (cond-> rel
+                             dir? (str "/"))]
+                     {:value v
+                      :label v
+                      :description nil
+                      :kind :file_path
+                      :is-directory dir?})))))))
+
+(defn- clear-autocomplete
+  [state]
+  (assoc-in state [:prompt-input-state :autocomplete]
+            {:prefix ""
+             :candidates []
+             :selected-index 0
+             :context nil
+             :trigger-mode nil}))
+
+(defn- open-autocomplete
+  [state {:keys [prefix context trigger-mode token-start token-end]} candidates]
+  (if (seq candidates)
+    (assoc-in state [:prompt-input-state :autocomplete]
+              {:prefix prefix
+               :candidates candidates
+               :selected-index 0
+               :context context
+               :trigger-mode trigger-mode
+               :token-start token-start
+               :token-end token-end})
+    (clear-autocomplete state)))
+
+(defn- context-candidates
+  [state context prefix]
+  (case context
+    :slash_command (slash-candidates state prefix)
+    :file_reference (file-reference-candidates state prefix)
+    :file_path (path-completion-candidates state prefix)
+    []))
+
+(defn- refresh-autocomplete
+  [state trigger-mode]
+  (let [{:keys [context prefix token-start token-end]} (token-context-at-cursor state)
+        candidates (context-candidates state context prefix)]
+    (open-autocomplete state {:prefix prefix
+                              :context context
+                              :trigger-mode trigger-mode
+                              :token-start token-start
+                              :token-end token-end}
+                       candidates)))
+
+(defn- autocomplete-open?
+  [state]
+  (seq (get-in state [:prompt-input-state :autocomplete :candidates])))
+
+(defn- move-autocomplete-selection
+  [state delta]
+  (let [cands (get-in state [:prompt-input-state :autocomplete :candidates])
+        cnt   (count cands)]
+    (if (zero? cnt)
+      state
+      (update-in state [:prompt-input-state :autocomplete :selected-index]
+                 (fn [i]
+                   (let [i (or i 0)]
+                     (mod (+ i delta) cnt)))))))
+
+(defn- drop-duplicate-closing-quote-in-after
+  [replacement after]
+  (if (and (str/ends-with? replacement "\"")
+           (str/starts-with? (or after "") "\""))
+    (subs after 1)
+    after))
+
+(defn- apply-selected-autocomplete
+  [state]
+  (let [ac         (get-in state [:prompt-input-state :autocomplete])
+        idx        (or (:selected-index ac) 0)
+        candidate  (nth (:candidates ac) idx nil)
+        text       (input-value state)
+        start      (or (:token-start ac) (count text))
+        end        (or (:token-end ac) (count text))
+        before     (subs text 0 (min start (count text)))
+        after      (subs text (min end (count text)))
+        context    (:context ac)]
+    (if-not candidate
+      state
+      (let [base-value (:value candidate)
+            replacement (case context
+                          :file_reference (str "@" base-value)
+                          base-value)
+            after       (drop-duplicate-closing-quote-in-after replacement after)
+            replacement (if (and (= :file_reference context)
+                                 (not (:is-directory candidate)))
+                          (str replacement " ")
+                          replacement)
+            text'      (str before replacement after)]
+        (-> state
+            (set-input-value text')
+            clear-autocomplete)))))
+
+(declare printable-key)
+
+(defn- maybe-auto-open-autocomplete
+  [state key-token]
+  (let [ch (printable-key key-token)]
+    (if-not (or (= ch "/") (= ch "@"))
+      state
+      (let [{:keys [context token]} (token-context-at-cursor state)]
+        (cond
+          (and (= ch "/") (= :slash_command context))
+          (refresh-autocomplete state :auto)
+
+          (and (= ch "@") (= :file_reference context)
+               (str/starts-with? token "@"))
+          (refresh-autocomplete state :auto)
+
+          :else
+          state)))))
+
+(defn- open-tab-autocomplete
+  [state]
+  (let [{:keys [token token-start token-end]} (token-context-at-cursor state)
+        context    (if (and (= token-start 0) (str/starts-with? token "/"))
+                     :slash_command
+                     :file_path)
+        candidates (context-candidates state context token)
+        opened     (open-autocomplete state {:prefix token
+                                             :context context
+                                             :trigger-mode :tab
+                                             :token-start token-start
+                                             :token-end token-end}
+                                      candidates)]
+    (if (and (= :file_path context)
+             (= 1 (count candidates)))
+      (apply-selected-autocomplete opened)
+      opened)))
 
 ;; ── Custom message predicates ───────────────────────────────
 
@@ -444,7 +744,8 @@
                           (query-fn [:psi.agent-session/prompt-templates
                                      :psi.agent-session/skills
                                      :psi.agent-session/extension-summary
-                                     :psi.agent-session/session-file]))]
+                                     :psi.agent-session/session-file
+                                     :psi.extension/command-names]))]
        (let [queue (or (:event-queue opts) (LinkedBlockingQueue.))]
          [{:messages              []
            :phase                 :idle
@@ -457,6 +758,7 @@
            :prompt-templates      (or (:psi.agent-session/prompt-templates introspected) [])
            :skills                (or (:psi.agent-session/skills introspected) [])
            :extension-summary     (or (:psi.agent-session/extension-summary introspected) {})
+           :extension-command-names (vec (:psi.extension/command-names introspected))
            :query-fn              query-fn
            :ui-state-atom         ui-state-atom
            :dispatch-fn           (:dispatch-fn opts)
@@ -465,6 +767,7 @@
                                       (:psi.agent-session/session-file introspected))
            :resume-fn!            (:resume-fn! opts)
            :session-selector      nil   ;; non-nil when /resume is active
+           :prompt-input-state    (initial-prompt-input-state)
            :queue                 queue
            :width                 80
            :height                24
@@ -819,9 +1122,15 @@
                       " shift=" (boolean (:shift m)))))
 
       (cond
-      ;; Quit: ctrl+c always; escape when idle and no dialog
+      ;; Quit: ctrl+c always (legacy; interrupt semantics handled in later task)
         (msg/key-match? m "ctrl+c")
         [state charm/quit-cmd]
+
+      ;; Escape closes autocomplete first.
+        (and (= :idle (:phase state))
+             (autocomplete-open? state)
+             (msg/key-match? m "escape"))
+        [(clear-autocomplete state) nil]
 
         (and (= :idle (:phase state))
              (not (has-active-dialog? state))
@@ -900,10 +1209,33 @@
                           " pos=" (:pos (:input new-state)))))
           [new-state nil])
 
+      ;; Up/Down navigate autocomplete selection when menu is open.
+        (and (= :idle (:phase state))
+             (autocomplete-open? state)
+             (msg/key-match? m "up"))
+        [(move-autocomplete-selection state -1) nil]
+
+        (and (= :idle (:phase state))
+             (autocomplete-open? state)
+             (msg/key-match? m "down"))
+        [(move-autocomplete-selection state 1) nil]
+
+      ;; Tab accepts selected autocomplete suggestion.
+        (and (= :idle (:phase state))
+             (autocomplete-open? state)
+             (msg/key-match? m "tab"))
+        [(apply-selected-autocomplete state) nil]
+
+      ;; Tab opens contextual slash/path autocomplete when no menu exists.
+        (and (= :idle (:phase state))
+             (msg/key-match? m "tab"))
+        [(open-tab-autocomplete state) nil]
+
       ;; Enter behavior:
       ;; - shift/alt/cmd(ctrl+alt)+enter => newline continuation
       ;; - trailing "\\" + enter => newline continuation
-      ;; - plain enter => submit
+      ;; - plain enter accepts autocomplete (and submits slash command)
+      ;; - otherwise plain enter submits
         (and (= :idle (:phase state))
              (msg/key-match? m "enter")
              (or (:shift m)
@@ -912,23 +1244,51 @@
                  (str/ends-with? (charm/text-input-value (:input state)) "\\")))
         (continue-input-line state)
 
+        (and (= :idle (:phase state))
+             (autocomplete-open? state)
+             (msg/key-match? m "enter"))
+        (let [slash? (= :slash_command (get-in state [:prompt-input-state :autocomplete :context]))
+              s1     (apply-selected-autocomplete state)]
+          (if slash?
+            (submit-input s1 run-agent-fn!)
+            [s1 nil]))
+
       ;; Enter → submit (idle + has text)
         (and (= :idle (:phase state))
              (msg/key-match? m "enter"))
         (submit-input state run-agent-fn!)
 
+      ;; Backspace edits text then refreshes open autocomplete.
+        (and (= :idle (:phase state))
+             (msg/key-match? m "backspace"))
+        (let [[new-input cmd] (charm/text-input-update (:input state) m)
+              next-state      (assoc state :input new-input)
+              next-state      (if (autocomplete-open? state)
+                                (refresh-autocomplete next-state (get-in state [:prompt-input-state :autocomplete :trigger-mode]))
+                                next-state)]
+          [next-state cmd])
+
       ;; Space from terminal input may arrive as keyword :space (not " ").
       ;; Normalize to a printable char so it inserts immediately.
         (and (= :idle (:phase state))
              (msg/key-match? m "space"))
-        (let [[new-input cmd] (charm/text-input-update (:input state) (msg/key-press " "))]
-          [(assoc state :input new-input) cmd])
+        (let [[new-input cmd] (charm/text-input-update (:input state) (msg/key-press " "))
+              next-state      (assoc state :input new-input)
+              next-state      (if (autocomplete-open? state)
+                                (refresh-autocomplete next-state (get-in state [:prompt-input-state :autocomplete :trigger-mode]))
+                                (maybe-auto-open-autocomplete next-state :space))]
+          [next-state cmd])
 
       ;; All other keys → text input (idle only)
         (and (= :idle (:phase state))
              (msg/key-press? m))
-        (let [[new-input cmd] (charm/text-input-update (:input state) m)]
-          [(assoc state :input new-input) cmd])
+        (let [key-token       (:key m)
+              [new-input cmd] (charm/text-input-update (:input state) m)
+              next-state      (assoc state :input new-input)
+              next-state      (if (autocomplete-open? state)
+                                (refresh-autocomplete next-state (get-in state [:prompt-input-state :autocomplete :trigger-mode]))
+                                (maybe-auto-open-autocomplete next-state key-token))]
+          [next-state cmd])
 
       ;; Ignore everything else (keys during streaming, etc.)
         :else

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -58,6 +58,16 @@
                  :result {:role    "assistant"
                           :content [{:type :text :text response-text}]}})))
 
+(defn- submit-text
+  "Type s then press enter; if submission starts streaming, advance once to idle."
+  [update-fn state s]
+  (let [typed          (type-text update-fn state s)
+        [submitted _]  (update-fn typed (msg/key-press :enter))]
+    (if (= :streaming (:phase submitted))
+      (first (update-fn submitted {:type :agent-result
+                                   :result {:content [{:type :text :text "ok"}]}}))
+      submitted)))
+
 (defn- error-agent-fn
   "A stub run-agent-fn! that immediately puts an error on the queue."
   [error-msg]
@@ -342,6 +352,67 @@
           streaming (assoc (init-state) :phase :streaming)
           [_s cmd]  (update-fn streaming (msg/key-press "c" :ctrl true))]
       (is (some? cmd)))))
+
+(deftest history-records-trimmed-non-empty-and-skips-consecutive-duplicates-test
+  (testing "submitted prompts are trimmed, blank ignored, and consecutive duplicates skipped"
+    (let [update-fn (app/make-update (stub-agent-fn "ok"))
+          s1        (submit-text update-fn (init-state) "   ")
+          s2        (submit-text update-fn s1 "  alpha  ")
+          s3        (submit-text update-fn s2 "alpha")
+          s4        (submit-text update-fn s3 "beta")
+          entries   (get-in s4 [:prompt-input-state :history :entries])]
+      (is (= ["alpha" "beta"] entries)))))
+
+(deftest history-cap-is-100-most-recent-entries-test
+  (testing "history keeps at most 100 latest entries"
+    (let [update-fn (app/make-update (stub-agent-fn "ok"))
+          end-state (reduce (fn [st i]
+                              (submit-text update-fn st (str "p-" i)))
+                            (init-state)
+                            (range 105))
+          entries   (get-in end-state [:prompt-input-state :history :entries])]
+      (is (= 100 (count entries)))
+      (is (= "p-5" (first entries)))
+      (is (= "p-104" (last entries))))))
+
+(deftest history-up-from-empty-enters-browsing-at-newest-test
+  (testing "up from empty input enters history browse mode at newest entry"
+    (let [update-fn (app/make-update (stub-agent-fn "ok"))
+          base      (submit-text update-fn
+                                 (submit-text update-fn (init-state) "alpha")
+                                 "beta")
+          state     (assoc base :phase :idle
+                                :input (charm/text-input-set-value (:input base) ""))
+          [s1 _]    (update-fn state (msg/key-press :up))]
+      (is (= "beta" (text-input/value (:input s1))))
+      (is (= 1 (get-in s1 [:prompt-input-state :history :browse-index]))))))
+
+(deftest history-down-from-newest-exits-browsing-to-empty-test
+  (testing "down at newest history entry exits browse mode and restores empty input"
+    (let [update-fn (app/make-update (stub-agent-fn "ok"))
+          base      (submit-text update-fn
+                                 (submit-text update-fn (init-state) "alpha")
+                                 "beta")
+          state     (assoc base :phase :idle
+                                :input (charm/text-input-set-value (:input base) ""))
+          [s1 _]    (update-fn state (msg/key-press :up))
+          [s2 _]    (update-fn s1 (msg/key-press :down))]
+      (is (= "" (text-input/value (:input s2))))
+      (is (nil? (get-in s2 [:prompt-input-state :history :browse-index]))))))
+
+(deftest history-editing-clears-browse-index-test
+  (testing "normal edit and programmatic set-text clear history browse mode"
+    (let [update-fn (app/make-update (stub-agent-fn "ok"))
+          base      (submit-text update-fn
+                                 (submit-text update-fn (init-state) "alpha")
+                                 "beta")
+          state     (assoc base :phase :idle
+                                :input (charm/text-input-set-value (:input base) ""))
+          [s1 _]    (update-fn state (msg/key-press :up))
+          [s2 _]    (update-fn s1 (msg/key-press "x"))
+          [s3 _]    (update-fn s2 (msg/key-press :enter))]
+      (is (nil? (get-in s2 [:prompt-input-state :history :browse-index])))
+      (is (nil? (get-in s3 [:prompt-input-state :history :browse-index]))))))
 
 (deftest autocomplete-slash-opens-on-leading-slash-test
   (testing "typing leading / opens slash autocomplete with slash context"

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -3,6 +3,7 @@
    Exercises init/update/view as pure functions — no terminal needed.
    Includes a JLine integration smoke test for terminal + keymap creation."
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [charm.components.text-input :as text-input]
@@ -73,7 +74,24 @@
       (is (some? cmd))
       (is (empty? (:messages state)))
       (is (nil? (:error state)))
-      (is (= "test-model" (:model-name state))))))
+      (is (= "test-model" (:model-name state)))))
+
+  (testing "init includes explicit prompt-input state shape"
+    (let [[state _] ((app/make-init "test-model"))
+          input-state (:prompt-input-state state)]
+      (is (= {:prefix ""
+              :candidates []
+              :selected-index 0
+              :context nil
+              :trigger-mode nil}
+             (:autocomplete input-state)))
+      (is (= {:entries []
+              :browse-index nil
+              :max-entries 100}
+             (:history input-state)))
+      (is (= {:last-ctrl-c-ms nil
+              :last-escape-ms nil}
+             (:timing input-state))))))
 
 ;;;; Update — key input
 
@@ -324,6 +342,97 @@
           streaming (assoc (init-state) :phase :streaming)
           [_s cmd]  (update-fn streaming (msg/key-press "c" :ctrl true))]
       (is (some? cmd)))))
+
+(deftest autocomplete-slash-opens-on-leading-slash-test
+  (testing "typing leading / opens slash autocomplete with slash context"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (init-state)
+          [s1 _]    (update-fn state (msg/key-press "/"))
+          ac        (get-in s1 [:prompt-input-state :autocomplete])]
+      (is (= :slash_command (:context ac)))
+      (is (= :auto (:trigger-mode ac)))
+      (is (seq (:candidates ac)))
+      (is (some #(= "/help" (:value %)) (:candidates ac))))))
+
+(deftest autocomplete-accept-on-enter-submits-slash-test
+  (testing "enter accepts selected slash suggestion and submits"
+    (let [submitted (atom nil)
+          agent-fn  (fn [text _queue] (reset! submitted text))
+          update-fn (app/make-update agent-fn)
+          state     (init-state)
+          state     (assoc state :prompt-templates [{:name "deploy"}])
+          [s1 _]    (update-fn state (msg/key-press "/"))
+          [s2 _]    (update-fn s1 (msg/key-press "d"))
+          [s3 _]    (update-fn s2 (msg/key-press :enter))]
+      (is (= :streaming (:phase s3)))
+      (is (= "/deploy" @submitted))
+      (is (empty? (get-in s3 [:prompt-input-state :autocomplete :candidates]))))))
+
+(deftest autocomplete-escape-closes-menu-not-quit-test
+  (testing "escape closes open autocomplete without quitting"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          [s1 _]    (update-fn (init-state) (msg/key-press "/"))
+          [s2 cmd]  (update-fn s1 (msg/key-press :escape))]
+      (is (= :idle (:phase s2)))
+      (is (nil? cmd))
+      (is (empty? (get-in s2 [:prompt-input-state :autocomplete :candidates]))))))
+
+(deftest autocomplete-tab-opens-path-and-single-auto-applies-test
+  (testing "tab opens path completion and single match auto-applies"
+    (let [tmp-dir (java.nio.file.Files/createTempDirectory "psi-ac" (make-array java.nio.file.attribute.FileAttribute 0))
+          root    (.toFile tmp-dir)
+          _       (spit (io/file root "alpha.txt") "x")
+          update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state) :cwd (.getAbsolutePath root))
+          state     (assoc state :input (charm/text-input-set-value (:input state) "alp"))
+          [s1 _]    (update-fn state (msg/key-press :tab))]
+      (is (= "alpha.txt" (text-input/value (:input s1))))
+      (is (empty? (get-in s1 [:prompt-input-state :autocomplete :candidates]))))))
+
+(deftest autocomplete-file-reference-filters-git-and-adds-space-test
+  (testing "@ completion excludes .git entries and appends trailing space for files"
+    (let [tmp-dir  (java.nio.file.Files/createTempDirectory "psi-fr" (make-array java.nio.file.attribute.FileAttribute 0))
+          root     (.toFile tmp-dir)
+          _        (.mkdir (io/file root ".git"))
+          _        (spit (io/file root ".git" "ignored.txt") "x")
+          _        (spit (io/file root ".hidden") "x")
+          _        (spit (io/file root "file.txt") "x")
+          update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state) :cwd (.getAbsolutePath root))
+          [s1 _]    (update-fn state (msg/key-press "@"))
+          cands     (get-in s1 [:prompt-input-state :autocomplete :candidates])
+          cand-vals (set (map :value cands))
+          _         (is (contains? cand-vals ".hidden"))
+          _         (is (contains? cand-vals "file.txt"))
+          _         (is (not-any? #(str/starts-with? % ".git") cand-vals))
+          ;; choose file.txt explicitly
+          s2        (assoc-in s1 [:prompt-input-state :autocomplete :selected-index]
+                              (or (first (keep-indexed (fn [idx c]
+                                                         (when (= "file.txt" (:value c)) idx))
+                                                       cands))
+                                  0))
+          [s3 _]    (update-fn s2 (msg/key-press :tab))]
+      (is (= "@file.txt " (text-input/value (:input s3)))))))
+
+(deftest autocomplete-quoted-acceptance-avoids-duplicate-closing-quote-test
+  (testing "accepting quoted completion does not duplicate closing quote"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (-> (init-state)
+                        (assoc :input (charm/text-input-set-value (:input (init-state)) "@\"foo\""))
+                        (assoc-in [:prompt-input-state :autocomplete]
+                                  {:prefix "@\"f"
+                                   :candidates [{:value "\"foo\""
+                                                 :label "\"foo\""
+                                                 :description nil
+                                                 :kind :file_reference
+                                                 :is-directory false}]
+                                   :selected-index 0
+                                   :context :file_reference
+                                   :trigger-mode :auto
+                                   :token-start 0
+                                   :token-end 5}))
+          [s1 _]    (update-fn state (msg/key-press :tab))]
+      (is (= "@\"foo\" " (text-input/value (:input s1)))))))
 
 (deftest keys-ignored-during-streaming-test
   (testing "printable keys are ignored while streaming"

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -217,11 +217,11 @@
           restored      {:messages [{:role :user :text "restored user"}
                                     {:role :assistant :text "restored assistant"}]
                          :tool-calls {"t1" {:name "read"
-                                             :args "{\"path\":\"foo.txt\"}"
-                                             :status :success
-                                             :result "ok"
-                                             :is-error false
-                                             :expanded? false}}
+                                            :args "{\"path\":\"foo.txt\"}"
+                                            :status :success
+                                            :result "ok"
+                                            :is-error false
+                                            :expanded? false}}
                          :tool-order ["t1"]}]
       (with-redefs [persist/session-dir-for (fn [_cwd] "/tmp/psi-test")
                     persist/list-sessions
@@ -336,22 +336,64 @@
       (is (= 1 (:spinner-frame s1)))
       (is (some? cmd)))))
 
-;;;; Update — quit
+;;;; Update — interrupt / clear / exit semantics
 
-(deftest escape-quits-when-idle-test
-  (testing "escape when idle returns quit-cmd"
+(deftest escape-idle-does-not-quit-by-default-test
+  (testing "escape when idle and no menu does not quit"
     (let [update-fn (app/make-update (stub-agent-fn ""))
           state     (init-state)
-          [_s cmd]  (update-fn state (msg/key-press :escape))]
-      ;; quit-cmd is a charm command map
-      (is (some? cmd)))))
+          [s1 cmd]  (update-fn state (msg/key-press :escape))]
+      (is (= :idle (:phase s1)))
+      (is (nil? cmd)))))
 
-(deftest ctrl-c-always-quits-test
-  (testing "ctrl+c quits even during streaming"
+(deftest ctrl-c-clears-first-then-quits-within-window-test
+  (testing "first ctrl+c clears input; second ctrl+c within window quits"
     (let [update-fn (app/make-update (stub-agent-fn ""))
-          streaming (assoc (init-state) :phase :streaming)
-          [_s cmd]  (update-fn streaming (msg/key-press "c" :ctrl true))]
-      (is (some? cmd)))))
+          state     (assoc (init-state)
+                           :input (charm/text-input-set-value (:input (init-state)) "hello"))
+          [s1 cmd1] (update-fn state (msg/key-press "c" :ctrl true))
+          [_s2 cmd2] (update-fn s1 (msg/key-press "c" :ctrl true))]
+      (is (= "" (text-input/value (:input s1))))
+      (is (nil? cmd1))
+      (is (some? cmd2)))))
+
+(deftest ctrl-d-exits-only-when-input-empty-test
+  (testing "ctrl+d exits when input empty and is ignored when input non-empty"
+    (let [update-fn   (app/make-update (stub-agent-fn ""))
+          non-empty   (assoc (init-state)
+                             :input (charm/text-input-set-value (:input (init-state)) "x"))
+          [_s1 cmd1]  (update-fn non-empty (msg/key-press "d" :ctrl true))
+          empty-state (assoc (init-state)
+                             :input (charm/text-input-set-value (:input (init-state)) ""))
+          [_s2 cmd2]  (update-fn empty-state (msg/key-press "d" :ctrl true))]
+      (is (nil? cmd1))
+      (is (some? cmd2)))))
+
+(deftest escape-streaming-interrupts-and-restores-queued-text-test
+  (testing "escape during streaming calls interrupt hook and restores queued input"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state "test-model"
+                                       {:on-interrupt-fn! (fn [_]
+                                                            {:queued-text "queued one\nqueued two"
+                                                             :message "Interrupted active work."})})
+                           :phase :streaming
+                           :input (charm/text-input-set-value (:input (init-state)) "draft"))
+          [s1 _cmd] (update-fn state (msg/key-press :escape))]
+      (is (= :idle (:phase s1)))
+      (is (= "queued one\nqueued two\ndraft" (text-input/value (:input s1))))
+      (is (= "Interrupted active work."
+             (:text (last (:messages s1))))))))
+
+(deftest double-escape-unsupported-action-is-safe-no-op-with-status-test
+  (testing "unsupported double-escape action does not crash and emits status"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state "test-model" {:double-escape-action :tree})
+                           :input (charm/text-input-set-value (:input (init-state)) ""))
+          [s1 cmd1] (update-fn state (msg/key-press :escape))
+          [s2 cmd2] (update-fn s1 (msg/key-press :escape))]
+      (is (nil? cmd1))
+      (is (nil? cmd2))
+      (is (str/includes? (:text (last (:messages s2))) "not available")))))
 
 (deftest history-records-trimmed-non-empty-and-skips-consecutive-duplicates-test
   (testing "submitted prompts are trimmed, blank ignored, and consecutive duplicates skipped"
@@ -382,7 +424,7 @@
                                  (submit-text update-fn (init-state) "alpha")
                                  "beta")
           state     (assoc base :phase :idle
-                                :input (charm/text-input-set-value (:input base) ""))
+                           :input (charm/text-input-set-value (:input base) ""))
           [s1 _]    (update-fn state (msg/key-press :up))]
       (is (= "beta" (text-input/value (:input s1))))
       (is (= 1 (get-in s1 [:prompt-input-state :history :browse-index]))))))
@@ -394,7 +436,7 @@
                                  (submit-text update-fn (init-state) "alpha")
                                  "beta")
           state     (assoc base :phase :idle
-                                :input (charm/text-input-set-value (:input base) ""))
+                           :input (charm/text-input-set-value (:input base) ""))
           [s1 _]    (update-fn state (msg/key-press :up))
           [s2 _]    (update-fn s1 (msg/key-press :down))]
       (is (= "" (text-input/value (:input s2))))
@@ -407,7 +449,7 @@
                                  (submit-text update-fn (init-state) "alpha")
                                  "beta")
           state     (assoc base :phase :idle
-                                :input (charm/text-input-set-value (:input base) ""))
+                           :input (charm/text-input-set-value (:input base) ""))
           [s1 _]    (update-fn state (msg/key-press :up))
           [s2 _]    (update-fn s1 (msg/key-press "x"))
           [s3 _]    (update-fn s2 (msg/key-press :enter))]


### PR DESCRIPTION
## Summary
Implements story #39: **Implement TUI prompt-input handling parity with distilled specs**.

This brings prompt input behavior in line with:
- `spec/tui-input-handling.allium`
- `spec/tui-input-autocomplete.allium`
- `spec/tui-input-history.allium`
- `spec/tui-input-interrupts.allium`

## What changed
- Added explicit prompt-input state model for autocomplete/history/timing.
- Implemented contextual autocomplete behavior for `/`, `@`, and `Tab` path completion.
- Implemented history recording + Up/Down browse semantics.
- Added/updated focused regression coverage in TUI app tests.

## Design notes
- Input behavior is modeled as explicit state transitions in TUI app state.
- History entries are normalized, deduped (consecutive), and capped.
- Autocomplete lifecycle is deterministic and context-aware.

## Commits
- 2bf6b39 ⚒ Implement Task #50 autocomplete parity (/ @ Tab)
- 04be5a3 ⚒ Implement Task #51 prompt history recording and browse semantics

## Additional context
Story token/context provided: `39`.