### PR TITLE
feat: Implement rpc-edn runtime transport and protocol handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ clojure -M:run --model claude-3-5-sonnet
 # Terminal UI
 clojure -M:run --tui
 
+# EDN-lines RPC mode (protocol frames on stdout)
+clojure -M:run --rpc-edn
+
 # OpenAI
 clojure -M:run --model gpt-4o --tui
 

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -698,6 +698,17 @@
 ;; -main
 ;; ============================================================
 
+(defn- run-rpc-edn-session!
+  "Run RPC EDN transport bound to a live AgentSession context."
+  []
+  (let [ctx (session/create-context)
+        state (atom {:handshake-server-info-fn (fn [] (rpc/session->handshake-server-info ctx))
+                     :subscribed-topics #{}})
+        request-handler (rpc/make-session-request-handler ctx)]
+    (reset! session-state {:ctx ctx})
+    (rpc/run-stdio-loop! {:request-handler request-handler
+                          :state state})))
+
 (defn -main
   "Entry point. Accepts optional --model <key>, --log-level <LEVEL>, --tui, --rpc-edn, --nrepl [port]."
   [& args]
@@ -711,7 +722,7 @@
     (try
       (cond
         rpc-edn?
-        (rpc/run-stdio-loop! {})
+        (run-rpc-edn-session!)
 
         tui?
         (run-tui-session model-key)

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -676,6 +676,14 @@
                      :ui-state-atom        (:ui-state-atom ctx)
                      :dispatch-fn          dispatch-fn
                      :on-interrupt-fn!     on-interrupt-fn!
+                     :on-queue-input-fn!   (fn [text _state]
+                                              (if (= :streaming (session/sc-phase-in ctx))
+                                                (do
+                                                  (session/steer-in! ctx text)
+                                                  {:message "Queued steering message."})
+                                                (do
+                                                  (session/follow-up-in! ctx text)
+                                                  {:message "Queued follow-up message."})))
                      :double-press-window-ms 500
                      :double-escape-action :none
                      :cwd                  cwd

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -6,6 +6,7 @@
      clojure -M:run --model sonnet-4.6
      clojure -M:run --log-level DEBUG
      clojure -M:run --tui
+     clojure -M:run --rpc-edn         # EDN-lines RPC on stdin/stdout
      clojure -M:run --nrepl            # random port
      clojure -M:run --nrepl 7888       # specific port
      clojure -M:run --tui --nrepl      # TUI + nREPL
@@ -46,6 +47,7 @@
    [psi.agent-session.extensions :as ext]
    [psi.agent-session.oauth.core :as oauth]
    [psi.agent-session.prompt-templates :as pt]
+   [psi.agent-session.rpc :as rpc]
    [psi.agent-session.skills :as skills]
    [psi.agent-session.system-prompt :as sys-prompt]
    [psi.agent-session.tools :as tools]
@@ -697,16 +699,24 @@
 ;; ============================================================
 
 (defn -main
-  "Entry point. Accepts optional --model <key>, --log-level <LEVEL>, --tui, --nrepl [port]."
+  "Entry point. Accepts optional --model <key>, --log-level <LEVEL>, --tui, --rpc-edn, --nrepl [port]."
   [& args]
   (set-log-level! (log-level-from-args args))
   (let [model-key  (model-key-from-args args)
         tui?       (some #(= "--tui" %) args)
+        rpc-edn?   (some #(= "--rpc-edn" %) args)
         nrepl-port (nrepl-port-from-args args)
-        nrepl-srv  (when nrepl-port (start-nrepl! nrepl-port))]
+        nrepl-srv  (when (and nrepl-port (not rpc-edn?))
+                     (start-nrepl! nrepl-port))]
     (try
-      (if tui?
+      (cond
+        rpc-edn?
+        (rpc/run-stdio-loop! {})
+
+        tui?
         (run-tui-session model-key)
+
+        :else
         (run-session model-key))
       (finally
         (stop-nrepl! nrepl-srv)))

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -701,9 +701,14 @@
 (defn- run-rpc-edn-session!
   "Run RPC EDN transport bound to a live AgentSession context."
   []
-  (let [ctx (session/create-context)
-        state (atom {:handshake-server-info-fn (fn [] (rpc/session->handshake-server-info ctx))
-                     :subscribed-topics #{}})
+  (let [ai-model (resolve-model default-model-key)
+        ctx      (session/create-context
+                  {:initial-session {:model {:provider (name (:provider ai-model))
+                                             :id (:id ai-model)
+                                             :reasoning (:supports-reasoning ai-model)}}})
+        state    (atom {:handshake-server-info-fn (fn [] (rpc/session->handshake-server-info ctx))
+                        :subscribed-topics #{}
+                        :rpc-ai-model ai-model})
         request-handler (rpc/make-session-request-handler ctx)]
     (reset! session-state {:ctx ctx})
     (rpc/run-stdio-loop! {:request-handler request-handler

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -11,6 +11,7 @@
    [clojure.string :as str]))
 
 (def protocol-version "1.0")
+(def ^:private default-max-pending-requests 64)
 
 (def ^:private request-required-keys #{:id :kind :op})
 (def ^:private request-allowed-keys  #{:id :kind :op :params})
@@ -103,10 +104,6 @@
   [request]
   (let [op (:op request)]
     (case op
-      "handshake"
-      (response-frame (:id request) "handshake" true
-                      {:server-info {:protocol-version protocol-version}})
-
       "ping"
       (response-frame (:id request) "ping" true {:pong true :protocol-version protocol-version})
 
@@ -114,6 +111,134 @@
                     :op            (:op request)
                     :error-code    "request/op-not-supported"
                     :error-message (str "unsupported op: " op)}))))
+
+(defn- valid-request-id? [id]
+  (and (string? id) (not (str/blank? id))))
+
+(defn- valid-request-op? [op]
+  (and (string? op) (not (str/blank? op))))
+
+(defn- terminal-frame? [frame]
+  (contains? #{:response :error} (normalize-kind (:kind frame))))
+
+(defn- clear-pending-if-terminal! [state frame]
+  (when-let [id (:id frame)]
+    (when (and (string? id) (terminal-frame? frame))
+      (swap! state update :pending dissoc id))))
+
+(defn- make-tracked-emitter [emit-frame! state]
+  (fn emit-tracked! [frame]
+    (emit-frame! frame)
+    (clear-pending-if-terminal! state frame)))
+
+(defn- request-error
+  [request error-code error-message]
+  (error-frame {:id            (:id request)
+                :op            (:op request)
+                :error-code    error-code
+                :error-message error-message}))
+
+(defn- protocol-major [version]
+  (when (string? version)
+    (some->> (re-find #"^(\d+)(?:\..*)?$" version)
+             second
+             Integer/parseInt)))
+
+(defn- handle-handshake! [request state]
+  (let [version (or (get-in request [:params :client-info :protocol-version])
+                    (get-in request [:params :protocol-version]))
+        major   (protocol-major version)]
+    (cond
+      (not (string? version))
+      (request-error request
+                     "request/invalid-params"
+                     "handshake requires :params :client-info :protocol-version string")
+
+      (not= 1 major)
+      (request-error request
+                     "protocol/unsupported-version"
+                     (str "unsupported protocol major: " (or major "unknown")))
+
+      :else
+      (do
+        (swap! state assoc
+               :ready? true
+               :negotiated-protocol-version protocol-version)
+        (response-frame (:id request)
+                        "handshake"
+                        true
+                        {:server-info {:protocol-version protocol-version}})))))
+
+(defn- accept-request!
+  "Register a request as pending when valid and capacity allows.
+   Returns {:ok true} or {:error <canonical-error-frame>}"
+  [request state]
+  (let [id      (:id request)
+        op      (:op request)
+        pending (:pending @state)
+        max-p   (long (or (:max-pending-requests @state)
+                          default-max-pending-requests))]
+    (cond
+      (not (valid-request-id? id))
+      {:error (request-error request "request/invalid-id" "request :id must be a non-empty string")}
+
+      (not (valid-request-op? op))
+      {:error (request-error request "request/invalid-op" "request :op must be a non-empty string")}
+
+      (contains? pending id)
+      {:error (request-error request "request/invalid-id" "duplicate request :id")}
+
+      (>= (count pending) max-p)
+      {:error (request-error request "transport/max-pending-exceeded" "maximum pending requests exceeded")}
+
+      :else
+      (do
+        (swap! state update :pending assoc id op)
+        {:ok true}))))
+
+(defn- process-request!
+  [request {:keys [state request-handler emit-tracked!]}]
+  (let [op (:op request)
+        ready? (:ready? @state)]
+    (cond
+      (and (not ready?) (not= "handshake" op))
+      (emit-tracked! (request-error request
+                                    "transport/not-ready"
+                                    "handshake must complete before non-handshake requests"))
+
+      (= "handshake" op)
+      (if-let [error (:error (accept-request! request state))]
+        (emit-tracked! error)
+        (emit-tracked! (handle-handshake! request state)))
+
+      :else
+      (if-let [error (:error (accept-request! request state))]
+        (emit-tracked! error)
+        (try
+          (let [result (binding [*out* (:err @state)]
+                         (request-handler request emit-tracked! state))]
+            (cond
+              (nil? result)
+              nil
+
+              (map? result)
+              (emit-tracked! result)
+
+              (sequential? result)
+              (doseq [frame result]
+                (emit-tracked! frame))
+
+              :else
+              (emit-tracked! (error-frame {:id            (:id request)
+                                           :op            (:op request)
+                                           :error-code    "runtime/failed"
+                                           :error-message "request handler returned unsupported result type"}))))
+          (catch Throwable t
+            (emit-tracked! (error-frame {:id            (:id request)
+                                         :op            (:op request)
+                                         :error-code    "runtime/failed"
+                                         :error-message (or (ex-message t)
+                                                            "unhandled runtime exception")}))))))))
 
 (defn run-stdio-loop!
   "Run an EDN-lines RPC loop.
@@ -123,7 +248,12 @@
    - :out              java.io.Writer (default *out*)
    - :err              java.io.Writer (default *err*)
    - :request-handler  (fn [request emit-frame! state] -> frame | [frame*] | nil)
-   - :state            mutable transport state passed to request-handler"
+   - :state            mutable transport state passed to request-handler
+
+   State keys:
+   - :ready?                   handshake readiness gate (default false)
+   - :pending                  map of request-id -> op for in-flight requests
+   - :max-pending-requests     guard limit (default 64)"
   [{:keys [in out err request-handler state]
     :or   {in *in*
            out *out*
@@ -132,38 +262,22 @@
                              (default-request-handler request))
            state (atom {})}}]
   (let [reader      (java.io.BufferedReader. in)
-        emit-frame! (make-frame-writer out)
-        emit-error! (fn [error-code error-message]
-                      (emit-frame! (error-frame {:error-code error-code
-                                                 :error-message error-message})))]
-    (doseq [line (line-seq reader)]
-      (if (str/blank? line)
-        (emit-error! "transport/invalid-frame" "empty frame")
-        (let [{:keys [ok error]} (parse-request-line line)]
-          (if error
-            (emit-frame! error)
-            (try
-              (let [result (binding [*out* err]
-                             (request-handler ok emit-frame! state))]
-                (cond
-                  (nil? result)
-                  nil
-
-                  (map? result)
-                  (emit-frame! result)
-
-                  (sequential? result)
-                  (doseq [frame result]
-                    (emit-frame! frame))
-
-                  :else
-                  (emit-frame! (error-frame {:id            (:id ok)
-                                             :op            (:op ok)
-                                             :error-code    "runtime/failed"
-                                             :error-message "request handler returned unsupported result type"}))))
-              (catch Throwable t
-                (emit-frame! (error-frame {:id            (:id ok)
-                                           :op            (:op ok)
-                                           :error-code    "runtime/failed"
-                                           :error-message (or (ex-message t)
-                                                              "unhandled runtime exception")}))))))))))
+        emit-frame! (make-frame-writer out)]
+    (swap! state #(merge {:ready? false
+                          :pending {}
+                          :max-pending-requests default-max-pending-requests}
+                         %
+                         {:err err}))
+    (let [emit-tracked! (make-tracked-emitter emit-frame! state)
+          emit-error!   (fn [error-code error-message]
+                          (emit-frame! (error-frame {:error-code error-code
+                                                     :error-message error-message})))]
+      (doseq [line (line-seq reader)]
+        (if (str/blank? line)
+          (emit-error! "transport/invalid-frame" "empty frame")
+          (let [{:keys [ok error]} (parse-request-line line)]
+            (if error
+              (emit-frame! error)
+              (process-request! ok {:state           state
+                                    :request-handler request-handler
+                                    :emit-tracked!   emit-tracked!}))))))))

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -12,7 +12,10 @@
    [clojure.string :as str]
    [psi.agent-core.core :as agent]
    [psi.agent-session.core :as session]
-   [psi.ai.models :as ai-models]))
+   [psi.agent-session.executor :as executor]
+   [psi.agent-session.persistence :as persist]
+   [psi.ai.models :as ai-models]
+   [psi.tui.extension-ui :as ext-ui]))
 
 (def protocol-version "1.0")
 (def ^:private default-max-pending-requests 64)
@@ -66,12 +69,19 @@
     (some? retryable) (assoc :retryable retryable)
     (some? data)      (assoc :data data)))
 
+(defn- normalize-ts [ts]
+  (cond
+    (nil? ts) nil
+    (string? ts) ts
+    :else (str ts)))
+
 (defn event-frame
   [{:keys [event data id seq ts]}]
-  (cond-> (array-map :kind :event :event event :data data)
-    (some? id)  (assoc :id id)
-    (some? seq) (assoc :seq seq)
-    (some? ts)  (assoc :ts ts)))
+  (let [ts* (normalize-ts ts)]
+    (cond-> (array-map :kind :event :event event :data data)
+      (some? id)  (assoc :id id)
+      (some? seq) (assoc :seq seq)
+      (some? ts*) (assoc :ts ts*))))
 
 (defn- normalize-kind [k]
   (cond
@@ -308,7 +318,7 @@
     (string? provider)  (keyword provider)
     :else               nil))
 
-(defn- resolve-model
+(defn resolve-model
   [provider model-id]
   (let [provider* (normalize-provider provider)]
     (some (fn [[_ model]]
@@ -338,6 +348,249 @@
                   :error-code    code
                   :error-message message})))
 
+(def ^:private event-topics
+  #{"session/updated"
+    "session/resumed"
+    "session/rehydrated"
+    "assistant/delta"
+    "assistant/message"
+    "tool/start"
+    "tool/delta"
+    "tool/executing"
+    "tool/update"
+    "tool/result"
+    "ui/dialog-requested"
+    "ui/widgets-updated"
+    "ui/status-updated"
+    "ui/notification"
+    "footer/updated"
+    "error"})
+
+(def ^:private required-event-payload-keys
+  {"session/updated" #{:session-id :phase :is-streaming :is-compacting :pending-message-count :retry-attempt}
+   "session/resumed" #{:session-id :session-file :message-count}
+   "session/rehydrated" #{:messages :tool-calls :tool-order}
+   "assistant/delta" #{:text}
+   "assistant/message" #{:role :content}
+   "tool/start" #{:tool-id :tool-name}
+   "tool/delta" #{:tool-id :arguments}
+   "tool/executing" #{:tool-id :tool-name}
+   "tool/update" #{:tool-id :tool-name :content :result-text :is-error}
+   "tool/result" #{:tool-id :tool-name :content :result-text :is-error}
+   "ui/dialog-requested" #{:dialog-id :kind :title}
+   "ui/widgets-updated" #{:widgets}
+   "ui/status-updated" #{:statuses}
+   "ui/notification" #{:id :message :level}
+   "footer/updated" #{:path-line :stats-line}
+   "error" #{:error-code :error-message}})
+
+(defn- topic-subscribed?
+  [state topic]
+  (let [subs (:subscribed-topics @state)]
+    (or (empty? subs)
+        (contains? subs topic))))
+
+(defn- next-event-seq!
+  [state]
+  (-> (swap! state update :event-seq (fnil inc 0))
+      :event-seq))
+
+(defn- emit-event!
+  [emit-frame! state {:keys [event data id]}]
+  (when (and (contains? event-topics event)
+             (topic-subscribed? state event))
+    (let [required (get required-event-payload-keys event #{})
+          payload  (or data {})
+          missing  (seq (remove #(contains? payload %) required))]
+      (if missing
+        (emit-frame! (event-frame {:event "error"
+                                   :id id
+                                   :seq (next-event-seq! state)
+                                   :ts (java.time.Instant/now)
+                                   :data {:error-code "protocol/invalid-event-payload"
+                                          :error-message "missing required event payload keys"
+                                          :event event
+                                          :missing-keys (vec missing)}}))
+        (emit-frame! (event-frame {:event event
+                                   :data payload
+                                   :id id
+                                   :seq (next-event-seq! state)
+                                   :ts (java.time.Instant/now)}))))))
+
+(defn- normalize-level [lvl]
+  (cond
+    (keyword? lvl) (name lvl)
+    (string? lvl)  lvl
+    :else          "info"))
+
+(defn- session-updated-payload
+  [ctx]
+  (let [sd (session/get-session-data-in ctx)]
+    {:session-id            (:session-id sd)
+     :phase                 (some-> (session/sc-phase-in ctx) name)
+     :is-streaming          (boolean (:is-streaming sd))
+     :is-compacting         (boolean (:is-compacting sd))
+     :pending-message-count (+ (count (:steering-messages sd))
+                               (count (:follow-up-messages sd)))
+     :retry-attempt         (or (:retry-attempt sd) 0)}))
+
+(defn- footer-updated-payload
+  [ctx]
+  (let [sd    (session/get-session-data-in ctx)
+        phase (some-> (session/sc-phase-in ctx) name)]
+    {:path-line   (str "cwd: " (:cwd ctx))
+     :stats-line  (str "session=" (:session-id sd) " phase=" phase)
+     :status-line (when (:is-streaming sd) "streaming")}))
+
+(defn- progress-event->rpc-event
+  [progress-event]
+  (let [k (:event-kind progress-event)]
+    (case k
+      :text-delta
+      {:event "assistant/delta"
+       :data  {:text (or (:text progress-event) "")}}
+
+      :tool-start
+      {:event "tool/start"
+       :data  {:tool-id   (:tool-id progress-event)
+               :tool-name (:tool-name progress-event)}}
+
+      :tool-delta
+      {:event "tool/delta"
+       :data  {:tool-id   (:tool-id progress-event)
+               :arguments (or (:arguments progress-event) "")}}
+
+      :tool-executing
+      {:event "tool/executing"
+       :data  (cond-> {:tool-id   (:tool-id progress-event)
+                       :tool-name (:tool-name progress-event)}
+                (some? (:parsed-args progress-event)) (assoc :parsed-args (:parsed-args progress-event)))}
+
+      :tool-execution-update
+      {:event "tool/update"
+       :data  {:tool-id     (:tool-id progress-event)
+               :tool-name   (:tool-name progress-event)
+               :content     (or (:content progress-event) [])
+               :result-text (or (:result-text progress-event) "")
+               :details     (:details progress-event)
+               :is-error    (boolean (:is-error progress-event))}}
+
+      :tool-result
+      {:event "tool/result"
+       :data  {:tool-id     (:tool-id progress-event)
+               :tool-name   (:tool-name progress-event)
+               :content     (or (:content progress-event) [])
+               :result-text (or (:result-text progress-event) "")
+               :details     (:details progress-event)
+               :is-error    (boolean (:is-error progress-event))}}
+
+      nil)))
+
+(defn- emit-progress-queue!
+  [progress-q emit!]
+  (loop []
+    (when-let [evt (.poll progress-q)]
+      (when-let [{:keys [event data]} (progress-event->rpc-event evt)]
+        (emit! event data))
+      (recur))))
+
+(defn- ui-snapshot->events
+  [previous current]
+  (let [events []
+        events (if (and (not= (:active-dialog previous) (:active-dialog current))
+                        (map? (:active-dialog current)))
+                 (conj events {:event "ui/dialog-requested"
+                               :data (let [d (:active-dialog current)]
+                                       (cond-> {:dialog-id (:id d)
+                                                :kind      (some-> (:kind d) name)
+                                                :title     (:title d)}
+                                         (contains? d :message) (assoc :message (:message d))
+                                         (contains? d :options) (assoc :options (:options d))
+                                         (contains? d :placeholder) (assoc :placeholder (:placeholder d))))})
+                 events)
+        events (if (not= (:widgets previous) (:widgets current))
+                 (conj events {:event "ui/widgets-updated"
+                               :data  {:widgets (or (:widgets current) [])}})
+                 events)
+        events (if (not= (:statuses previous) (:statuses current))
+                 (conj events {:event "ui/status-updated"
+                               :data  {:statuses (or (:statuses current) [])}})
+                 events)
+        previous-notes (into {} (map (juxt :id identity) (or (:visible-notifications previous) [])))
+        current-notes  (into {} (map (juxt :id identity) (or (:visible-notifications current) [])))
+        new-notes      (remove #(contains? previous-notes (:id %)) (vals current-notes))]
+    (reduce (fn [acc n]
+              (conj acc {:event "ui/notification"
+                         :data  {:id           (:id n)
+                                 :extension-id (:extension-id n)
+                                 :message      (:message n)
+                                 :level        (normalize-level (:level n))}}))
+            events
+            new-notes)))
+
+(defn- run-prompt-async!
+  [ctx request emit-frame! state]
+  (let [message      (get-in request [:params :message])
+        images       (get-in request [:params :images])
+        request-id   (:id request)
+        run-loop-fn  (or (:run-agent-loop-fn @state) executor/run-agent-loop!)
+        progress-q   (java.util.concurrent.LinkedBlockingQueue.)
+        ui-state-atom (:ui-state-atom ctx)
+        stop?        (atom false)
+        worker       (future
+                       (binding [*out* (:err @state)
+                                 *err* (:err @state)]
+                         (let [emit! (fn [event payload]
+                                       (emit-event! emit-frame! state {:event event :data payload :id request-id}))
+                               ui-loop (future
+                                         (loop [last-snap (or (ext-ui/snapshot ui-state-atom) {})]
+                                           (when-not @stop?
+                                             (let [current (or (ext-ui/snapshot ui-state-atom) {})]
+                                               (doseq [{:keys [event data]} (ui-snapshot->events last-snap current)]
+                                                 (emit! event data))
+                                               (Thread/sleep 50)
+                                               (recur current)))))]
+                           (try
+                             (let [sd       (session/get-session-data-in ctx)
+                                   ai-model (or (when-let [provider (get-in sd [:model :provider])]
+                                                  (when-let [model-id (get-in sd [:model :id])]
+                                                    (resolve-model provider model-id)))
+                                                (:rpc-ai-model @state))
+                                   _        (when-not ai-model
+                                              (throw (ex-info "session model is not configured"
+                                                              {:error-code "request/invalid-params"})))
+                                   user-msg {:role      "user"
+                                             :content   (cond-> [{:type :text :text message}]
+                                                          (seq images) (into images))
+                                             :timestamp (java.time.Instant/now)}
+                                   _        (session/journal-append-in! ctx (persist/message-entry user-msg))
+                                   _        (emit! "session/updated" (session-updated-payload ctx))
+                                   _        (emit! "footer/updated" (footer-updated-payload ctx))
+                                   result   (run-loop-fn nil ctx (:agent-ctx ctx) ai-model [user-msg]
+                                                         {:turn-ctx-atom  (:turn-ctx-atom ctx)
+                                                          :progress-queue progress-q})]
+                               (emit-progress-queue! progress-q emit!)
+                               (emit! "assistant/message"
+                                      (cond-> {:role    (:role result)
+                                               :content (or (:content result) [])}
+                                        (contains? result :stop-reason)   (assoc :stop-reason (:stop-reason result))
+                                        (contains? result :error-message) (assoc :error-message (:error-message result))
+                                        (contains? result :usage)         (assoc :usage (:usage result))))
+                               (emit! "session/updated" (session-updated-payload ctx))
+                               (emit! "footer/updated" (footer-updated-payload ctx)))
+                             (catch Throwable t
+                               (emit! "error" {:error-code "runtime/failed"
+                                               :error-message (or (ex-message t) "prompt execution failed")
+                                               :id request-id
+                                               :op "prompt"})
+                               (emit! "session/updated" (session-updated-payload ctx))
+                               (emit! "footer/updated" (footer-updated-payload ctx)))
+                             (finally
+                               (reset! stop? true)
+                               (future-cancel ui-loop))))))]
+    (swap! state update :inflight-futures (fnil conj []) worker)
+    (response-frame (:id request) "prompt" true {:accepted true})))
+
 (defn make-session-request-handler
   "Create a canonical op router bound to an agent-session context.
 
@@ -347,7 +600,7 @@
    Runtime state mutations used by this handler:
    - :subscribed-topics (set of topic strings)"
   [ctx]
-  (fn [request _emit! state]
+  (fn [request emit-frame! state]
     (try
       (let [op     (:op request)
             params (params-map request)]
@@ -367,12 +620,8 @@
             (response-frame (:id request) op true {:result result}))
 
           "prompt"
-          (let [message (req-arg! request params :message #(and (string? %) (not (str/blank? %))) "non-empty string")
-                images  (:images params)]
-            (if (seq images)
-              (session/prompt-in! ctx message images)
-              (session/prompt-in! ctx message))
-            (response-frame (:id request) op true {:accepted true}))
+          (let [_message (req-arg! request params :message #(and (string? %) (not (str/blank? %))) "non-empty string")]
+            (run-prompt-async! ctx request emit-frame! state))
 
           "steer"
           (let [message (req-arg! request params :message #(and (string? %) (not (str/blank? %))) "non-empty string")]
@@ -390,7 +639,18 @@
             (response-frame (:id request) op true {:accepted true}))
 
           "new_session"
-          (let [sd (session/new-session-in! ctx)]
+          (let [sd (session/new-session-in! ctx)
+                msgs (:messages (agent/get-data-in (:agent-ctx ctx)))]
+            (emit-event! emit-frame! state {:event "session/resumed"
+                                            :id (:id request)
+                                            :data {:session-id   (:session-id sd)
+                                                   :session-file (:session-file sd)
+                                                   :message-count (count msgs)}})
+            (emit-event! emit-frame! state {:event "session/rehydrated"
+                                            :id (:id request)
+                                            :data {:messages msgs
+                                                   :tool-calls {}
+                                                   :tool-order []}})
             (response-frame (:id request) op true {:session-id (:session-id sd)
                                                    :session-file (:session-file sd)}))
 
@@ -399,7 +659,18 @@
             (when-not (.exists (io/file session-path))
               (throw (ex-info "session file not found"
                               {:error-code "request/not-found"})))
-            (let [sd (session/resume-session-in! ctx session-path)]
+            (let [sd   (session/resume-session-in! ctx session-path)
+                  msgs (:messages (agent/get-data-in (:agent-ctx ctx)))]
+              (emit-event! emit-frame! state {:event "session/resumed"
+                                              :id (:id request)
+                                              :data {:session-id   (:session-id sd)
+                                                     :session-file (:session-file sd)
+                                                     :message-count (count msgs)}})
+              (emit-event! emit-frame! state {:event "session/rehydrated"
+                                              :id (:id request)
+                                              :data {:messages msgs
+                                                     :tool-calls {}
+                                                     :tool-order []}})
               (response-frame (:id request) op true {:session-id (:session-id sd)
                                                      :session-file (:session-file sd)})))
 
@@ -482,7 +753,7 @@
                 _       (when-not (sequential? topics)
                           (throw (ex-info "subscribe :topics must be sequential"
                                           {:error-code "request/invalid-params"})))
-                topics* (->> topics (filter string?) set)]
+                topics* (->> topics (filter #(contains? event-topics %)) set)]
             (swap! state update :subscribed-topics (fnil into #{}) topics*)
             (response-frame (:id request) op true {:subscribed (->> (:subscribed-topics @state) sort vec)}))
 
@@ -531,7 +802,9 @@
     (swap! state #(merge {:ready? false
                           :pending {}
                           :max-pending-requests default-max-pending-requests
-                          :subscribed-topics #{}}
+                          :subscribed-topics #{}
+                          :event-seq 0
+                          :inflight-futures []}
                          %
                          {:err err}))
     (let [emit-tracked! (make-tracked-emitter emit-frame! state)

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -1,0 +1,169 @@
+(ns psi.agent-session.rpc
+  "EDN-lines RPC transport runtime helpers.
+
+   Transport guarantees in this namespace:
+   - one top-level EDN map per input line
+   - canonical outbound frame envelopes
+   - serialized outbound frame writing
+   - protocol-only stdout (handler diagnostics are rebound to stderr)"
+  (:require
+   [clojure.edn :as edn]
+   [clojure.string :as str]))
+
+(def protocol-version "1.0")
+
+(def ^:private request-required-keys #{:id :kind :op})
+(def ^:private request-allowed-keys  #{:id :kind :op :params})
+
+(def ^:private response-allowed-keys [:id :kind :op :ok :data])
+(def ^:private error-allowed-keys    [:kind :id :op :error-code :error-message :retryable :data])
+(def ^:private event-allowed-keys    [:kind :event :data :id :seq :ts])
+
+(defn response-frame
+  ([id op ok]
+   (response-frame id op ok nil))
+  ([id op ok data]
+   (cond-> (array-map :id id :kind :response :op op :ok ok)
+     (some? data) (assoc :data data))))
+
+(defn error-frame
+  [{:keys [id op error-code error-message retryable data]}]
+  (cond-> (array-map :kind :error
+                     :error-code error-code
+                     :error-message error-message)
+    (some? id)        (assoc :id id)
+    (some? op)        (assoc :op op)
+    (some? retryable) (assoc :retryable retryable)
+    (some? data)      (assoc :data data)))
+
+(defn event-frame
+  [{:keys [event data id seq ts]}]
+  (cond-> (array-map :kind :event :event event :data data)
+    (some? id)  (assoc :id id)
+    (some? seq) (assoc :seq seq)
+    (some? ts)  (assoc :ts ts)))
+
+(defn- normalize-kind [k]
+  (cond
+    (keyword? k) k
+    (string? k)  (keyword k)
+    :else        k))
+
+(defn- canonicalize-outbound-frame [frame]
+  (case (normalize-kind (:kind frame))
+    :response (select-keys frame response-allowed-keys)
+    :error    (select-keys frame error-allowed-keys)
+    :event    (select-keys frame event-allowed-keys)
+    (error-frame {:id            (:id frame)
+                  :op            (:op frame)
+                  :error-code    "protocol/invalid-envelope"
+                  :error-message "unsupported outbound frame kind"
+                  :data          {:kind (:kind frame)}})))
+
+(defn make-frame-writer
+  "Return a serialized frame emitter writing one EDN map per line to `out-writer`."
+  [^java.io.Writer out-writer]
+  (let [lock   (Object.)
+        writer (java.io.BufferedWriter. out-writer)]
+    (fn emit-frame! [frame]
+      (locking lock
+        (.write writer (str (pr-str (canonicalize-outbound-frame frame)) "\n"))
+        (.flush writer)))))
+
+(defn- invalid-envelope [frame-id frame-op message]
+  (error-frame {:id            frame-id
+                :op            frame-op
+                :error-code    "protocol/invalid-envelope"
+                :error-message message}))
+
+(defn- parse-request-line [line]
+  (try
+    (let [frame (edn/read-string line)]
+      (cond
+        (not (map? frame))
+        {:error (invalid-envelope nil nil "request frame must be an EDN map")}
+
+        (not= :request (normalize-kind (:kind frame)))
+        {:error (invalid-envelope (:id frame) (:op frame) "request frame :kind must be :request")}
+
+        (not (every? #(contains? frame %) request-required-keys))
+        {:error (invalid-envelope (:id frame) (:op frame) "request frame missing required keys")}
+
+        (not (every? request-allowed-keys (keys frame)))
+        {:error (invalid-envelope (:id frame) (:op frame) "request frame contains unsupported keys")}
+
+        :else
+        {:ok frame}))
+    (catch Throwable _
+      {:error (error-frame {:error-code    "transport/invalid-frame"
+                            :error-message "unable to parse EDN request frame"})})))
+
+(defn default-request-handler
+  "Default request handler used before per-op routing is implemented."
+  [request]
+  (let [op (:op request)]
+    (case op
+      "handshake"
+      (response-frame (:id request) "handshake" true
+                      {:server-info {:protocol-version protocol-version}})
+
+      "ping"
+      (response-frame (:id request) "ping" true {:pong true :protocol-version protocol-version})
+
+      (error-frame {:id            (:id request)
+                    :op            (:op request)
+                    :error-code    "request/op-not-supported"
+                    :error-message (str "unsupported op: " op)}))))
+
+(defn run-stdio-loop!
+  "Run an EDN-lines RPC loop.
+
+   Options:
+   - :in               java.io.Reader (default *in*)
+   - :out              java.io.Writer (default *out*)
+   - :err              java.io.Writer (default *err*)
+   - :request-handler  (fn [request emit-frame! state] -> frame | [frame*] | nil)
+   - :state            mutable transport state passed to request-handler"
+  [{:keys [in out err request-handler state]
+    :or   {in *in*
+           out *out*
+           err *err*
+           request-handler (fn [request _emit! _state]
+                             (default-request-handler request))
+           state (atom {})}}]
+  (let [reader      (java.io.BufferedReader. in)
+        emit-frame! (make-frame-writer out)
+        emit-error! (fn [error-code error-message]
+                      (emit-frame! (error-frame {:error-code error-code
+                                                 :error-message error-message})))]
+    (doseq [line (line-seq reader)]
+      (if (str/blank? line)
+        (emit-error! "transport/invalid-frame" "empty frame")
+        (let [{:keys [ok error]} (parse-request-line line)]
+          (if error
+            (emit-frame! error)
+            (try
+              (let [result (binding [*out* err]
+                             (request-handler ok emit-frame! state))]
+                (cond
+                  (nil? result)
+                  nil
+
+                  (map? result)
+                  (emit-frame! result)
+
+                  (sequential? result)
+                  (doseq [frame result]
+                    (emit-frame! frame))
+
+                  :else
+                  (emit-frame! (error-frame {:id            (:id ok)
+                                             :op            (:op ok)
+                                             :error-code    "runtime/failed"
+                                             :error-message "request handler returned unsupported result type"}))))
+              (catch Throwable t
+                (emit-frame! (error-frame {:id            (:id ok)
+                                           :op            (:op ok)
+                                           :error-code    "runtime/failed"
+                                           :error-message (or (ex-message t)
+                                                              "unhandled runtime exception")}))))))))))

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -8,7 +8,11 @@
    - protocol-only stdout (handler diagnostics are rebound to stderr)"
   (:require
    [clojure.edn :as edn]
-   [clojure.string :as str]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [psi.agent-core.core :as agent]
+   [psi.agent-session.core :as session]
+   [psi.ai.models :as ai-models]))
 
 (def protocol-version "1.0")
 (def ^:private default-max-pending-requests 64)
@@ -19,6 +23,31 @@
 (def ^:private response-allowed-keys [:id :kind :op :ok :data])
 (def ^:private error-allowed-keys    [:kind :id :op :error-code :error-message :retryable :data])
 (def ^:private event-allowed-keys    [:kind :event :data :id :seq :ts])
+
+(def ^:private supported-rpc-ops
+  ["handshake"
+   "ping"
+   "query_eql"
+   "prompt"
+   "steer"
+   "follow_up"
+   "abort"
+   "new_session"
+   "switch_session"
+   "fork"
+   "set_session_name"
+   "set_model"
+   "cycle_model"
+   "set_thinking_level"
+   "cycle_thinking_level"
+   "compact"
+   "set_auto_compaction"
+   "set_auto_retry"
+   "get_state"
+   "get_messages"
+   "get_session_stats"
+   "subscribe"
+   "unsubscribe"])
 
 (defn response-frame
   ([id op ok]
@@ -110,7 +139,8 @@
       (error-frame {:id            (:id request)
                     :op            (:op request)
                     :error-code    "request/op-not-supported"
-                    :error-message (str "unsupported op: " op)}))))
+                    :error-message (str "unsupported op: " op)
+                    :data          {:supported-ops supported-rpc-ops}}))))
 
 (defn- valid-request-id? [id]
   (and (string? id) (not (str/blank? id))))
@@ -160,14 +190,17 @@
                      (str "unsupported protocol major: " (or major "unknown")))
 
       :else
-      (do
+      (let [server-info-fn (or (:handshake-server-info-fn @state)
+                               (fn [] {:protocol-version protocol-version}))
+            server-info    (merge {:protocol-version protocol-version}
+                                  (or (server-info-fn) {}))]
         (swap! state assoc
                :ready? true
                :negotiated-protocol-version protocol-version)
         (response-frame (:id request)
                         "handshake"
                         true
-                        {:server-info {:protocol-version protocol-version}})))))
+                        {:server-info server-info})))))
 
 (defn- accept-request!
   "Register a request as pending when valid and capacity allows.
@@ -240,6 +273,238 @@
                                          :error-message (or (ex-message t)
                                                             "unhandled runtime exception")}))))))))
 
+(defn- params-map
+  [request]
+  (let [params (:params request)]
+    (when-not (or (nil? params) (map? params))
+      (throw (ex-info "request :params must be a map"
+                      {:error-code "request/invalid-params"})))
+    (or params {})))
+
+(defn- req-arg!
+  [request params k pred desc]
+  (let [v (get params k)]
+    (when-not (pred v)
+      (throw (ex-info (str "invalid request parameter " k ": " desc)
+                      {:error-code "request/invalid-params"})))
+    v))
+
+(defn- parse-query-edn!
+  [query-str]
+  (let [q (try
+            (binding [*read-eval* false]
+              (edn/read-string query-str))
+            (catch Throwable _
+              (throw (ex-info "query must be valid EDN"
+                              {:error-code "request/invalid-query"}))))]
+    (when-not (vector? q)
+      (throw (ex-info "query must be an EDN vector"
+                      {:error-code "request/invalid-query"})))
+    q))
+
+(defn- normalize-provider [provider]
+  (cond
+    (keyword? provider) provider
+    (string? provider)  (keyword provider)
+    :else               nil))
+
+(defn- resolve-model
+  [provider model-id]
+  (let [provider* (normalize-provider provider)]
+    (some (fn [[_ model]]
+            (when (and (= provider* (:provider model))
+                       (= model-id (:id model)))
+              model))
+          ai-models/all-models)))
+
+(defn session->handshake-server-info
+  [ctx]
+  (let [sd (session/get-session-data-in ctx)]
+    {:protocol-version protocol-version
+     :features         #{"eql-graph" "eql-memory"}
+     :session-id       (:session-id sd)
+     :model-id         (get-in sd [:model :id])
+     :thinking-level   (some-> (:thinking-level sd) name)}))
+
+(defn- exception->error-frame
+  [request e]
+  (let [code    (or (:error-code (ex-data e))
+                    (when (= "Session is not idle" (ex-message e))
+                      "request/session-not-idle")
+                    "runtime/failed")
+        message (or (ex-message e) "runtime request failed")]
+    (error-frame {:id            (:id request)
+                  :op            (:op request)
+                  :error-code    code
+                  :error-message message})))
+
+(defn make-session-request-handler
+  "Create a canonical op router bound to an agent-session context.
+
+   Returned fn signature matches `run-stdio-loop!` request-handler:
+   (fn [request emit-frame! state] -> frame | [frame*] | nil)
+
+   Runtime state mutations used by this handler:
+   - :subscribed-topics (set of topic strings)"
+  [ctx]
+  (fn [request _emit! state]
+    (try
+      (let [op     (:op request)
+            params (params-map request)]
+        (case op
+          "ping"
+          (response-frame (:id request) "ping" true {:pong true :protocol-version protocol-version})
+
+          "query_eql"
+          (let [query-str (req-arg! request params :query #(and (string? %) (not (str/blank? %))) "non-empty EDN string")
+                q         (parse-query-edn! query-str)
+                result    (try
+                            (session/query-in ctx q)
+                            (catch Throwable e
+                              (throw (ex-info (or (ex-message e) "query execution failed")
+                                              {:error-code "runtime/query-failed"}
+                                              e))))]
+            (response-frame (:id request) op true {:result result}))
+
+          "prompt"
+          (let [message (req-arg! request params :message #(and (string? %) (not (str/blank? %))) "non-empty string")
+                images  (:images params)]
+            (if (seq images)
+              (session/prompt-in! ctx message images)
+              (session/prompt-in! ctx message))
+            (response-frame (:id request) op true {:accepted true}))
+
+          "steer"
+          (let [message (req-arg! request params :message #(and (string? %) (not (str/blank? %))) "non-empty string")]
+            (session/steer-in! ctx message)
+            (response-frame (:id request) op true {:accepted true}))
+
+          "follow_up"
+          (let [message (req-arg! request params :message #(and (string? %) (not (str/blank? %))) "non-empty string")]
+            (session/follow-up-in! ctx message)
+            (response-frame (:id request) op true {:accepted true}))
+
+          "abort"
+          (do
+            (session/abort-in! ctx)
+            (response-frame (:id request) op true {:accepted true}))
+
+          "new_session"
+          (let [sd (session/new-session-in! ctx)]
+            (response-frame (:id request) op true {:session-id (:session-id sd)
+                                                   :session-file (:session-file sd)}))
+
+          "switch_session"
+          (let [session-path (req-arg! request params :session-path #(and (string? %) (not (str/blank? %))) "non-empty path string")]
+            (when-not (.exists (io/file session-path))
+              (throw (ex-info "session file not found"
+                              {:error-code "request/not-found"})))
+            (let [sd (session/resume-session-in! ctx session-path)]
+              (response-frame (:id request) op true {:session-id (:session-id sd)
+                                                     :session-file (:session-file sd)})))
+
+          "fork"
+          (let [entry-id (req-arg! request params :entry-id #(and (string? %) (not (str/blank? %))) "non-empty entry id")
+                sd       (session/fork-session-in! ctx entry-id)]
+            (response-frame (:id request) op true {:session-id (:session-id sd)
+                                                   :session-file (:session-file sd)}))
+
+          "set_session_name"
+          (let [name (req-arg! request params :name #(and (string? %) (not (str/blank? %))) "non-empty string")
+                sd   (session/set-session-name-in! ctx name)]
+            (response-frame (:id request) op true {:session-name (:session-name sd)}))
+
+          "set_model"
+          (let [provider (req-arg! request params :provider #(or (keyword? %) (string? %)) "string or keyword")
+                model-id (req-arg! request params :model-id #(and (string? %) (not (str/blank? %))) "non-empty string")
+                resolved (resolve-model provider model-id)]
+            (when-not resolved
+              (throw (ex-info "unknown model"
+                              {:error-code "request/unknown-model"})))
+            (let [provider-str (name (:provider resolved))
+                  model       {:provider provider-str
+                               :id (:id resolved)
+                               :reasoning (:supports-reasoning resolved)}
+                  sd          (session/set-model-in! ctx model)]
+              (response-frame (:id request) op true {:model {:provider (:provider (:model sd))
+                                                             :id (:id (:model sd))}})))
+
+          "cycle_model"
+          (let [direction (case (:direction params)
+                            "prev" :backward
+                            "next" :forward
+                            :backward :backward
+                            :forward :forward
+                            :forward)
+                sd        (session/cycle-model-in! ctx direction)]
+            (response-frame (:id request) op true {:model (some-> (:model sd)
+                                                                  (select-keys [:provider :id]))}))
+
+          "set_thinking_level"
+          (let [level (req-arg! request params :level some? "keyword, string, or integer")
+                level* (cond
+                         (keyword? level) level
+                         (string? level)  (keyword level)
+                         :else            level)
+                sd    (session/set-thinking-level-in! ctx level*)]
+            (response-frame (:id request) op true {:thinking-level (:thinking-level sd)}))
+
+          "cycle_thinking_level"
+          (let [sd (session/cycle-thinking-level-in! ctx)]
+            (response-frame (:id request) op true {:thinking-level (:thinking-level sd)}))
+
+          "compact"
+          (let [result (session/manual-compact-in! ctx (:custom-instructions params))]
+            (response-frame (:id request) op true {:compacted (boolean result)
+                                                   :summary   result}))
+
+          "set_auto_compaction"
+          (let [enabled (req-arg! request params :enabled boolean? "boolean")
+                sd      (session/set-auto-compaction-in! ctx enabled)]
+            (response-frame (:id request) op true {:enabled (:auto-compaction-enabled sd)}))
+
+          "set_auto_retry"
+          (let [enabled (req-arg! request params :enabled boolean? "boolean")
+                sd      (session/set-auto-retry-in! ctx enabled)]
+            (response-frame (:id request) op true {:enabled (:auto-retry-enabled sd)}))
+
+          "get_state"
+          (response-frame (:id request) op true {:state (session/get-session-data-in ctx)})
+
+          "get_messages"
+          (response-frame (:id request) op true {:messages (:messages (agent/get-data-in (:agent-ctx ctx)))})
+
+          "get_session_stats"
+          (response-frame (:id request) op true {:stats (session/diagnostics-in ctx)})
+
+          "subscribe"
+          (let [topics  (or (:topics params) [])
+                _       (when-not (sequential? topics)
+                          (throw (ex-info "subscribe :topics must be sequential"
+                                          {:error-code "request/invalid-params"})))
+                topics* (->> topics (filter string?) set)]
+            (swap! state update :subscribed-topics (fnil into #{}) topics*)
+            (response-frame (:id request) op true {:subscribed (->> (:subscribed-topics @state) sort vec)}))
+
+          "unsubscribe"
+          (let [topics  (or (:topics params) [])
+                _       (when-not (sequential? topics)
+                          (throw (ex-info "unsubscribe :topics must be sequential"
+                                          {:error-code "request/invalid-params"})))
+                topics* (->> topics (filter string?) set)]
+            (if (seq topics*)
+              (swap! state update :subscribed-topics (fn [s] (apply disj (or s #{}) topics*)))
+              (swap! state assoc :subscribed-topics #{}))
+            (response-frame (:id request) op true {:subscribed (->> (:subscribed-topics @state) sort vec)}))
+
+          (error-frame {:id            (:id request)
+                        :op            op
+                        :error-code    "request/op-not-supported"
+                        :error-message (str "unsupported op: " op)
+                        :data          {:supported-ops supported-rpc-ops}})))
+      (catch Throwable e
+        (exception->error-frame request e)))))
+
 (defn run-stdio-loop!
   "Run an EDN-lines RPC loop.
 
@@ -265,7 +530,8 @@
         emit-frame! (make-frame-writer out)]
     (swap! state #(merge {:ready? false
                           :pending {}
-                          :max-pending-requests default-max-pending-requests}
+                          :max-pending-requests default-max-pending-requests
+                          :subscribed-topics #{}}
                          %
                          {:err err}))
     (let [emit-tracked! (make-tracked-emitter emit-frame! state)

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -3,20 +3,25 @@
    [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.core :as session]
    [psi.agent-session.rpc :as rpc]))
 
 (defn- run-loop
-  [input handler]
-  (let [out (java.io.StringWriter.)
-        err (java.io.StringWriter.)]
-    (rpc/run-stdio-loop! {:in              (java.io.StringReader. input)
-                          :out             out
-                          :err             err
-                          :request-handler handler})
-    {:out-lines (->> (str/split-lines (str out))
-                     (remove str/blank?)
-                     vec)
-     :err-text  (str err)}))
+  ([input handler]
+   (run-loop input handler (atom {})))
+  ([input handler state]
+   (let [out (java.io.StringWriter.)
+         err (java.io.StringWriter.)]
+     (rpc/run-stdio-loop! {:in              (java.io.StringReader. input)
+                           :out             out
+                           :err             err
+                           :state           state
+                           :request-handler handler})
+     {:out-lines (->> (str/split-lines (str out))
+                      (remove str/blank?)
+                      vec)
+      :err-text  (str err)
+      :state     @state})))
 
 (defn- parse-frames [lines]
   (mapv edn/read-string lines))
@@ -109,50 +114,121 @@
 
 (deftest run-stdio-loop-pending-lifecycle-test
   (testing "accepted request adds pending and terminal response clears it"
-    (let [state (atom {:max-pending-requests 2})
-          out   (java.io.StringWriter.)
-          err   (java.io.StringWriter.)]
-      (rpc/run-stdio-loop!
-       {:in (java.io.StringReader.
-             (str "{:id \"h\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
-                  "{:id \"r1\" :kind :request :op \"echo\"}\n"))
-        :out out
-        :err err
-        :state state
-        :request-handler
-        (fn [request _emit _state]
-          (if (= "echo" (:op request))
-            (rpc/response-frame (:id request) "echo" true {:ok true})
-            (rpc/response-frame (:id request) (:op request) true {})))})
+    (let [state (atom {:max-pending-requests 2})]
+      (run-loop (str "{:id \"h\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                     "{:id \"r1\" :kind :request :op \"echo\"}\n")
+                (fn [request _emit _state]
+                  (if (= "echo" (:op request))
+                    (rpc/response-frame (:id request) "echo" true {:ok true})
+                    (rpc/response-frame (:id request) (:op request) true {})))
+                state)
       (is (= {} (:pending @state)))
       (is (= true (:ready? @state)))))
 
   (testing "max pending guard returns canonical error"
     (let [state (atom {:max-pending-requests 1 :ready? true :pending {"existing" "op"}})
-          out   (java.io.StringWriter.)
-          err   (java.io.StringWriter.)]
-      (rpc/run-stdio-loop!
-       {:in (java.io.StringReader. "{:id \"r2\" :kind :request :op \"echo\"}\n")
-        :out out
-        :err err
-        :state state
-        :request-handler (fn [_ _ _] nil)})
-      (let [frame (-> out str str/split-lines first edn/read-string)]
-        (is (= :error (:kind frame)))
-        (is (= "transport/max-pending-exceeded" (:error-code frame)))
-        (is (= "r2" (:id frame))))))
+          {:keys [out-lines]} (run-loop "{:id \"r2\" :kind :request :op \"echo\"}\n"
+                                        (fn [_ _ _] nil)
+                                        state)
+          frame (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "transport/max-pending-exceeded" (:error-code frame)))
+      (is (= "r2" (:id frame)))))
 
   (testing "duplicate request id is rejected with request/invalid-id"
     (let [state (atom {:ready? true :pending {"dup" "existing-op"}})
-          out   (java.io.StringWriter.)
-          err   (java.io.StringWriter.)]
-      (rpc/run-stdio-loop!
-       {:in (java.io.StringReader. "{:id \"dup\" :kind :request :op \"echo\"}\n")
-        :out out
-        :err err
-        :state state
-        :request-handler (fn [_ _ _] nil)})
-      (let [frame (-> out str str/split-lines first edn/read-string)]
-        (is (= :error (:kind frame)))
-        (is (= "request/invalid-id" (:error-code frame)))
-        (is (= "dup" (:id frame)))))))
+          {:keys [out-lines]} (run-loop "{:id \"dup\" :kind :request :op \"echo\"}\n"
+                                        (fn [_ _ _] nil)
+                                        state)
+          frame (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "request/invalid-id" (:error-code frame)))
+      (is (= "dup" (:id frame))))))
+
+(deftest session-request-handler-query-eql-and-op-mapping-test
+  (testing "query_eql routes to session/query-in and returns canonical result envelope"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"q1\" :kind :request :op \"query_eql\" :params {:query \"[:psi.graph/domain-coverage :psi.memory/status]\"}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :response (:kind frame)))
+      (is (= "query_eql" (:op frame)))
+      (is (= true (:ok frame)))
+      (is (map? (get-in frame [:data :result])))
+      (is (contains? (get-in frame [:data :result]) :psi.graph/domain-coverage))
+      (is (contains? (get-in frame [:data :result]) :psi.memory/status))))
+
+  (testing "query_eql invalid query EDN returns request/invalid-query"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"q2\" :kind :request :op \"query_eql\" :params {:query \"not-edn\"}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "query_eql" (:op frame)))
+      (is (= "request/invalid-query" (:error-code frame)))))
+
+  (testing "query_eql non-vector query returns request/invalid-query"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"q3\" :kind :request :op \"query_eql\" :params {:query \"{:a 1}\"}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "request/invalid-query" (:error-code frame)))))
+
+  (testing "unknown op returns request/op-not-supported with supported ops"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"u1\" :kind :request :op \"nope\"}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "request/op-not-supported" (:error-code frame)))
+      (is (vector? (get-in frame [:data :supported-ops])))))
+
+  (testing "subscribe/unsubscribe update shared state and return subscribed topics"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {} :subscribed-topics #{}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines state]}
+          (run-loop (str "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/delta\" \"tool/start\"]}}\n"
+                         "{:id \"s2\" :kind :request :op \"unsubscribe\" :params {:topics [\"tool/start\"]}}\n")
+                    handler
+                    state)
+          [f1 f2] (parse-frames out-lines)]
+      (is (= :response (:kind f1)))
+      (is (= ["assistant/delta" "tool/start"] (get-in f1 [:data :subscribed])))
+      (is (= :response (:kind f2)))
+      (is (= ["assistant/delta"] (get-in f2 [:data :subscribed])))
+      (is (= #{"assistant/delta"} (:subscribed-topics state))))))
+
+(deftest rpc-handshake-server-info-test
+  (testing "handshake emits server-info with protocol/session metadata"
+    (let [ctx     (session/create-context)
+          state   (atom {:handshake-server-info-fn (fn [] (rpc/session->handshake-server-info ctx))})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)
+          info    (get-in frame [:data :server-info])]
+      (is (= :response (:kind frame)))
+      (is (= "handshake" (:op frame)))
+      (is (= "1.0" (:protocol-version info)))
+      (is (contains? info :session-id))
+      (is (= #{"eql-graph" "eql-memory"} (:features info))))))

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -43,11 +43,12 @@
 (deftest run-stdio-loop-emits-canonical-response-frame-test
   (testing "writer strips non-canonical keys from response frames"
     (let [{:keys [out-lines]}
-          (run-loop "{:id \"42\" :kind :request :op \"ping\"}\n"
+          (run-loop (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                         "{:id \"42\" :kind :request :op \"ping\"}\n")
                     (fn [request _emit _state]
-                      (assoc (rpc/response-frame (:id request) "ping" true {:pong true})
+                      (assoc (rpc/response-frame (:id request) (:op request) true {:pong true})
                              :extra "drop-me")))
-          frame (-> out-lines parse-frames first)]
+          frame (-> out-lines parse-frames second)]
       (is (= {:id "42"
               :kind :response
               :op "ping"
@@ -59,11 +60,99 @@
 (deftest run-stdio-loop-routes-handler-stdout-to-stderr-test
   (testing "non-protocol output from request handler is redirected to stderr"
     (let [{:keys [out-lines err-text]}
-          (run-loop "{:id \"10\" :kind :request :op \"ping\"}\n"
-                    (fn [_ _ _]
+          (run-loop (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                         "{:id \"10\" :kind :request :op \"ping\"}\n")
+                    (fn [request _ _]
                       (println "diagnostic line")
-                      (rpc/response-frame "10" "ping" true {:pong true})))
-          frame (-> out-lines parse-frames first)]
+                      (rpc/response-frame (:id request) (:op request) true {:pong true})))
+          frame (-> out-lines parse-frames second)]
       (is (= :response (:kind frame)))
       (is (str/includes? err-text "diagnostic line"))
-      (is (= 1 (count out-lines))))))
+      (is (= 2 (count out-lines))))))
+
+(deftest run-stdio-loop-enforces-handshake-gate-test
+  (testing "non-handshake requests are rejected before ready"
+    (let [{:keys [out-lines]}
+          (run-loop "{:id \"1\" :kind :request :op \"ping\"}\n"
+                    (fn [_ _ _]
+                      (rpc/response-frame "1" "ping" true {:pong true})))
+          frame (-> out-lines parse-frames first)]
+      (is (= :error (:kind frame)))
+      (is (= "transport/not-ready" (:error-code frame)))
+      (is (= "1" (:id frame)))
+      (is (= "ping" (:op frame))))))
+
+(deftest run-stdio-loop-handshake-compatibility-test
+  (testing "unsupported major protocol is rejected and transport remains not-ready"
+    (let [{:keys [out-lines]}
+          (run-loop (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"2.0\"}}}\n"
+                         "{:id \"p1\" :kind :request :op \"ping\"}\n")
+                    (fn [_ _ _]
+                      (rpc/response-frame "p1" "ping" true {:pong true})))
+          [h p] (parse-frames out-lines)]
+      (is (= :error (:kind h)))
+      (is (= "protocol/unsupported-version" (:error-code h)))
+      (is (= :error (:kind p)))
+      (is (= "transport/not-ready" (:error-code p)))))
+
+  (testing "supported major protocol sets ready and allows non-handshake ops"
+    (let [{:keys [out-lines]}
+          (run-loop (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                         "{:id \"p1\" :kind :request :op \"ping\"}\n")
+                    (fn [request _ _]
+                      (rpc/response-frame (:id request) (:op request) true {:pong true})))
+          [h p] (parse-frames out-lines)]
+      (is (= :response (:kind h)))
+      (is (= "handshake" (:op h)))
+      (is (= :response (:kind p)))
+      (is (= "ping" (:op p))))))
+
+(deftest run-stdio-loop-pending-lifecycle-test
+  (testing "accepted request adds pending and terminal response clears it"
+    (let [state (atom {:max-pending-requests 2})
+          out   (java.io.StringWriter.)
+          err   (java.io.StringWriter.)]
+      (rpc/run-stdio-loop!
+       {:in (java.io.StringReader.
+             (str "{:id \"h\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                  "{:id \"r1\" :kind :request :op \"echo\"}\n"))
+        :out out
+        :err err
+        :state state
+        :request-handler
+        (fn [request _emit _state]
+          (if (= "echo" (:op request))
+            (rpc/response-frame (:id request) "echo" true {:ok true})
+            (rpc/response-frame (:id request) (:op request) true {})))})
+      (is (= {} (:pending @state)))
+      (is (= true (:ready? @state)))))
+
+  (testing "max pending guard returns canonical error"
+    (let [state (atom {:max-pending-requests 1 :ready? true :pending {"existing" "op"}})
+          out   (java.io.StringWriter.)
+          err   (java.io.StringWriter.)]
+      (rpc/run-stdio-loop!
+       {:in (java.io.StringReader. "{:id \"r2\" :kind :request :op \"echo\"}\n")
+        :out out
+        :err err
+        :state state
+        :request-handler (fn [_ _ _] nil)})
+      (let [frame (-> out str str/split-lines first edn/read-string)]
+        (is (= :error (:kind frame)))
+        (is (= "transport/max-pending-exceeded" (:error-code frame)))
+        (is (= "r2" (:id frame))))))
+
+  (testing "duplicate request id is rejected with request/invalid-id"
+    (let [state (atom {:ready? true :pending {"dup" "existing-op"}})
+          out   (java.io.StringWriter.)
+          err   (java.io.StringWriter.)]
+      (rpc/run-stdio-loop!
+       {:in (java.io.StringReader. "{:id \"dup\" :kind :request :op \"echo\"}\n")
+        :out out
+        :err err
+        :state state
+        :request-handler (fn [_ _ _] nil)})
+      (let [frame (-> out str str/split-lines first edn/read-string)]
+        (is (= :error (:kind frame)))
+        (is (= "request/invalid-id" (:error-code frame)))
+        (is (= "dup" (:id frame)))))))

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -4,12 +4,15 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
-   [psi.agent-session.rpc :as rpc]))
+   [psi.agent-session.rpc :as rpc]
+   [psi.tui.extension-ui :as ext-ui]))
 
 (defn- run-loop
   ([input handler]
-   (run-loop input handler (atom {})))
+   (run-loop input handler (atom {}) 0))
   ([input handler state]
+   (run-loop input handler state 0))
+  ([input handler state wait-ms]
    (let [out (java.io.StringWriter.)
          err (java.io.StringWriter.)]
      (rpc/run-stdio-loop! {:in              (java.io.StringReader. input)
@@ -17,6 +20,8 @@
                            :err             err
                            :state           state
                            :request-handler handler})
+     (when (pos? wait-ms)
+       (Thread/sleep wait-ms))
      {:out-lines (->> (str/split-lines (str out))
                       (remove str/blank?)
                       vec)
@@ -232,3 +237,109 @@
       (is (= "1.0" (:protocol-version info)))
       (is (contains? info :session-id))
       (is (= #{"eql-graph" "eql-memory"} (:features info))))))
+
+(deftest rpc-prompt-streams-events-and-interleaves-test
+  (testing "prompt emits canonical events that interleave with accepted response"
+    (let [ctx (session/create-context)
+          _   (ext-ui/set-status! (:ui-state-atom ctx) "ext.demo" "ready")
+          state (atom {:ready? true
+                       :pending {}
+                       :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                       :run-agent-loop-fn (fn [_ai-ctx _ctx _agent-ctx _ai-model _new-messages {:keys [progress-queue]}]
+                                            (.offer ^java.util.concurrent.LinkedBlockingQueue progress-queue
+                                                    {:event-kind :text-delta :text "Hello" :type :agent-event})
+                                            (.offer ^java.util.concurrent.LinkedBlockingQueue progress-queue
+                                                    {:event-kind :tool-start :tool-id "tc-1" :tool-name "read" :type :agent-event})
+                                            (.offer ^java.util.concurrent.LinkedBlockingQueue progress-queue
+                                                    {:event-kind :tool-result
+                                                     :tool-id "tc-1"
+                                                     :tool-name "read"
+                                                     :content [{:type :text :text "done"}]
+                                                     :result-text "done"
+                                                     :details nil
+                                                     :is-error false
+                                                     :type :agent-event})
+                                            {:role "assistant"
+                                             :content [{:type :text :text "Hello final"}]
+                                             :stop-reason :stop
+                                             :usage {:total-tokens 3}})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"p1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/delta\" \"assistant/message\" \"tool/start\" \"tool/result\" \"session/updated\" \"footer/updated\"]}}\n"
+                       "{:id \"r1\" :kind :request :op \"prompt\" :params {:message \"hi\"}}\n")
+          {:keys [out-lines]} (run-loop input handler state 250)
+          frames (->> out-lines
+                      (keep (fn [line]
+                              (try
+                                (edn/read-string line)
+                                (catch Throwable _ nil))))
+                      vec)
+          response-index (first (keep-indexed (fn [i f] (when (and (= :response (:kind f)) (= "prompt" (:op f))) i)) frames))
+          event-indexes  (keep-indexed (fn [i f] (when (= :event (:kind f)) i)) frames)
+          seqs           (->> frames (filter #(= :event (:kind %))) (map :seq) (remove nil?))
+          topics         (->> frames (filter #(= :event (:kind %))) (map :event) set)]
+      (is (number? response-index))
+      (is (seq event-indexes))
+      (is (some #(< response-index %) event-indexes))
+      (is (contains? topics "assistant/delta"))
+      (is (contains? topics "assistant/message"))
+      (is (contains? topics "tool/start"))
+      (is (contains? topics "tool/result"))
+      (is (contains? topics "session/updated"))
+      (is (contains? topics "footer/updated"))
+      (is (= seqs (sort seqs)))
+      (is (every? #(contains? % :data) (filter #(= :event (:kind %)) frames)))
+      (is (contains? #{:response :event} (:kind (last frames)))))))
+
+(deftest rpc-session-resume-and-rehydrate-events-test
+  (testing "new_session emits session/resumed and session/rehydrated canonical events"
+    (let [ctx (session/create-context)
+          state (atom {:ready? true
+                       :pending {}
+                       :subscribed-topics #{"session/resumed" "session/rehydrated"}})
+          handler (rpc/make-session-request-handler ctx)
+          input (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                     "{:id \"n1\" :kind :request :op \"new_session\"}\n")
+          {:keys [out-lines]} (run-loop input handler state)
+          frames (parse-frames out-lines)
+          events (filter #(= :event (:kind %)) frames)
+          event-topics (set (map :event events))]
+      (is (contains? event-topics "session/resumed"))
+      (is (contains? event-topics "session/rehydrated"))
+      (is (some #(contains? (:data %) :session-id) events))
+      (is (some #(contains? (:data %) :messages) events)))))
+
+(deftest rpc-e2e-handshake-query-and-streaming-test
+  (testing "handshake -> query_eql -> prompt with interleaved events"
+    (let [ctx (session/create-context)
+          state (atom {:ready? true
+                       :pending {}
+                       :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                       :run-agent-loop-fn (fn [_ai-ctx _ctx _agent-ctx _ai-model _new-messages {:keys [progress-queue]}]
+                                            (.offer ^java.util.concurrent.LinkedBlockingQueue progress-queue
+                                                    {:event-kind :text-delta :text "Hello" :type :agent-event})
+                                            {:role "assistant"
+                                             :content [{:type :text :text "Hello final"}]
+                                             :stop-reason :stop
+                                             :usage {:total-tokens 2}})})
+          handler (rpc/make-session-request-handler ctx)
+          input (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                     "{:id \"q1\" :kind :request :op \"query_eql\" :params {:query \"[:psi.graph/domain-coverage :psi.memory/status]\"}}\n"
+                     "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/delta\" \"assistant/message\" \"session/updated\" \"footer/updated\"]}}\n"
+                     "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"hi\"}}\n")
+          {:keys [out-lines]} (run-loop input handler state 250)
+          frames (parse-frames out-lines)
+          handshake-frame (some #(when (and (= :response (:kind %)) (= "handshake" (:op %))) %) frames)
+          query-frame (some #(when (and (= :response (:kind %)) (= "query_eql" (:op %))) %) frames)
+          prompt-response-index (first (keep-indexed (fn [i f] (when (and (= :response (:kind f)) (= "prompt" (:op f))) i)) frames))
+          event-indexes (vec (keep-indexed (fn [i f] (when (= :event (:kind f)) i)) frames))]
+      (is handshake-frame)
+      (is (= true (:ok handshake-frame)))
+      (is query-frame)
+      (is (= true (:ok query-frame)))
+      (is (contains? (get-in query-frame [:data :result]) :psi.graph/domain-coverage))
+      (is (contains? (get-in query-frame [:data :result]) :psi.memory/status))
+      (is (number? prompt-response-index))
+      (is (seq event-indexes))
+      (is (some #(< prompt-response-index %) event-indexes))
+      (is (some #(= "assistant/delta" (:event %)) (filter #(= :event (:kind %)) frames))))))

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -1,0 +1,69 @@
+(ns psi.agent-session.rpc-test
+  (:require
+   [clojure.edn :as edn]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.rpc :as rpc]))
+
+(defn- run-loop
+  [input handler]
+  (let [out (java.io.StringWriter.)
+        err (java.io.StringWriter.)]
+    (rpc/run-stdio-loop! {:in              (java.io.StringReader. input)
+                          :out             out
+                          :err             err
+                          :request-handler handler})
+    {:out-lines (->> (str/split-lines (str out))
+                     (remove str/blank?)
+                     vec)
+     :err-text  (str err)}))
+
+(defn- parse-frames [lines]
+  (mapv edn/read-string lines))
+
+(deftest run-stdio-loop-validates-request-envelopes-test
+  (testing "returns canonical protocol/transport errors for invalid input frames"
+    (let [{:keys [out-lines]}
+          (run-loop (str "\n"
+                         "{:kind :request :op \"ping\"}\n"
+                         "{:id \"1\" :kind :response :op \"ping\"}\n"
+                         "{:id \"2\" :kind :request :op \"ping\" :x 1}\n"
+                         "not-edn\n")
+                    (fn [_ _ _] nil))
+          frames (parse-frames out-lines)]
+      (is (= 5 (count frames)))
+      (is (= ["transport/invalid-frame"
+              "protocol/invalid-envelope"
+              "protocol/invalid-envelope"
+              "protocol/invalid-envelope"
+              "protocol/invalid-envelope"]
+             (mapv :error-code frames)))
+      (is (every? #(= :error (:kind %)) frames)))))
+
+(deftest run-stdio-loop-emits-canonical-response-frame-test
+  (testing "writer strips non-canonical keys from response frames"
+    (let [{:keys [out-lines]}
+          (run-loop "{:id \"42\" :kind :request :op \"ping\"}\n"
+                    (fn [request _emit _state]
+                      (assoc (rpc/response-frame (:id request) "ping" true {:pong true})
+                             :extra "drop-me")))
+          frame (-> out-lines parse-frames first)]
+      (is (= {:id "42"
+              :kind :response
+              :op "ping"
+              :ok true
+              :data {:pong true}}
+             frame))
+      (is (not (contains? frame :extra))))))
+
+(deftest run-stdio-loop-routes-handler-stdout-to-stderr-test
+  (testing "non-protocol output from request handler is redirected to stderr"
+    (let [{:keys [out-lines err-text]}
+          (run-loop "{:id \"10\" :kind :request :op \"ping\"}\n"
+                    (fn [_ _ _]
+                      (println "diagnostic line")
+                      (rpc/response-frame "10" "ping" true {:pong true})))
+          frame (-> out-lines parse-frames first)]
+      (is (= :response (:kind frame)))
+      (is (str/includes? err-text "diagnostic line"))
+      (is (= 1 (count out-lines))))))

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -854,6 +854,8 @@
                               returns {:messages [...], :tool-calls {...}, :tool-order [...]}
      :dispatch-fn          — (fn [text]) → command result map or nil; central command dispatch
      :on-interrupt-fn!     — (fn [state]) -> {:queued-text str? :message str?} | nil
+     :on-queue-input-fn!   — (fn [text state]) -> {:message str?} | nil
+                              called when Enter is pressed while streaming
      :double-press-window-ms — ctrl+c / escape timing window (default 500)
      :double-escape-action — :tree | :fork | :none (default :none)
      :event-queue          — shared LinkedBlockingQueue for agent + extension events"
@@ -885,6 +887,7 @@
            :ui-state-atom         ui-state-atom
            :dispatch-fn           (:dispatch-fn opts)
            :on-interrupt-fn!      (:on-interrupt-fn! opts)
+           :on-queue-input-fn!    (:on-queue-input-fn! opts)
            :double-press-window-ms (or (:double-press-window-ms opts) 500)
            :double-escape-action  (or (:double-escape-action opts) :none)
            :cwd                   (or (:cwd opts) (System/getProperty "user.dir"))
@@ -1289,6 +1292,32 @@
       [next-state (poll-cmd (:queue state))])
     [(append-assistant-status state "Interrupt unavailable in this runtime.") nil]))
 
+(defn- handle-streaming-submit
+  "Queue draft input as steering/follow-up while the agent is streaming."
+  [state]
+  (let [text     (str/trim (input-value state))
+        queue-fn (:on-queue-input-fn! state)]
+    (cond
+      (str/blank? text)
+      [state (poll-cmd (:queue state))]
+
+      queue-fn
+      (let [result  (try
+                      (queue-fn text state)
+                      (catch Exception e
+                        {:message (str "Failed to queue input: " (ex-message e))}))
+            message (or (:message result)
+                        "Queued for next turn.")]
+        [(-> state
+             (set-input-value "")
+             (clear-autocomplete)
+             (append-assistant-status message))
+         (poll-cmd (:queue state))])
+
+      :else
+      [(append-assistant-status state "Queueing input is unavailable in this runtime.")
+       (poll-cmd (:queue state))])))
+
 ;; ── Update ──────────────────────────────────────────────────
 
 (defn make-update
@@ -1488,6 +1517,29 @@
         (and (= :idle (:phase state))
              (msg/key-match? m "enter"))
         (submit-input state run-agent-fn!)
+
+      ;; Enter while streaming queues steering/follow-up input.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "enter"))
+        (handle-streaming-submit state)
+
+      ;; Backspace edits text while streaming.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "backspace"))
+        (let [[new-input cmd] (charm/text-input-update (:input state) m)]
+          [(set-input-model state new-input) cmd])
+
+      ;; Space may arrive as keyword :space while streaming.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "space"))
+        (let [[new-input cmd] (charm/text-input-update (:input state) (msg/key-press " "))]
+          [(set-input-model state new-input) cmd])
+
+      ;; Text input remains editable while streaming.
+        (and (= :streaming (:phase state))
+             (msg/key-press? m))
+        (let [[new-input cmd] (charm/text-input-update (:input state) m)]
+          [(set-input-model state new-input) cmd])
 
       ;; Backspace edits text then refreshes open autocomplete.
         (and (= :idle (:phase state))
@@ -2315,12 +2367,14 @@
             ;; Dialog replaces editor when active
             (if dialog-active?
               (render-dialog ui-state-atom)
-              (if (= :idle phase)
-                (wrap-text-input-view input term-width)
-                (charm/render dim-style
-                              (if progress-spinner-visible?
-                                "(waiting for response…)"
-                                (str spinner-char " waiting for response…")))))
+              (str (wrap-text-input-view input term-width)
+                   (when (= :streaming phase)
+                     (str "\n"
+                          (charm/render dim-style
+                                        (if progress-spinner-visible?
+                                          "(Enter queues input • Esc interrupts)"
+                                          (str spinner-char " waiting for response…")))
+                          clear-line-end-seq))))
             "\n"
             (render-separator) "\n"
             ;; Widgets below editor
@@ -2350,6 +2404,7 @@
                                                :tool-calls {...}
                                                :tool-order [...]}
                        :on-interrupt-fn!    — (fn [state]) -> {:queued-text str? :message str?}
+                       :on-queue-input-fn!  — (fn [text state]) -> {:message str?}
                        :double-press-window-ms — ctrl+c / escape timing window (default 500)
                        :double-escape-action — :tree | :fork | :none (default :none)
                        :alt-screen          — true/false (default true)"

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -384,6 +384,33 @@
       (is (= "Interrupted active work."
              (:text (last (:messages s1))))))))
 
+(deftest streaming-enter-queues-input-test
+  (testing "enter during streaming queues draft text via callback and keeps streaming"
+    (let [queued    (atom nil)
+          update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state "test-model"
+                                       {:on-queue-input-fn! (fn [text _]
+                                                              (reset! queued text)
+                                                              {:message "Queued steering message."})})
+                           :phase :streaming
+                           :input (charm/text-input-set-value (:input (init-state)) "steer this"))
+          [s1 _cmd] (update-fn state (msg/key-press :enter))]
+      (is (= :streaming (:phase s1)))
+      (is (= "steer this" @queued))
+      (is (= "" (text-input/value (:input s1))))
+      (is (= "Queued steering message." (:text (last (:messages s1))))))))
+
+(deftest streaming-input-remains-editable-test
+  (testing "printable input and backspace mutate editor while streaming"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state)
+                           :phase :streaming
+                           :input (charm/text-input-set-value (:input (init-state)) "ab"))
+          [s1 _]    (update-fn state (msg/key-press "c"))
+          [s2 _]    (update-fn s1 (msg/key-press :backspace))]
+      (is (= "abc" (text-input/value (:input s1))))
+      (is (= "ab" (text-input/value (:input s2)))))))
+
 (deftest double-escape-unsupported-action-is-safe-no-op-with-status-test
   (testing "unsupported double-escape action does not crash and emits status"
     (let [update-fn (app/make-update (stub-agent-fn ""))
@@ -547,12 +574,15 @@
           [s1 _]    (update-fn state (msg/key-press :tab))]
       (is (= "@\"foo\" " (text-input/value (:input s1)))))))
 
-(deftest keys-ignored-during-streaming-test
-  (testing "printable keys are ignored while streaming"
+(deftest keys-edit-input-during-streaming-test
+  (testing "printable keys edit draft input while streaming"
     (let [update-fn (app/make-update (stub-agent-fn ""))
-          streaming (assoc (init-state) :phase :streaming)
+          streaming (-> (init-state)
+                        (assoc :phase :streaming)
+                        (assoc :input (charm/text-input-set-value (:input (init-state)) "")))
           [s1 cmd]  (update-fn streaming (msg/key-press "x"))]
       (is (= :streaming (:phase s1)))
+      (is (= "x" (text-input/value (:input s1))))
       (is (nil? cmd)))))
 
 ;;;; View
@@ -624,7 +654,7 @@ clojure-lsp"}]})
     (let [state (assoc (init-state) :phase :streaming)
           out   (app/view state)]
       (is (str/includes? out "thinking"))
-      (is (str/includes? out "(waiting for response…)"))
+      (is (str/includes? out "Enter queues input"))
       (is (not (str/includes? out "⠋ waiting for response…"))))))
 
 (deftest view-shows-spinner-in-waiting-indicator-with-tool-history-test
@@ -644,7 +674,7 @@ clojure-lsp"}]})
       (is (not (str/includes? out "(waiting for response…)"))))))
 
 (deftest view-hides-waiting-spinner-when-tool-spinner-visible-test
-  (testing "waiting indicator stays static when tool list already shows spinner"
+  (testing "streaming hint remains static when tool list already shows spinner"
     (let [state (-> (init-state)
                     (assoc :phase :streaming
                            :spinner-frame 0
@@ -656,7 +686,7 @@ clojure-lsp"}]})
                                               :result nil
                                               :is-error false}}))
           out   (app/view state)]
-      (is (str/includes? out "(waiting for response…)"))
+      (is (str/includes? out "Enter queues input"))
       (is (not (str/includes? out "⠋ waiting for response…"))))))
 
 (deftest ctrl-o-toggles-tools-expanded-test

--- a/doc/rpc-edn-op-mapping-contract.md
+++ b/doc/rpc-edn-op-mapping-contract.md
@@ -1,0 +1,206 @@
+# RPC EDN Op Mapping Contract (Story #76 / Task #78)
+
+Status: normative implementation contract for runtime transport work.
+
+References:
+- `spec/rpc-edn.allium` (canonical wire contract)
+- `spec/coding-agent.allium` (`RpcApi` operation surface)
+- `spec/emacs-frontend.allium` (frontend consumer expectations)
+
+## 1) Canonical wire envelope rules
+
+All wire keys are EDN kebab-case keywords.
+
+### Request frame (stdin)
+Required keys: `:id :kind :op`
+Allowed keys: `:id :kind :op :params`
+Constraints:
+- `:kind` MUST be `:request`
+- `:id` MUST be non-empty string
+- `:op` MUST be non-empty string
+
+### Response frame (stdout)
+Required keys: `:id :kind :op :ok`
+Allowed keys: `:id :kind :op :ok :data`
+Constraints:
+- `:kind` MUST be `:response`
+- `:ok` is boolean
+- no extra envelope keys
+
+### Error frame (stdout)
+Required keys: `:kind :error-code :error-message`
+Allowed keys: `:kind :id :op :error-code :error-message :retryable :data`
+Constraints:
+- `:kind` MUST be `:error`
+- no extra envelope keys
+
+### Event frame (stdout)
+Required keys: `:kind :event :data`
+Allowed keys: `:kind :event :data :id :seq :ts`
+Constraints:
+- `:kind` MUST be `:event`
+- `:seq` (when present) MUST be monotonic increasing
+- no extra envelope keys
+
+### Transport discipline
+- Exactly one top-level EDN map per line.
+- stdout in RPC mode is protocol-only (`:response | :event | :error`).
+- diagnostics/logging go to stderr only.
+
+## 2) Handshake and readiness policy
+
+- Only `handshake` is allowed before ready.
+- Any non-handshake request pre-ready returns:
+  - `{:kind :error :id <req-id?> :op <op?> :error-code "transport/not-ready" ...}`
+- Unsupported protocol major returns:
+  - `:error-code "protocol/unsupported-version"`
+  - endpoint transitions to disconnected/non-ready (disconnect behavior)
+- Successful handshake negotiates server protocol within major `1` and sets transport ready.
+
+## 3) Pending request lifecycle policy
+
+- Accepted request adds pending entry `id -> op`.
+- Terminal `:response` or `:error` with matching `:id` clears entry.
+- Enforce `max_pending_requests` guard.
+- Duplicate/invalid IDs return canonical request errors (no transport crash).
+
+## 4) `query_eql` request contract
+
+Canonical input contract for wire requests:
+- `:params {:query <string>}` where `<string>` parses as EDN vector query.
+
+Validation outcomes:
+- not EDN => canonical request/protocol error
+- EDN but non-vector => canonical request error
+- vector => run via live runtime query path
+
+Success response shape:
+- `{:id ... :kind :response :op "query_eql" :ok true :data {:result <query-result>}}`
+
+Parity expectation:
+- queries containing `:psi.graph/*` and `:psi.memory/*` must return values when runtime context provides them.
+
+## 5) Operation mapping table
+
+The transport op router MUST remain a thin translation boundary over existing `psi.agent-session.core` APIs.
+
+| RPC op | Params contract | Runtime mapping target | Success `:data` shape | Canonical error mapping |
+|---|---|---|---|---|
+| `handshake` | `{:client-info {:name s :version s :protocol-version s :features [s*]?}}` | transport-level negotiation (not session domain op) | `{:server-info {:protocol-version s :features [s*] :session-id s? :model-id s? :thinking-level s?}}` | `protocol/unsupported-version`, `request/invalid-params` |
+| `query_eql` | `{:query <edn-string-vector>}` | `session/query-in` | `{:result any}` | `request/invalid-params`, `request/invalid-query`, `runtime/query-failed` |
+| `prompt` | `{:message s :images ?}` | `session/prompt-in!` | `{:accepted true}` | `transport/not-ready`, `request/invalid-params`, `request/session-not-idle`, `runtime/failed` |
+| `steer` | `{:message s :images ?}` | `session/steer-in!` | `{:accepted true}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `follow_up` | `{:message s :images ?}` | `session/follow-up-in!` | `{:accepted true}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `abort` | `{}` | `session/abort-in!` | `{:accepted true}` | `transport/not-ready`, `runtime/failed` |
+| `new_session` | `{:parent-session ?}` | `session/new-session-in!` | `{:session-id s :session-file s?}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `switch_session` | `{:session-path s}` | `session/resume-session-in!` | `{:session-id s :session-file s?}` | `transport/not-ready`, `request/invalid-params`, `request/not-found`, `runtime/failed` |
+| `fork` | `{:entry-id s}` | `session/fork-session-in!` | `{:session-id s :session-file s?}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `set_session_name` | `{:name s}` | `session/set-session-name-in!` | `{:session-name s}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `set_model` | `{:provider s :model-id s}` | resolve model + `session/set-model-in!` | `{:model {:provider s :id s}}` | `transport/not-ready`, `request/invalid-params`, `request/unknown-model`, `runtime/failed` |
+| `cycle_model` | `{:direction ("next"\|"prev")?}` | `session/cycle-model-in!` | `{:model {:provider s :id s}}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `set_thinking_level` | `{:level keyword\|string\|int}` | `session/set-thinking-level-in!` | `{:thinking-level any}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `cycle_thinking_level` | `{}` | `session/cycle-thinking-level-in!` | `{:thinking-level any}` | `transport/not-ready`, `runtime/failed` |
+| `compact` | `{:custom-instructions s?}` | `session/manual-compact-in!` | `{:compacted true :summary ?}` | `transport/not-ready`, `request/session-not-idle`, `runtime/failed` |
+| `set_auto_compaction` | `{:enabled boolean}` | `session/set-auto-compaction-in!` | `{:enabled boolean}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `set_auto_retry` | `{:enabled boolean}` | `session/set-auto-retry-in!` | `{:enabled boolean}` | `transport/not-ready`, `request/invalid-params`, `runtime/failed` |
+| `get_state` | `{}` | `session/query-in` (state attrs projection) | `{:state map}` | `transport/not-ready`, `runtime/query-failed` |
+| `get_messages` | `{}` | `session/query-in` (messages projection) | `{:messages vector}` | `transport/not-ready`, `runtime/query-failed` |
+| `get_session_stats` | `{}` | `session/diagnostics-in` and/or query projection | `{:stats map}` | `transport/not-ready`, `runtime/query-failed` |
+| `subscribe` | `{:topics [string*]?}` | transport subscription state | `{:subscribed [string*]}` | `transport/not-ready`, `request/invalid-params` |
+| `unsubscribe` | `{:topics [string*]?}` | transport subscription state | `{:subscribed [string*]}` | `transport/not-ready`, `request/invalid-params` |
+| `ping` | `{}` | transport heartbeat | `{:pong true :protocol-version s}` | `transport/not-ready` |
+
+## 6) Unsupported-op policy
+
+If `:op` is unknown or not implemented in current runtime:
+- return canonical error frame with:
+  - `:kind :error`
+  - `:id` echoed when present
+  - `:op` echoed when present
+  - `:error-code "request/op-not-supported"`
+  - `:error-message` stable, human-readable
+  - optional `:data {:supported-ops [...]}`
+- do not crash/disconnect transport solely for unsupported op.
+
+Ops currently expected to start as unsupported until later implementation tasks land:
+- `abort_retry`
+- `bash`
+- `abort_bash`
+- `export_html`
+- `get_fork_messages`
+- `get_last_assistant_text`
+- `get_commands`
+- `get_available_models`
+
+## 7) Event topic bridge mapping
+
+Only catalog topics from `rpc-edn.allium` may be emitted:
+- `session/updated`
+- `session/resumed`
+- `session/rehydrated`
+- `assistant/delta`
+- `assistant/message`
+- `tool/start`
+- `tool/delta`
+- `tool/executing`
+- `tool/update`
+- `tool/result`
+- `ui/dialog-requested`
+- `ui/widgets-updated`
+- `ui/status-updated`
+- `ui/notification`
+- `footer/updated`
+- `error`
+
+Planned source signal exemplars for bridge implementation:
+- executor progress event kinds: `:text-delta`, `:tool-start`, `:tool-delta`, `:tool-executing`, `:tool-execution-update`, `:tool-result`
+- session lifecycle hooks: `session_switch`, resume/bootstrap flows
+- UI extension state atom updates for widgets/status/notifications/footer
+
+Bridge requirements:
+- map source fields to required kebab-case payload keys per topic
+- include optional `:seq` + `:ts` policy support
+- preserve interleaving with direct responses
+
+## 8) Canonical error-code taxonomy (minimum for Story #76)
+
+- transport:
+  - `transport/not-ready`
+  - `transport/invalid-frame`
+  - `transport/max-pending-exceeded`
+- protocol:
+  - `protocol/unsupported-version`
+  - `protocol/invalid-envelope`
+- request:
+  - `request/invalid-id`
+  - `request/invalid-op`
+  - `request/invalid-params`
+  - `request/invalid-query`
+  - `request/op-not-supported`
+  - `request/session-not-idle`
+  - `request/not-found`
+  - `request/unknown-model`
+- runtime:
+  - `runtime/query-failed`
+  - `runtime/failed`
+
+## 9) Acceptance-criteria traceability (Story #76)
+
+| Story criterion | Covered by this contract |
+|---|---|
+| 1. Canonical request validation | Sections 1, 8 |
+| 2. Handshake gate + compatibility | Sections 2, 8 |
+| 3. Canonical response/error/event envelopes | Section 1 |
+| 4. Pending request lifecycle | Section 3 |
+| 5. Event stream interleaving | Sections 7, 1 |
+| 6. Event topic/payload catalog compliance | Section 7 |
+| 7. `query_eql` graph/memory parity | Sections 4, 5 |
+| 8. stdout discipline | Section 1 (Transport discipline) |
+| 9. Tests (contract target) | Sections 1–8 define testable rules |
+
+## 10) Out-of-scope reminders (for this task)
+
+- No protocol version bump (stay `1.0`).
+- No new event topics beyond `rpc-edn.allium` catalog.
+- No HTTP transport.
+- No Emacs rendering internals.

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -765,13 +765,14 @@
        (str "Current story children snapshot (EDN):\n"
             (pr-str children) "\n\n"))
 
+     (when user-confirmation
+       (str "User confirmation context (EDN):\n"
+            (pr-str user-confirmation) "\n\n"))
+
      (when (= :wait-user-confirmation state)
-       (str "Workflow is waiting for explicit user confirmation answer.\n"
-            "Current confirmation payload (EDN):\n"
-            (pr-str user-confirmation) "\n\n"
-            "You must provide a deterministic safe answer and call:\n"
-            "mcp-tasks-run resume <run-id> <answer>\n"
-            "using available extension command mechanism if present; otherwise set answer in workflow data via CLI-supported path.\n\n"))
+       (str "This step is currently paused for explicit user confirmation.\n"
+            "If additional material clarification is required after processing the answer,\n"
+            "emit MCP_TASKS_RUN_USER_CONFIRMATION again as the last line.\n\n"))
 
      (when user-answer
        (str "Resume answer payload provided for this step (EDN):\n"
@@ -786,46 +787,59 @@
   [{:keys [run-id step-name prompt-body task-id entity-type
            project-dir worktree-dir task children state
            user-confirmation user-answer get-api-key-fn
-           category-prompt]}]
-  (let [started (now-ms)
-        model   (resolve-active-model)
-        api-key (when (fn? get-api-key-fn)
-                  (get-api-key-fn (:provider model)))
-        req     (build-step-request {:step-name step-name
-                                     :prompt-body prompt-body
-                                     :task-id task-id
-                                     :entity-type entity-type
-                                     :project-dir project-dir
-                                     :worktree-dir worktree-dir
-                                     :task task
-                                     :children children
-                                     :state state
-                                     :user-confirmation user-confirmation
-                                     :user-answer user-answer
-                                     :category-prompt category-prompt})
-        user-msg {:role      "user"
-                  :content   [{:type :text :text req}]
-                  :timestamp (java.time.Instant/now)}]
+           category-prompt resume-step-session]}]
+  (let [started          (now-ms)
+        resume?          (map? resume-step-session)
+        agent-ctx        (or (:agent-ctx resume-step-session)
+                             (create-step-agent-ctx worktree-dir))
+        step-session-ctx (or (:session-ctx resume-step-session)
+                             (create-step-session-ctx agent-ctx))
+        model            (or (:model resume-step-session)
+                             (resolve-active-model))
+        api-key          (when (fn? get-api-key-fn)
+                           (get-api-key-fn (:provider model)))
+        req              (when-not resume?
+                           (build-step-request {:step-name step-name
+                                                :prompt-body prompt-body
+                                                :task-id task-id
+                                                :entity-type entity-type
+                                                :project-dir project-dir
+                                                :worktree-dir worktree-dir
+                                                :task task
+                                                :children children
+                                                :state state
+                                                :user-confirmation user-confirmation
+                                                :user-answer user-answer
+                                                :category-prompt category-prompt}))
+        user-text        (if resume? (str (or user-answer "")) req)
+        user-msg         {:role      "user"
+                          :content   [{:type :text :text user-text}]
+                          :timestamp (java.time.Instant/now)}
+        step-session     {:agent-ctx agent-ctx
+                          :session-ctx step-session-ctx
+                          :model model
+                          :step-name step-name
+                          :step-state state}]
     (set-live-progress!
      run-id
      {:status  :running
       :state   state
       :step    step-name
-      :message (str "Executing step " step-name)})
+      :message (if resume?
+                 (str "Continuing step " step-name " with user answer")
+                 (str "Executing step " step-name))})
     (try
-      (let [agent-ctx        (create-step-agent-ctx worktree-dir)
-            step-session-ctx (create-step-session-ctx agent-ctx)
-            result           (executor/run-agent-loop!
-                              nil
-                              step-session-ctx
-                              agent-ctx
-                              model
-                              [user-msg]
-                              (cond-> {:turn-ctx-atom nil}
-                                api-key (assoc :api-key api-key)))
-            elapsed          (- (now-ms) started)
-            text             (result->text result)
-            ok?              (not= :error (:stop-reason result))]
+      (let [result  (executor/run-agent-loop!
+                     nil
+                     step-session-ctx
+                     agent-ctx
+                     model
+                     [user-msg]
+                     (cond-> {:turn-ctx-atom nil}
+                       api-key (assoc :api-key api-key)))
+            elapsed (- (now-ms) started)
+            text    (result->text result)
+            ok?     (not= :error (:stop-reason result))]
         (set-live-progress!
          run-id
          {:status  (if ok? :running :error)
@@ -835,7 +849,8 @@
         {:ok?           ok?
          :elapsed-ms    elapsed
          :text          text
-         :error-message (:error-message result)})
+         :error-message (:error-message result)
+         :step-session  step-session})
       (catch Exception e
         (set-live-progress!
          run-id
@@ -846,18 +861,26 @@
         {:ok?           false
          :elapsed-ms    (- (now-ms) started)
          :text          (str "Error: " (ex-message e))
-         :error-message (ex-message e)}))))
+         :error-message (ex-message e)
+         :step-session  step-session}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Control helpers
 ;; ---------------------------------------------------------------------------
+
+(defn- initial-control-state []
+  {:pause? false
+   :cancel? false
+   :merge? false
+   :answer nil
+   :pending-step-session nil})
 
 (defn- ensure-control!
   [run-id]
   (let [run-id (str run-id)
         a      (:run-controls @state)]
     (or (get @a run-id)
-        (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
+        (let [ctrl (atom (initial-control-state))]
           (swap! a assoc run-id ctrl)
           ctrl))))
 
@@ -1058,13 +1081,14 @@
   [{:keys [run-id task-id project-dir worktree-dir control max-steps
            current-state steps history user-confirmation user-answer
            get-api-key-fn]}]
-  (let [started-ms (now-ms)
-        max-steps* (long (or max-steps max-steps-default))
-        steps      (long (or steps 0))
-        history    (vec (or history []))
-        phase      (normalize-run-phase current-state)
-        merge?     (boolean (:merge? @control))
-        answer     (or (:answer @control) user-answer)]
+  (let [started-ms           (now-ms)
+        max-steps*           (long (or max-steps max-steps-default))
+        steps                (long (or steps 0))
+        history              (vec (or history []))
+        phase                (normalize-run-phase current-state)
+        merge?               (boolean (:merge? @control))
+        answer               (or (:answer @control) user-answer)
+        pending-step-session (:pending-step-session @control)]
     (try
       (cond
         (>= steps max-steps*)
@@ -1153,7 +1177,22 @@
                          :started-ms    started-ms
                          :error-message err})
             (let [{:keys [task children entity-type state completed-count]} derived
-                  step-state                                                (if (and (= state :wait-pr-merge) merge?) :merging-pr state)]
+                  resume-step-session
+                  (when (and (= phase :wait-user-confirmation)
+                             (seq (str answer))
+                             (map? pending-step-session))
+                    pending-step-session)
+                  step-state*
+                  (if (and (= state :wait-pr-merge) merge?) :merging-pr state)
+                  step-state
+                  (or (:step-state resume-step-session)
+                      step-state*)
+                  prompt-name
+                  (or (:step-name resume-step-session)
+                      (step-prompt-name entity-type step-state))
+                  confirmation-context
+                  (or user-confirmation
+                      (:user-confirmation resume-step-session))]
               (cond
                 (= state :terminated)
                 (run-result {:status        :done
@@ -1190,56 +1229,64 @@
                              :history           history
                              :started-ms        started-ms
                              :pause-reason      :wait-user-confirmation
-                             :user-confirmation user-confirmation})
+                             :user-confirmation confirmation-context})
 
                 :else
-                (if-let [prompt-name (step-prompt-name entity-type step-state)]
-                  (let [prompt-body    (resolve-step-prompt project-dir prompt-name)
-                        cat-prompt     (resolve-category-for-step
-                                        prompt-name task children entity-type project-dir)
-                        step-start     (now-ms)
-                        step-result    (run-step-subagent!
-                                        {:run-id run-id
-                                         :step-name prompt-name
-                                         :prompt-body prompt-body
-                                         :task-id task-id
-                                         :entity-type entity-type
-                                         :project-dir project-dir
-                                         :worktree-dir worktree-dir
-                                         :task task
-                                         :children children
-                                         :state step-state
-                                         :user-confirmation user-confirmation
-                                         :user-answer user-answer
-                                         :get-api-key-fn get-api-key-fn
-                                         :category-prompt cat-prompt})
+                (if prompt-name
+                  (let [prompt-body (resolve-step-prompt project-dir prompt-name)
+                        cat-prompt  (resolve-category-for-step
+                                     prompt-name task children entity-type project-dir)
+                        step-start  (now-ms)
+                        step-result (run-step-subagent!
+                                     {:run-id run-id
+                                      :step-name prompt-name
+                                      :prompt-body prompt-body
+                                      :task-id task-id
+                                      :entity-type entity-type
+                                      :project-dir project-dir
+                                      :worktree-dir worktree-dir
+                                      :task task
+                                      :children children
+                                      :state step-state
+                                      :user-confirmation confirmation-context
+                                      :user-answer answer
+                                      :get-api-key-fn get-api-key-fn
+                                      :category-prompt cat-prompt
+                                      :resume-step-session resume-step-session})
                         step-elapsed (- (now-ms) step-start)
                         base-entry   {:state      step-state
                                       :step       prompt-name
                                       :elapsed-ms step-elapsed
                                       :output     (task-preview (:text step-result) 500)}]
                     (if-not (:ok? step-result)
-                      (let [history' (conj history (assoc base-entry :ok? false))]
-                        (run-result {:status        :error
-                                     :run-id        run-id
-                                     :task-id       task-id
-                                     :entity-type   entity-type
-                                     :worktree-dir  worktree-dir
-                                     :current-state step-state
-                                     :steps         steps
-                                     :history       history'
-                                     :last-step     prompt-name
-                                     :last-output   (task-preview (:text step-result) 500)
-                                     :started-ms    started-ms
-                                     :error-message (or (:error-message step-result)
-                                                        (:text step-result)
-                                                        "Step failed")}))
+                      (do
+                        (when (instance? clojure.lang.IAtom control)
+                          (swap! control assoc :answer nil :pending-step-session nil))
+                        (let [history' (conj history (assoc base-entry :ok? false))]
+                          (run-result {:status        :error
+                                       :run-id        run-id
+                                       :task-id       task-id
+                                       :entity-type   entity-type
+                                       :worktree-dir  worktree-dir
+                                       :current-state step-state
+                                       :steps         steps
+                                       :history       history'
+                                       :last-step     prompt-name
+                                       :last-output   (task-preview (:text step-result) 500)
+                                       :started-ms    started-ms
+                                       :error-message (or (:error-message step-result)
+                                                          (:text step-result)
+                                                          "Step failed")})))
                       (let [confirmation (parse-user-confirmation (:text step-result))
                             history'     (conj history (assoc base-entry :ok? true))]
                         (if confirmation
                           (do
                             (when (instance? clojure.lang.IAtom control)
-                              (swap! control assoc :answer nil :pause? false))
+                              (swap! control assoc
+                                     :answer nil
+                                     :pause? false
+                                     :pending-step-session (or (:step-session step-result)
+                                                               resume-step-session)))
                             (run-result {:status            :paused
                                          :run-id            run-id
                                          :task-id           task-id
@@ -1254,53 +1301,70 @@
                                          :pause-reason      :wait-user-confirmation
                                          :user-confirmation confirmation
                                          :user-answer       nil}))
-                          (let [derived2 (derive-current! project-dir worktree-dir task-id)]
-                            (if-let [err2 (:error derived2)]
-                              (run-result {:status        :error
-                                           :run-id        run-id
-                                           :task-id       task-id
-                                           :entity-type   entity-type
-                                           :worktree-dir  worktree-dir
-                                           :current-state step-state
-                                           :steps         steps
-                                           :history       history'
-                                           :last-step     prompt-name
-                                           :last-output   (task-preview (:text step-result) 500)
-                                           :started-ms    started-ms
-                                           :error-message err2})
-                              (let [next-state     (:state derived2)
-                                    next-completed (:completed-count derived2)
-                                    next-task      (:task derived2)
-                                    next-children  (:children derived2)
-                                    pre-snapshot   (progress-snapshot entity-type
-                                                                      task
-                                                                      children
-                                                                      completed-count)
-                                    next-snapshot  (progress-snapshot entity-type
-                                                                      next-task
-                                                                      next-children
-                                                                      next-completed)
-                                    progress?      (not (no-progress? state
-                                                                      next-state
-                                                                      completed-count
-                                                                      next-completed
-                                                                      pre-snapshot
-                                                                      next-snapshot))
-                                    history-entry  (assoc base-entry
-                                                          :ok? true
-                                                          :next-state next-state
-                                                          :completed-count next-completed
-                                                          :progress? progress?)
-                                    history''      (conj history history-entry)
-                                    has-tasks-stall? (and (= state :has-tasks)
-                                                          (= next-state :has-tasks))
-                                    no-progress-streak (when has-tasks-stall?
-                                                         (has-tasks-no-progress-streak history''))]
-                                (cond
-                                  progress?
-                                  (do
-                                    (when (= step-state :merging-pr)
-                                      (swap! control assoc :merge? false))
+                          (do
+                            (when (instance? clojure.lang.IAtom control)
+                              (swap! control assoc :answer nil :pending-step-session nil))
+                            (let [derived2 (derive-current! project-dir worktree-dir task-id)]
+                              (if-let [err2 (:error derived2)]
+                                (run-result {:status        :error
+                                             :run-id        run-id
+                                             :task-id       task-id
+                                             :entity-type   entity-type
+                                             :worktree-dir  worktree-dir
+                                             :current-state step-state
+                                             :steps         steps
+                                             :history       history'
+                                             :last-step     prompt-name
+                                             :last-output   (task-preview (:text step-result) 500)
+                                             :started-ms    started-ms
+                                             :error-message err2})
+                                (let [next-state     (:state derived2)
+                                      next-completed (:completed-count derived2)
+                                      next-task      (:task derived2)
+                                      next-children  (:children derived2)
+                                      pre-snapshot   (progress-snapshot entity-type
+                                                                        task
+                                                                        children
+                                                                        completed-count)
+                                      next-snapshot  (progress-snapshot entity-type
+                                                                        next-task
+                                                                        next-children
+                                                                        next-completed)
+                                      progress?      (not (no-progress? state
+                                                                        next-state
+                                                                        completed-count
+                                                                        next-completed
+                                                                        pre-snapshot
+                                                                        next-snapshot))
+                                      history-entry  (assoc base-entry
+                                                            :ok? true
+                                                            :next-state next-state
+                                                            :completed-count next-completed
+                                                            :progress? progress?)
+                                      history''      (conj history history-entry)
+                                      has-tasks-stall? (and (= state :has-tasks)
+                                                            (= next-state :has-tasks))
+                                      no-progress-streak (when has-tasks-stall?
+                                                           (has-tasks-no-progress-streak history''))]
+                                  (cond
+                                    progress?
+                                    (do
+                                      (when (= step-state :merging-pr)
+                                        (swap! control assoc :merge? false))
+                                      (run-result {:status        :running
+                                                   :run-id        run-id
+                                                   :task-id       task-id
+                                                   :entity-type   entity-type
+                                                   :worktree-dir  worktree-dir
+                                                   :current-state :derive-state
+                                                   :steps         (inc steps)
+                                                   :history       history''
+                                                   :last-step     prompt-name
+                                                   :last-output   (task-preview (:text step-result) 500)
+                                                   :started-ms    started-ms}))
+
+                                    (and has-tasks-stall?
+                                         (< no-progress-streak max-has-tasks-no-progress-default))
                                     (run-result {:status        :running
                                                  :run-id        run-id
                                                  :task-id       task-id
@@ -1311,40 +1375,26 @@
                                                  :history       history''
                                                  :last-step     prompt-name
                                                  :last-output   (task-preview (:text step-result) 500)
-                                                 :started-ms    started-ms}))
+                                                 :started-ms    started-ms})
 
-                                  (and has-tasks-stall?
-                                       (< no-progress-streak max-has-tasks-no-progress-default))
-                                  (run-result {:status        :running
-                                               :run-id        run-id
-                                               :task-id       task-id
-                                               :entity-type   entity-type
-                                               :worktree-dir  worktree-dir
-                                               :current-state :derive-state
-                                               :steps         (inc steps)
-                                               :history       history''
-                                               :last-step     prompt-name
-                                               :last-output   (task-preview (:text step-result) 500)
-                                               :started-ms    started-ms})
-
-                                  :else
-                                  (run-result {:status        :error
-                                               :run-id        run-id
-                                               :task-id       task-id
-                                               :entity-type   entity-type
-                                               :worktree-dir  worktree-dir
-                                               :current-state next-state
-                                               :steps         (inc steps)
-                                               :history       history''
-                                               :last-step     prompt-name
-                                               :last-output   (task-preview (:text step-result) 500)
-                                               :started-ms    started-ms
-                                               :error-message (if has-tasks-stall?
-                                                                (str "No progress after step " prompt-name
-                                                                     ", state remained " (name next-state)
-                                                                     " for " no-progress-streak " consecutive attempt(s)")
-                                                                (str "No progress after step " prompt-name
-                                                                     ", state remained " (name next-state)))})))))))))
+                                    :else
+                                    (run-result {:status        :error
+                                                 :run-id        run-id
+                                                 :task-id       task-id
+                                                 :entity-type   entity-type
+                                                 :worktree-dir  worktree-dir
+                                                 :current-state next-state
+                                                 :steps         (inc steps)
+                                                 :history       history''
+                                                 :last-step     prompt-name
+                                                 :last-output   (task-preview (:text step-result) 500)
+                                                 :started-ms    started-ms
+                                                 :error-message (if has-tasks-stall?
+                                                                  (str "No progress after step " prompt-name
+                                                                       ", state remained " (name next-state)
+                                                                       " for " no-progress-streak " consecutive attempt(s)")
+                                                                  (str "No progress after step " prompt-name
+                                                                       ", state remained " (name next-state)))}))))))))))
                   (run-result {:status        :error
                                :run-id        run-id
                                :task-id       task-id
@@ -1387,7 +1437,7 @@
         control (or (control-for run-id)
                     (ensure-control! run-id))]
     (when (instance? clojure.lang.IAtom control)
-      (reset! control {:pause? false :cancel? false :merge? false :answer nil}))
+      (reset! control (initial-control-state)))
     (set-live-progress!
      run-id
      {:status  :running
@@ -1522,7 +1572,7 @@
         control (or (control-for run-id)
                     (ensure-control! run-id))]
     (when (instance? clojure.lang.IAtom control)
-      (swap! control assoc :pause? false :cancel? false :merge? false :answer nil))
+      (reset! control (initial-control-state)))
     (set-live-progress!
      run-id
      {:status  :running
@@ -1852,8 +1902,16 @@
 
       (= "resume" cmd)
       (if-let [rid (second parts)]
-        (let [arg3 (nth parts 2 nil)]
-          (resume-run! rid (= "merge" arg3) (when (and arg3 (not= "merge" arg3)) arg3)))
+        (let [resume-args (drop 2 parts)
+              arg3        (first resume-args)
+              merge?      (= "merge" arg3)
+              answer      (when (seq resume-args)
+                            (if merge?
+                              (some->> (next resume-args)
+                                       seq
+                                       (str/join " "))
+                              (str/join " " resume-args)))]
+          (resume-run! rid merge? answer))
         (println "Usage: /mcp-tasks-run resume <run-id> [merge|<answer>]"))
 
       (= "cancel" cmd)

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -345,7 +345,12 @@
 
 (deftest workflow-user-confirmation-wait-and-resume-test
   (testing "run-loop-job pauses explicitly on user confirmation marker"
-    (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
+    (let [pending-session {:agent-ctx :ctx
+                           :session-ctx :session
+                           :model {:id "test"}
+                           :step-name "review-story-implementation"
+                           :step-state :done}
+          ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
       (with-redefs [sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
                                           {:task {:id 42 :type :task}
                                            :children []
@@ -355,6 +360,7 @@
                     sut/resolve-step-prompt (fn [_project-dir _prompt-name] "prompt")
                     sut/run-step-subagent! (fn [_]
                                              {:ok? true
+                                              :step-session pending-session
                                               :text "MCP_TASKS_RUN_USER_CONFIRMATION: {:question \"Continue?\" :expected-answer :yes-no}"})]
         (let [res (#'sut/run-loop-job {:run-id "run-1"
                                        :task-id 42
@@ -370,7 +376,61 @@
           (is (= :paused (:status res)))
           (is (= :wait-user-confirmation (:current-state res)))
           (is (= :wait-user-confirmation (:pause-reason res)))
-          (is (= "Continue?" (get-in res [:user-confirmation :question]))))))))
+          (is (= "Continue?" (get-in res [:user-confirmation :question])))
+          (is (= pending-session (:pending-step-session @ctrl))))))))
+
+(deftest workflow-user-confirmation-resume-routes-to-asking-session-test
+  (testing "resume answer is sent back to the session that asked"
+    (let [pending-session {:agent-ctx :ctx
+                           :session-ctx :session
+                           :model {:id "test"}
+                           :step-name "review-story-implementation"
+                           :step-state :done}
+          ctrl            (atom {:pause? false
+                                 :cancel? false
+                                 :merge? false
+                                 :answer "create follow-up tasks"
+                                 :pending-step-session pending-session})
+          captured        (atom nil)
+          derived-states  (atom [{:task {:id 42 :type :story :status :open :meta {:refined "true"}}
+                                  :children [{:id 1 :status :done :meta {:refined "true"}}]
+                                  :entity-type :story
+                                  :state :done
+                                  :completed-count 1}
+                                 {:task {:id 42 :type :story :status :open :meta {:refined "true"}}
+                                  :children [{:id 1 :status :done :meta {:refined "true"}}
+                                             {:id 2 :status :open :meta {}}]
+                                  :entity-type :story
+                                  :state :has-tasks
+                                  :completed-count 1}])]
+      (with-redefs [sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
+                                          (let [entry (first @derived-states)]
+                                            (swap! derived-states #(if (seq %) (vec (rest %)) %))
+                                            entry))
+                    sut/resolve-step-prompt (fn [_project-dir _prompt-name] "prompt")
+                    sut/run-step-subagent! (fn [args]
+                                             (reset! captured args)
+                                             {:ok? true
+                                              :step-session pending-session
+                                              :text "Processed answer and created new story tasks."})]
+        (let [res (#'sut/run-loop-job {:run-id "run-1"
+                                       :task-id 42
+                                       :project-dir "/tmp"
+                                       :worktree-dir "/tmp/wt"
+                                       :control ctrl
+                                       :current-state :wait-user-confirmation
+                                       :steps 1
+                                       :history []
+                                       :user-confirmation {:question "Which review items should be added?"}
+                                       :user-answer nil
+                                       :max-steps 10})]
+          (is (= :running (:status res)))
+          (is (= :derive-state (:current-state res)))
+          (is (= pending-session (:resume-step-session @captured)))
+          (is (= "create follow-up tasks" (:user-answer @captured)))
+          (is (= "review-story-implementation" (:step-name @captured)))
+          (is (nil? (:pending-step-session @ctrl)))
+          (is (nil? (:answer @ctrl))))))))
 
 (deftest start-run-admission-policy-test
   (testing "allows concurrent runs for distinct task IDs"
@@ -512,10 +572,12 @@
                :psi.extension.workflow/phase :paused
                :psi.extension.workflow/data {:run/pause-reason :wait-user-confirmation})
         (let [before (count (send-events))]
-          (with-out-str (handler "resume run-1 yes"))
+          (with-out-str (handler "resume run-1 add review-item-1 and review-item-2"))
           (let [events (drop before (send-events))]
             (is (= 1 (count events)))
-            (is (= "run-1" (get-in (first events) [:params :id])))))
+            (is (= "run-1" (get-in (first events) [:params :id])))
+            (is (= "add review-item-1 and review-item-2"
+                   (get-in (first events) [:params :data :answer])))))
 
         (swap! state update-in [:workflows "run-1"]
                assoc
@@ -843,3 +905,51 @@
           (is (= fake-model (nth @captured 3)))
           (is (= "user" (get-in (nth @captured 4) [0 :role])))
           (is (= {:turn-ctx-atom nil} (nth @captured 5))))))))
+
+(deftest run-step-subagent-resume-session-test
+  (testing "run-step-subagent reuses the pending asking session on resume"
+    (let [captured         (atom nil)
+          fake-agent-ctx   {:fake :agent-ctx}
+          fake-session-ctx {:agent-ctx fake-agent-ctx
+                            :session-data-atom (atom {:tool-output-overrides {}})
+                            :tool-output-stats-atom (atom {:calls []
+                                                           :aggregates {:total-context-bytes 0
+                                                                        :by-tool {}
+                                                                        :limit-hits-by-tool {}}})}
+          fake-model       {:provider "anthropic" :id "sonnet"}
+          resume-session   {:agent-ctx fake-agent-ctx
+                            :session-ctx fake-session-ctx
+                            :model fake-model
+                            :step-name "review-story-implementation"
+                            :step-state :done}]
+      (with-redefs [sut/set-live-progress! (fn [& _])
+                    sut/create-step-agent-ctx (fn [_]
+                                                (throw (ex-info "should not create a new agent ctx" {})))
+                    sut/create-step-session-ctx (fn [_]
+                                                  (throw (ex-info "should not create a new session ctx" {})))
+                    executor/run-agent-loop! (fn [& args]
+                                               (reset! captured args)
+                                               {:role "assistant"
+                                                :stop-reason :stop
+                                                :content [{:type :text :text "ok"}]})]
+        (let [result (#'sut/run-step-subagent!
+                      {:run-id "run-1"
+                       :step-name "review-story-implementation"
+                       :prompt-body "prompt"
+                       :task-id 42
+                       :entity-type :story
+                       :project-dir "/tmp"
+                       :worktree-dir "/tmp/wt"
+                       :task {:id 42 :type :story}
+                       :children [{:id 1 :status :done}]
+                       :state :done
+                       :user-answer "Create two follow-up tasks first."
+                       :resume-step-session resume-session})]
+          (is (:ok? result))
+          (is (= 6 (count @captured)))
+          (is (= fake-session-ctx (nth @captured 1)))
+          (is (= fake-agent-ctx (nth @captured 2)))
+          (is (= fake-model (nth @captured 3)))
+          (is (= "Create two follow-up tasks first."
+                 (get-in (nth @captured 4) [0 :content 0 :text])))
+          (is (= resume-session (:step-session result))))))))

--- a/spec/coding-agent.allium
+++ b/spec/coding-agent.allium
@@ -642,6 +642,8 @@ surface RpcApi {
         -- Commands, responses, events, and errors use canonical EDN envelopes over stdio.
         -- Events are interleaved with responses; callers match by :id where present.
         -- The RpcClient may integrate as a library or over stdio.
+        -- query_eql is the discovery path for live graph + memory surfaces
+        -- (for example :psi.graph/* and :psi.memory/* attributes).
         -- Canonical frame shapes, event payload catalog, and MUST/SHOULD compatibility/versioning policy are specified in rpc-edn.allium.
         -- Emacs-specific parity behavior is specified in emacs-frontend.allium.
 }

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -236,6 +236,8 @@ surface EmacsSessionApi {
         -- behavior values for prompt_while_streaming: queue | steer | follow_up | reject.
         -- Emacs mode is not headless fallback: extension UI operations are active.
         -- /resume parity requires list_sessions + resume_session with rehydrated tool rows.
+        -- query_eql should expose runtime graph + memory attrs when available,
+        -- e.g. :psi.graph/domain-coverage and :psi.memory/status.
         -- Wire protocol details (canonical envelopes, event payloads, versioning policy)
         -- are defined in rpc-edn.allium.
 }

--- a/spec/feed-forward-recursion.allium
+++ b/spec/feed-forward-recursion.allium
@@ -250,6 +250,11 @@ config {
         "manual", "session_end", "graph_changed", "memory_updated", "verification_failed"
     }
 
+    -- Internal manual-trigger prompt definition (spec-owned, not external).
+    internal_manual_trigger_prompt_name: String = "feed-forward-manual-trigger"
+    internal_manual_trigger_prompt: String =
+        "Trigger a manual feed-forward cycle. Capture operator reason and current readiness context."
+
     required_recursion_eql_attrs: Set<String> = {
         ":psi.recursion/status",
         ":psi.recursion/paused?",
@@ -600,7 +605,26 @@ surface FeedForwardControlApi {
         graph/CapabilityGraphApi(ActiveCapabilityGraph())
 }
 
+surface FeedForwardManualTriggerApi {
+    -- Explicit manual-trigger surface for operator-initiated feed-forward cycles.
+    for operator: FeedForwardOperator
+
+    context controller: FeedForwardController
+
+    provides:
+        TriggerFeedForward(operator, reason)
+            when controller.canStartCycle
+            when "manual" in config.enabled_trigger_hooks
+
+    guidance:
+        -- Emits TriggerSignal.type = manual.
+        -- Prompt name: config.internal_manual_trigger_prompt_name
+        -- Prompt body: config.internal_manual_trigger_prompt
+        -- This prompt is internally defined by this spec (not an external /template).
+}
+
 -- Resolved: Step 11 uses explicit/manual + event-driven hooks (no periodic cadence).
 -- Hook activation is controlled by config.enabled_trigger_hooks.
 -- Resolved: manual approval remains default; low-risk auto-approval is opt-in
 -- via trusted_local_mode_enabled + auto_approve_low_risk_in_trusted_local_mode.
+-- Manual-trigger prompt note: internal prompt "feed-forward-manual-trigger" (spec-defined).

--- a/spec/rpc-edn.allium
+++ b/spec/rpc-edn.allium
@@ -648,11 +648,20 @@ surface RpcTransportApi {
         --   {:id "42" :kind :request :op "prompt" :params {:message "Summarize this ns"}}
         -- Example response frame:
         --   {:id "42" :kind :response :op "prompt" :ok true :data {:message-id "msg_9"}}
+        -- Example query_eql request frame:
+        --   {:id "43" :kind :request :op "query_eql"
+        --    :params {:query "[:psi.graph/domain-coverage :psi.memory/status]"}}
+        -- Example query_eql response frame:
+        --   {:id "43" :kind :response :op "query_eql" :ok true
+        --    :data {:result {:psi.graph/domain-coverage [...]
+        --                    :psi.memory/status :ready}}}
         -- Example event frame:
         --   {:kind :event :event "tool/start" :seq 18 :data {:tool-id "tc_1" :tool-name "read"}}
         -- Example error frame:
         --   {:kind :error :id "42" :op "prompt" :error-code "transport/not-ready"
         --    :error-message "handshake required" :retryable true}
+        -- Handshake feature strings are implementation-defined; deployments MAY
+        -- advertise discovery hints such as "eql-graph" and "eql-memory".
         -- Keep stdout protocol-only; write logs/diagnostics to stderr.
 }
 


### PR DESCRIPTION
## Summary
Implement runtime EDN RPC transport conforming to `spec/rpc-edn.allium` protocol `1.0`.

### Delivered
- EDN-lines stdio RPC loop with canonical response/error/event envelopes
- Protocol-only stdout discipline (diagnostics/logging on stderr)
- Handshake/readiness gate with protocol major compatibility checks
- Pending request lifecycle (`:id -> :op`) with duplicate/max-pending guards and terminal cleanup
- RPC op router mapped to AgentSession APIs, including `query_eql` parity for `:psi.graph/*` and `:psi.memory/*`
- Canonical async event bridge with topic catalog compliance, monotonic `:seq`, and `:ts`
- Contract/integration/E2E tests including handshake → `query_eql`(graph+memory) → prompt streaming with interleaved events

## Design Notes
- `spec/rpc-edn.allium` used as normative contract for envelope shape and event catalog
- Unsupported ops return canonical `request/op-not-supported`
- Unknown event payload additions remain compatibility-safe (ignore-by-default)
- No protocol version bump (remains `1.0`)

## Commits
- f5d4d65 ⚒ Task 83: add rpc-edn E2E handshake/query/stream coverage
- ed7b879 ⚒ Implement Task #81 RPC op router + query_eql parity
- 28bff1b ⚒ Implement rpc-edn handshake gate + pending lifecycle for task 80
- b37e3cd ⚒ Task 79: add rpc-edn stdio loop, canonical frame writer, and stdout discipline
- 34cc94c ⚒ Define rpc-edn op mapping contract for story 76