### PR TITLE
feat: Implement Step 7 graph emergence capability graph via EQL

### DIFF
--- a/components/engine/src/psi/engine/core.clj
+++ b/components/engine/src/psi/engine/core.clj
@@ -270,6 +270,22 @@
       (swap! ss assoc component-key ready?)
       @ss)))
 
+(defn set-evolution-stage-in!
+  "Set system evolution stage in `ctx`.
+   Stage must satisfy `evolution-stage-schema`."
+  [ctx stage]
+  (when-not (m/validate evolution-stage-schema stage)
+    (throw (ex-info "Invalid evolution stage"
+                    {:stage stage
+                     :validation-errors (explain-validation-error
+                                         evolution-stage-schema stage)})))
+  (let [ss (:system-state ctx)]
+    (when @ss
+      (swap! ss assoc
+             :evolution-stage stage
+             :last-updated (java.time.Instant/now))
+      @ss)))
+
 (defn system-has-interface-in?
   "Check if system in `ctx` has complete interface (engine + query ready)."
   [ctx]

--- a/components/introspection/src/psi/introspection/core.clj
+++ b/components/introspection/src/psi/introspection/core.clj
@@ -38,9 +38,11 @@
      query-engine-detail-in        — single-engine diagnostics (ctx)
      query-agent-session-in        — EQL query over :psi.agent-session/* (ctx, q)"
   (:require
+   [psi.introspection.graph :as graph]
    [psi.introspection.resolvers :as resolvers]
    [psi.engine.core :as engine]
    [psi.query.core :as query]
+   [psi.query.registry :as registry]
    [psi.ai.core :as ai]
    [psi.history.resolvers :as history-resolvers]
    [psi.agent-session.core :as agent-session]
@@ -109,6 +111,35 @@
 ;; Context-aware helpers
 ;; ─────────────────────────────────────────────────────────────────────────────
 
+(defn reconcile-graph-readiness-in!
+  "Derive Step 7 graph readiness from computed graph shape and update engine state.
+
+   Ready gate:
+   - node-count > 0
+   - edge-count > 0
+
+   Stage semantics:
+   - ready => :integrating
+   - not ready => :developing"
+  [ctx]
+  (let [qctx    (:query-ctx ctx)
+        ectx    (:engine-ctx ctx)
+        cgraph  (graph/derive-capability-graph
+                 {:resolver-ops (mapv #(graph/operation->metadata :resolver %)
+                                      (registry/all-resolvers-in (:reg qctx)))
+                  :mutation-ops (mapv #(graph/operation->metadata :mutation %)
+                                      (registry/all-mutations-in (:reg qctx)))})
+        ready?  (and (pos? (count (:nodes cgraph)))
+                     (pos? (count (:edges cgraph))))
+        stage   (if ready? :integrating :developing)]
+    (engine/update-system-component-in! ectx :query-ready true)
+    (engine/update-system-component-in! ectx :graph-ready ready?)
+    (engine/set-evolution-stage-in! ectx stage)
+    {:graph-ready ready?
+     :evolution-stage stage
+     :node-count (count (:nodes cgraph))
+     :edge-count (count (:edges cgraph))}))
+
 (defn register-resolvers-in!
   "Register Step 7 startup domains into `ctx`'s query context and rebuild once.
 
@@ -120,7 +151,11 @@
 
    If `ctx` carries an :agent-session-ctx, agent-session resolvers + mutations
    are also registered so :psi.agent-session/* and mutation-backed workflows are
-   queryable/executable."
+   queryable/executable.
+
+   Also derives and applies runtime Step 7 readiness:
+   - :graph-ready true when graph has nodes and edges, else false
+   - :evolution-stage set to :integrating when ready, else :developing"
   [ctx]
   (let [qctx (:query-ctx ctx)]
     ;; AI resolvers
@@ -141,7 +176,8 @@
       (agent-session/register-mutations-in! qctx false))
 
     ;; Single env rebuild after all operations are registered.
-    (query/rebuild-env-in! qctx)))
+    (query/rebuild-env-in! qctx)
+    (reconcile-graph-readiness-in! ctx)))
 
 (defn query-system-state-in
   "Return system state + derived properties via EQL using `ctx`."

--- a/components/introspection/src/psi/introspection/core.clj
+++ b/components/introspection/src/psi/introspection/core.clj
@@ -41,6 +41,8 @@
    [psi.introspection.resolvers :as resolvers]
    [psi.engine.core :as engine]
    [psi.query.core :as query]
+   [psi.ai.core :as ai]
+   [psi.history.resolvers :as history-resolvers]
    [psi.agent-session.core :as agent-session]
    [psi.agent-session.resolvers :as as-resolvers]))
 
@@ -49,15 +51,33 @@
 ;; ─────────────────────────────────────────────────────────────────────────────
 
 (defn register-resolvers!
-  "Register all introspection + agent-session resolvers, plus agent-session
-   mutations, into the global query graph. Rebuilds env once at the end."
+  "Register Step 7 startup domains into the global query graph and rebuild once.
+
+   Domains:
+   - AI resolvers
+   - History resolvers
+   - Introspection resolvers
+   - Agent-session resolvers + mutations"
   []
+  ;; AI resolvers (register directly to avoid per-domain env rebuilds)
+  (query/register-resolver! ai/ai-model-resolver)
+  (query/register-resolver! ai/ai-model-list-resolver)
+  (query/register-resolver! ai/ai-provider-models-resolver)
+  (query/register-resolver! ai/ai-provider-registry-resolver)
+
+  ;; History + Introspection + Agent-session resolvers
+  (doseq [r history-resolvers/all-resolvers]
+    (query/register-resolver! r))
   (doseq [r resolvers/all-resolvers]
     (query/register-resolver! r))
   (doseq [r as-resolvers/all-resolvers]
     (query/register-resolver! r))
+
+  ;; Agent-session mutations
   (doseq [m agent-session/all-mutations]
     (query/register-mutation! m))
+
+  ;; Single env rebuild after all operations are registered.
   (query/rebuild-env!))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
@@ -90,20 +110,37 @@
 ;; ─────────────────────────────────────────────────────────────────────────────
 
 (defn register-resolvers-in!
-  "Register introspection resolvers (and optionally agent-session operations)
-   into `ctx`'s query context, then rebuild env once.
+  "Register Step 7 startup domains into `ctx`'s query context and rebuild once.
+
+   Domains:
+   - AI resolvers
+   - History resolvers
+   - Introspection resolvers
+   - Agent-session resolvers + mutations (when :agent-session-ctx is present)
 
    If `ctx` carries an :agent-session-ctx, agent-session resolvers + mutations
    are also registered so :psi.agent-session/* and mutation-backed workflows are
    queryable/executable."
   [ctx]
   (let [qctx (:query-ctx ctx)]
+    ;; AI resolvers
+    (query/register-resolver-in! qctx ai/ai-model-resolver)
+    (query/register-resolver-in! qctx ai/ai-model-list-resolver)
+    (query/register-resolver-in! qctx ai/ai-provider-models-resolver)
+    (query/register-resolver-in! qctx ai/ai-provider-registry-resolver)
+
+    ;; History + Introspection resolvers
+    (doseq [r history-resolvers/all-resolvers]
+      (query/register-resolver-in! qctx r))
     (doseq [r resolvers/all-resolvers]
       (query/register-resolver-in! qctx r))
+
     (when (:agent-session-ctx ctx)
       ;; Pass rebuild?=false — we rebuild once below after all operations are in.
       (agent-session/register-resolvers-in! qctx false)
       (agent-session/register-mutations-in! qctx false))
+
+    ;; Single env rebuild after all operations are registered.
     (query/rebuild-env-in! qctx)))
 
 (defn query-system-state-in

--- a/components/introspection/src/psi/introspection/core.clj
+++ b/components/introspection/src/psi/introspection/core.clj
@@ -173,7 +173,7 @@
                     [:psi.engine/recent-transitions])))
 
 (defn query-graph-summary-in
-  "Return query graph statistics via EQL using `ctx`."
+  "Return query graph statistics and Step 7 capability graph attrs via EQL using `ctx`."
   [ctx]
   (let [{:keys [query-ctx]} ctx]
     (query/query-in query-ctx {:psi/query-ctx query-ctx}
@@ -181,7 +181,11 @@
                      :psi.graph/mutation-count
                      :psi.graph/resolver-syms
                      :psi.graph/mutation-syms
-                     :psi.graph/env-built])))
+                     :psi.graph/env-built
+                     :psi.graph/nodes
+                     :psi.graph/edges
+                     :psi.graph/capabilities
+                     :psi.graph/domain-coverage])))
 
 (defn query-all-engines-in
   "Return all registered engines and count via EQL using `ctx`."

--- a/components/introspection/src/psi/introspection/graph.clj
+++ b/components/introspection/src/psi/introspection/graph.clj
@@ -1,0 +1,167 @@
+(ns psi.introspection.graph
+  "Pure Step 7 capability-graph derivation helpers.
+
+   The functions in this namespace operate on operation metadata and return
+   deterministic graph shapes for introspection resolvers.
+
+   Node types in Step 7 are restricted to:
+   - :resolver
+   - :mutation
+   - :capability
+
+   Attribute links are represented as edge metadata (:attribute), not nodes.
+   Mutation side effects are deferred in Step 7 and are represented as nil.
+  "
+  (:require
+   [clojure.string :as str]
+   [com.wsscode.pathom3.connect.operation :as pco]))
+
+(def required-domains
+  "Required Step 7 domains for graph emergence."
+  [:ai :history :agent-session :introspection])
+
+(defn classify-domain
+  "Classify an operation symbol into a Step 7 domain keyword."
+  [op-sym]
+  (let [n (namespace op-sym)]
+    (cond
+      (str/starts-with? n "psi.ai") :ai
+      (str/starts-with? n "psi.history") :history
+      (str/starts-with? n "psi.introspection") :introspection
+      (or (str/starts-with? n "psi.agent-session")
+          (str/starts-with? n "psi.extension")) :agent-session
+      :else :unknown)))
+
+(defn operation->metadata
+  "Extract normalized metadata from a Pathom operation.
+
+   Returns map keys:
+   - :op-type   (:resolver | :mutation)
+   - :symbol    qualified symbol
+   - :input     vector
+   - :output    vector
+   - :params    vector"
+  [op-type operation]
+  (let [cfg (pco/operation-config operation)]
+    {:op-type op-type
+     :symbol  (::pco/op-name cfg)
+     :input   (vec (or (::pco/input cfg) []))
+     :output  (vec (or (::pco/output cfg) []))
+     :params  (vec (or (::pco/params cfg) []))}))
+
+(defn operation-node-id
+  [{:keys [op-type symbol]}]
+  (str (name op-type) ":" symbol))
+
+(defn capability-node-id
+  [domain]
+  (str "capability:" (name domain)))
+
+(defn domain-operation
+  "Build a normalized domain operation record from operation metadata."
+  [{:keys [op-type symbol input output params] :as op}]
+  (let [domain      (classify-domain symbol)
+        io-attrs    (vec (distinct (concat input output params)))
+        operation-id (operation-node-id op)]
+    {:id          operation-id
+     :symbol      symbol
+     :domain      domain
+     :type        op-type
+     :io          {:input input :output output :params params}
+     :attributes  io-attrs
+     :sideEffects (when (= op-type :mutation) nil)}))
+
+(defn derive-domain-operations
+  "Derive sorted domain operation records from resolver/mutation metadata."
+  [{:keys [resolver-ops mutation-ops]}]
+  (->> (concat resolver-ops mutation-ops)
+       (map domain-operation)
+       (sort-by (comp str :symbol))
+       vec))
+
+(defn derive-capabilities
+  "Derive capability summaries grouped by domain."
+  [domain-ops]
+  (->> domain-ops
+       (group-by :domain)
+       (map (fn [[domain ops]]
+              {:id               (capability-node-id domain)
+               :domain           domain
+               :operation-count  (count ops)
+               :resolver-count   (count (filter #(= :resolver (:type %)) ops))
+               :mutation-count   (count (filter #(= :mutation (:type %)) ops))
+               :operation-symbols (vec (map :symbol ops))
+               :attributes       (vec (distinct (mapcat :attributes ops)))}))
+       (sort-by (comp str :domain))
+       vec))
+
+(defn derive-nodes
+  "Derive graph nodes (resolver/mutation/capability only)."
+  [domain-ops capabilities]
+  (vec
+   (concat
+    (map (fn [{:keys [id symbol domain type sideEffects]}]
+           (cond-> {:id id :type type :symbol symbol :domain domain}
+             (= type :mutation) (assoc :sideEffects sideEffects)))
+         domain-ops)
+    (map (fn [{:keys [id domain operation-count]}]
+           {:id id :type :capability :domain domain :operation-count operation-count})
+         capabilities))))
+
+(defn derive-edges
+  "Derive operation→capability edges with :attribute edge metadata.
+
+   For operations with no IO attrs, emits one edge with nil :attribute so
+   graph linkage is still explicit."
+  [domain-ops]
+  (->> domain-ops
+       (mapcat (fn [{:keys [id domain attributes]}]
+                 (let [cap-id (capability-node-id domain)
+                       attrs  (seq attributes)]
+                   (if attrs
+                     (map (fn [attr]
+                            {:from id :to cap-id :attribute attr})
+                          attrs)
+                     [{:from id :to cap-id :attribute nil}]))))
+       vec))
+
+(defn derive-domain-coverage
+  "Derive deterministic domain coverage summary.
+
+   Includes required Step 7 domains even when they have zero operations."
+  [domain-ops]
+  (let [grouped        (group-by :domain domain-ops)
+        present-domains (set (keys grouped))
+        ordered-domains (vec (concat required-domains
+                                     (sort (remove (set required-domains)
+                                                   present-domains))))]
+    (mapv (fn [domain]
+            (let [ops (get grouped domain [])]
+              {:domain          domain
+               :resolver-count  (count (filter #(= :resolver (:type %)) ops))
+               :mutation-count  (count (filter #(= :mutation (:type %)) ops))
+               :operation-count (count ops)}))
+          ordered-domains)))
+
+(defn derive-capability-graph
+  "Derive complete Step 7 capability graph structure from operation metadata.
+
+   Input map:
+   {:resolver-ops [{:op-type :resolver ...}]
+    :mutation-ops [{:op-type :mutation ...}]}
+
+   Returns:
+   {:domain-operations [...]
+    :nodes [...]
+    :edges [...]
+    :capabilities [...]
+    :domain-coverage [...]}"
+  [{:keys [resolver-ops mutation-ops] :as operation-metadata}]
+  (let [domain-ops    (derive-domain-operations operation-metadata)
+        capabilities  (derive-capabilities domain-ops)]
+    {:domain-operations domain-ops
+     :nodes             (derive-nodes domain-ops capabilities)
+     :edges             (derive-edges domain-ops)
+     :capabilities      capabilities
+     :domain-coverage   (derive-domain-coverage domain-ops)
+     :operation-count   (+ (count resolver-ops) (count mutation-ops))}))

--- a/components/introspection/src/psi/introspection/resolvers.clj
+++ b/components/introspection/src/psi/introspection/resolvers.clj
@@ -49,7 +49,9 @@
   (:require
    [com.wsscode.pathom3.connect.operation :as pco]
    [psi.engine.core :as engine]
-   [psi.query.core :as query]))
+   [psi.introspection.graph :as graph]
+   [psi.query.core :as query]
+   [psi.query.registry :as registry]))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Engine / System resolvers
@@ -119,21 +121,43 @@
 ;; Query graph resolvers
 ;; ─────────────────────────────────────────────────────────────────────────────
 
+(defn- operation-metadata-in
+  "Collect normalized resolver/mutation metadata for the current query registry."
+  [query-ctx]
+  {:resolver-ops (mapv #(graph/operation->metadata :resolver %)
+                       (registry/all-resolvers-in (:reg query-ctx)))
+   :mutation-ops (mapv #(graph/operation->metadata :mutation %)
+                       (registry/all-mutations-in (:reg query-ctx)))})
+
+(defn- capability-graph-in
+  "Derive Step 7 capability graph entities from current query registry."
+  [query-ctx]
+  (graph/derive-capability-graph (operation-metadata-in query-ctx)))
+
 (pco/defresolver query-graph-summary
-  "Resolve query graph statistics from a :psi/query-ctx."
+  "Resolve query graph statistics and Step 7 capability graph attrs from :psi/query-ctx."
   [{:keys [psi/query-ctx]}]
   {::pco/input  [:psi/query-ctx]
    ::pco/output [:psi.graph/resolver-count
                  :psi.graph/mutation-count
                  :psi.graph/resolver-syms
                  :psi.graph/mutation-syms
-                 :psi.graph/env-built]}
-  (let [summary (query/graph-summary-in query-ctx)]
+                 :psi.graph/env-built
+                 :psi.graph/nodes
+                 :psi.graph/edges
+                 :psi.graph/capabilities
+                 :psi.graph/domain-coverage]}
+  (let [summary (query/graph-summary-in query-ctx)
+        cgraph  (capability-graph-in query-ctx)]
     {:psi.graph/resolver-count (:resolver-count summary)
      :psi.graph/mutation-count (:mutation-count summary)
      :psi.graph/resolver-syms  (:resolvers summary)
      :psi.graph/mutation-syms  (:mutations summary)
-     :psi.graph/env-built      (:env-built? summary)}))
+     :psi.graph/env-built      (:env-built? summary)
+     :psi.graph/nodes          (:nodes cgraph)
+     :psi.graph/edges          (:edges cgraph)
+     :psi.graph/capabilities   (:capabilities cgraph)
+     :psi.graph/domain-coverage (:domain-coverage cgraph)}))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; All resolvers

--- a/components/introspection/test/psi/introspection/agent_session_test.clj
+++ b/components/introspection/test/psi/introspection/agent_session_test.clj
@@ -56,6 +56,12 @@
       (let [result  (introspection/query-graph-summary-in ctx)
             r-syms  (:psi.graph/resolver-syms result)
             m-syms  (:psi.graph/mutation-syms result)]
+        (is (true? (:psi.graph/env-built result))
+            "graph env should be built after registration")
+        (is (contains? r-syms 'psi.ai.core/ai-model-list-resolver)
+            "AI resolver should appear in graph summary")
+        (is (contains? r-syms 'psi.history.resolvers/git-repo-status)
+            "History resolver should appear in graph summary")
         (is (contains? r-syms 'psi.agent-session.resolvers/agent-session-identity)
             "identity resolver should appear in graph summary")
         (is (contains? r-syms 'psi.agent-session.resolvers/agent-session-phase)

--- a/components/introspection/test/psi/introspection/core_test.clj
+++ b/components/introspection/test/psi/introspection/core_test.clj
@@ -52,8 +52,8 @@
       (testing ":psi.system/mode is a keyword"
         (is (keyword? (:psi.system/mode result))))
 
-      (testing ":psi.system/evolution-stage is :bootstrap"
-        (is (= :bootstrap (:psi.system/evolution-stage result))))
+      (testing ":psi.system/evolution-stage is :integrating after graph emergence"
+        (is (= :integrating (:psi.system/evolution-stage result))))
 
       (testing ":psi.system/readiness contains expected keys"
         (let [readiness (:psi.system/readiness result)]
@@ -64,7 +64,10 @@
       (testing "has-substrate is true after bootstrap"
         (is (true? (:psi.system/has-substrate result))))
 
-      (testing "is-ai-complete is false at bootstrap stage"
+      (testing "readiness includes derived :graph-ready true"
+        (is (true? (get-in result [:psi.system/readiness :graph-ready]))))
+
+      (testing "is-ai-complete is false at integrating stage"
         (is (false? (:psi.system/is-ai-complete result)))))))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
@@ -213,18 +216,28 @@
 ;; ─────────────────────────────────────────────────────────────────────────────
 
 (deftest derived-properties-test
-  (testing "Derived system properties update as components become ready"
+  (testing "Derived system properties reflect Step 7 readiness reconciliation"
     (let [ctx        (bootstrapped-ctx)
           engine-ctx (:engine-ctx ctx)]
 
-      ;; Initially only engine is ready (bootstrap marks engine-ready=true)
+      ;; Bootstrapped introspection registration derives query+graph readiness.
       (let [r1 (introspection/query-system-state-in ctx)]
-        (is (false? (:psi.system/has-interface r1))
-            "No interface before query is marked ready"))
+        (is (true? (:psi.system/has-interface r1))
+            "Has interface when engine + query both ready")
+        (is (true? (get-in r1 [:psi.system/readiness :graph-ready]))
+            "graph-ready should be true when graph has nodes+edges")
+        (is (= :integrating (:psi.system/evolution-stage r1))
+            "evolution stage should be integrating when graph emerges"))
 
-      ;; Mark query as ready too
-      (engine/update-system-component-in! engine-ctx :query-ready true)
+      ;; Negative path: clear readiness flags and set emerging semantics.
+      (engine/update-system-component-in! engine-ctx :query-ready false)
+      (engine/update-system-component-in! engine-ctx :graph-ready false)
+      (engine/set-evolution-stage-in! engine-ctx :developing)
 
       (let [r2 (introspection/query-system-state-in ctx)]
-        (is (true? (:psi.system/has-interface r2))
-            "Has interface when engine + query both ready")))))
+        (is (false? (:psi.system/has-interface r2))
+            "No interface after query-ready is cleared")
+        (is (false? (get-in r2 [:psi.system/readiness :graph-ready]))
+            "graph-ready should be false when gate does not hold")
+        (is (= :developing (:psi.system/evolution-stage r2))
+            "evolution stage should reflect emerging semantics")))))

--- a/components/introspection/test/psi/introspection/core_test.clj
+++ b/components/introspection/test/psi/introspection/core_test.clj
@@ -149,8 +149,9 @@
 
 (deftest query-graph-summary-test
   (testing "Query graph statistics are queryable"
-    (let [ctx    (bootstrapped-ctx)
-          result (introspection/query-graph-summary-in ctx)]
+    (let [ctx     (bootstrapped-ctx)
+          result  (introspection/query-graph-summary-in ctx)
+          result2 (introspection/query-graph-summary-in ctx)]
 
       (testing ":psi.graph/resolver-count includes introspection resolvers"
         (is (pos? (:psi.graph/resolver-count result))))
@@ -173,7 +174,26 @@
               "Introspection resolver should be present")))
 
       (testing ":psi.graph/mutation-count is a non-negative integer"
-        (is (nat-int? (:psi.graph/mutation-count result)))))))
+        (is (nat-int? (:psi.graph/mutation-count result))))
+
+      (testing "Step 7 capability graph attrs are exposed"
+        (is (vector? (:psi.graph/nodes result)))
+        (is (vector? (:psi.graph/edges result)))
+        (is (vector? (:psi.graph/capabilities result)))
+        (is (vector? (:psi.graph/domain-coverage result))))
+
+      (testing "domain coverage includes required domains"
+        (let [domains (set (map :domain (:psi.graph/domain-coverage result)))]
+          (is (contains? domains :ai))
+          (is (contains? domains :history))
+          (is (contains? domains :agent-session))
+          (is (contains? domains :introspection))))
+
+      (testing "repeated queries are deterministic for graph attrs"
+        (is (= (:psi.graph/nodes result) (:psi.graph/nodes result2)))
+        (is (= (:psi.graph/edges result) (:psi.graph/edges result2)))
+        (is (= (:psi.graph/capabilities result) (:psi.graph/capabilities result2)))
+        (is (= (:psi.graph/domain-coverage result) (:psi.graph/domain-coverage result2)))))))
 
 (deftest graph-self-describes-test
   (testing "Introspection resolvers appear in the graph summary"

--- a/components/introspection/test/psi/introspection/core_test.clj
+++ b/components/introspection/test/psi/introspection/core_test.clj
@@ -163,6 +163,15 @@
       (testing ":psi.graph/env-built is true"
         (is (true? (:psi.graph/env-built result))))
 
+      (testing "Step 7 startup domains are registered in same graph"
+        (let [syms (:psi.graph/resolver-syms result)]
+          (is (contains? syms 'psi.ai.core/ai-model-list-resolver)
+              "AI resolver should be present")
+          (is (contains? syms 'psi.history.resolvers/git-repo-status)
+              "History resolver should be present")
+          (is (contains? syms 'psi.introspection.resolvers/query-graph-summary)
+              "Introspection resolver should be present")))
+
       (testing ":psi.graph/mutation-count is a non-negative integer"
         (is (nat-int? (:psi.graph/mutation-count result)))))))
 

--- a/components/introspection/test/psi/introspection/graph_test.clj
+++ b/components/introspection/test/psi/introspection/graph_test.clj
@@ -1,0 +1,60 @@
+(ns psi.introspection.graph-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [psi.introspection.core :as introspection]
+   [psi.introspection.graph :as graph]
+   [psi.engine.core :as engine]
+   [psi.agent-session.core :as agent-session]
+   [psi.query.registry :as registry]))
+
+(defn- operation-metadata
+  []
+  (let [session-ctx (agent-session/create-context)
+        ctx         (introspection/create-context {:agent-session-ctx session-ctx})
+        qctx        (:query-ctx ctx)]
+    (engine/bootstrap-system-in! (:engine-ctx ctx))
+    (introspection/register-resolvers-in! ctx)
+    {:resolver-ops (mapv #(graph/operation->metadata :resolver %)
+                         (registry/all-resolvers-in (:reg qctx)))
+     :mutation-ops (mapv #(graph/operation->metadata :mutation %)
+                         (registry/all-mutations-in (:reg qctx)))}))
+
+(deftest classify-domain-test
+  (testing "domain classification maps required Step 7 domains"
+    (is (= :ai (graph/classify-domain 'psi.ai.core/ai-model-resolver)))
+    (is (= :history (graph/classify-domain 'psi.history.resolvers/git-log)))
+    (is (= :introspection (graph/classify-domain 'psi.introspection.resolvers/query-graph-summary)))
+    (is (= :agent-session (graph/classify-domain 'psi.agent-session.core/add-prompt-template)))
+    (is (= :agent-session (graph/classify-domain 'psi.extension/add-prompt-template)))))
+
+(deftest derive-capability-graph-deterministic-shape-test
+  (testing "capability graph derivation is deterministic and Step 7-constrained"
+    (let [ops    (operation-metadata)
+          g1     (graph/derive-capability-graph ops)
+          g2     (graph/derive-capability-graph ops)
+          types  (set (map :type (:nodes g1)))]
+
+      (is (= g1 g2) "graph derivation should be deterministic for same inputs")
+
+      (testing "node types are limited to resolver/mutation/capability"
+        (is (= #{:resolver :mutation :capability} types)))
+
+      (testing "at least one edge includes non-nil :attribute metadata"
+        (is (some :attribute (:edges g1))))
+
+      (testing "mutation-derived operations have deferred sideEffects=nil"
+        (let [mutation-ops (filter #(= :mutation (:type %)) (:domain-operations g1))]
+          (is (seq mutation-ops))
+          (is (every? #(contains? % :sideEffects) mutation-ops))
+          (is (every? #(nil? (:sideEffects %)) mutation-ops)))))))
+
+(deftest domain-coverage-includes-required-domains-test
+  (testing "domain coverage always includes required Step 7 domains"
+    (let [coverage (-> (operation-metadata)
+                       (graph/derive-capability-graph)
+                       :domain-coverage)
+          by-domain (into {} (map (juxt :domain identity) coverage))]
+      (is (contains? by-domain :ai))
+      (is (contains? by-domain :history))
+      (is (contains? by-domain :agent-session))
+      (is (contains? by-domain :introspection)))))


### PR DESCRIPTION
## Summary
Implement Step 7 graph emergence capability graph via EQL.

This story makes the query graph self-describing so ψ/tooling can discover runtime capabilities via EQL instead of hardcoded assumptions.

## What changed
- Step 7 startup registration now batches AI, history, introspection, and agent-session operations into one env rebuild.
- Added deterministic capability graph derivation from operation metadata (nodes, edges, capabilities, domain coverage).
- Exposed new EQL graph attributes:
  - `:psi.graph/nodes`
  - `:psi.graph/edges`
  - `:psi.graph/capabilities`
  - `:psi.graph/domain-coverage`
- Derived runtime `:graph-ready` from computed graph shape with stage semantics (`:integrating` when nodes+edges, otherwise `:developing`).
- Expanded focused tests around derivation shape, domain coverage, readiness transitions, and resolver exposure.

## Step 7 decisions preserved
- Attribute links represented as edge metadata (`:attribute`) not attribute nodes.
- Mutation side-effects remain deferred (`sideEffects = nil`).
- Required domains covered: `ai`, `history`, `agent-session`, `introspection`.

## Commit summary
- `2da2611` ⚒ Step 7 startup wiring: register AI/history with introspection graph
- `ef12bad` ⚒ Step 7 λ expose capability graph attrs via EQL (Task 57)

## Verification
- `clojure -M:test --focus psi.introspection.core-test --focus psi.introspection.agent-session-test`
- Focused graph derivation tests added under `psi.introspection.graph-test`