### PR TITLE
feat: Complete feed-forward runtime integration and orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ clojure -M:run --tui --nrepl 8888
 
 ### In-session commands
 
-`/status` `/history` `/new` `/help` `/quit` `/skills` `/prompts`
+`/status` `/history` `/new` `/help` `/quit` `/skills` `/prompts` `/feed-forward [reason]`
 `/skill:<name>` plus any extension commands
+
+`/feed-forward` triggers a manual recursion cycle from the runtime command surface.
+It is bound to the internal spec prompt name `feed-forward-manual-trigger`.
 
 ---
 

--- a/components/agent-session/deps.edn
+++ b/components/agent-session/deps.edn
@@ -7,4 +7,5 @@
         psi/agent-core              {:local/root "../agent-core"}
         psi/ai                      {:local/root "../ai"}
         psi/query                   {:local/root "../query"}
+        psi/recursion               {:local/root "../recursion"}
         psi/tui                     {:local/root "../tui"}}}

--- a/components/agent-session/src/psi/agent_session/commands.clj
+++ b/components/agent-session/src/psi/agent_session/commands.clj
@@ -21,7 +21,8 @@
    [psi.agent-session.extensions :as ext]
    [psi.agent-session.prompt-templates :as pt]
    [psi.agent-session.oauth.core :as oauth]
-   [psi.agent-core.core :as agent]))
+   [psi.agent-core.core :as agent]
+   [psi.recursion.core :as recursion]))
 
 ;; ============================================================
 ;; Formatting helpers (pure — return strings, no side effects)
@@ -84,6 +85,7 @@
          "  /resume  — resume a previous session\n"
          "  /login [provider] — login with an OAuth provider\n"
          "  /logout  — logout from an OAuth provider\n"
+         "  /feed-forward [reason] — trigger a manual feed-forward cycle\n"
          "  /help    — show this help\n"
          "  /skill:name — invoke a skill (loads full content)"
          (when (seq templates)
@@ -153,6 +155,38 @@
   {:anthropic "ANTHROPIC_API_KEY"
    :openai    "OPENAI_API_KEY"
    :google    "GOOGLE_API_KEY"})
+
+(def ^:private default-feed-forward-readiness
+  {:query-ready true
+   :graph-ready true
+   :introspection-ready true
+   :memory-ready true})
+
+(defn- feed-forward-trigger-signal
+  [reason]
+  (recursion/manual-trigger-signal reason {:source :runtime-command}))
+
+(defn- format-feed-forward-trigger-result
+  [result]
+  (case (:result result)
+    :accepted
+    (str "✓ Feed-forward trigger accepted"
+         "\n  cycle-id: " (:cycle-id result)
+         "\n  prompt: " recursion/feed-forward-manual-trigger-prompt-name)
+
+    :blocked
+    (str "‖ Feed-forward trigger blocked"
+         "\n  cycle-id: " (:cycle-id result)
+         "\n  reason: recursion_prerequisites_not_ready")
+
+    :ignored
+    "… Feed-forward trigger ignored (manual hook disabled)."
+
+    :rejected
+    (str "✗ Feed-forward trigger rejected"
+         "\n  reason: " (name (:reason result)))
+
+    (str result)))
 
 ;; ============================================================
 ;; Login provider selection (pure — returns data)
@@ -237,6 +271,21 @@
       ;; Skills
       (= trimmed "/skills")
       {:type :text :message (format-skills ctx)}
+
+      ;; Feed-forward manual trigger
+      (or (= trimmed "/feed-forward")
+          (str/starts-with? trimmed "/feed-forward "))
+      (if-let [recursion-ctx (:recursion-ctx ctx)]
+        (let [reason (-> (str/replace trimmed #"^/feed-forward\s*" "")
+                         (str/trim)
+                         (not-empty))
+              result (recursion/handle-trigger-in! recursion-ctx
+                                                   (feed-forward-trigger-signal reason)
+                                                   default-feed-forward-readiness)]
+          {:type :text
+           :message (format-feed-forward-trigger-result result)})
+        {:type :text
+         :message "✗ Feed-forward recursion context not configured."})
 
       ;; Login
       (or (= trimmed "/login")

--- a/components/agent-session/src/psi/agent_session/commands.clj
+++ b/components/agent-session/src/psi/agent_session/commands.clj
@@ -162,6 +162,21 @@
    :introspection-ready true
    :memory-ready true})
 
+(defn- readiness-from-session
+  "Derive recursion readiness from live session query + memory state.
+   Falls back to default all-ready values when attrs are unavailable."
+  [ctx]
+  (let [snapshot (session/query-in ctx
+                                   [:psi.graph/nodes
+                                    :psi.graph/edges
+                                    :psi.memory/status])
+        memory-ready? (= :ready (:psi.memory/status snapshot))
+        graph-ready? (and (seq (:psi.graph/nodes snapshot))
+                          (seq (:psi.graph/edges snapshot)))]
+    (merge default-feed-forward-readiness
+           {:graph-ready graph-ready?
+            :memory-ready memory-ready?})))
+
 (defn- feed-forward-trigger-signal
   [reason]
   (recursion/manual-trigger-signal reason {:source :runtime-command}))
@@ -279,9 +294,10 @@
         (let [reason (-> (str/replace trimmed #"^/feed-forward\s*" "")
                          (str/trim)
                          (not-empty))
+              readiness (readiness-from-session ctx)
               result (recursion/handle-trigger-in! recursion-ctx
                                                    (feed-forward-trigger-signal reason)
-                                                   default-feed-forward-readiness)]
+                                                   readiness)]
           {:type :text
            :message (format-feed-forward-trigger-result result)})
         {:type :text

--- a/components/agent-session/src/psi/agent_session/commands.clj
+++ b/components/agent-session/src/psi/agent_session/commands.clj
@@ -162,46 +162,66 @@
    :introspection-ready true
    :memory-ready true})
 
-(defn- readiness-from-session
-  "Derive recursion readiness from live session query + memory state.
-   Falls back to default all-ready values when attrs are unavailable."
+(defn- runtime-feed-forward-inputs
+  "Derive live runtime readiness + observe snapshots from session query state.
+   Falls back to safe defaults when attrs are unavailable."
   [ctx]
   (let [snapshot (session/query-in ctx
                                    [:psi.graph/nodes
                                     :psi.graph/edges
-                                    :psi.memory/status])
-        memory-ready? (= :ready (:psi.memory/status snapshot))
-        graph-ready? (and (seq (:psi.graph/nodes snapshot))
-                          (seq (:psi.graph/edges snapshot)))]
-    (merge default-feed-forward-readiness
-           {:graph-ready graph-ready?
-            :memory-ready memory-ready?})))
+                                    :psi.memory/status
+                                    :psi.memory/entry-count])
+        node-count (count (:psi.graph/nodes snapshot))
+        edge-count (count (:psi.graph/edges snapshot))
+        memory-status (:psi.memory/status snapshot)
+        memory-entry-count (or (:psi.memory/entry-count snapshot) 0)
+        memory-ready? (= :ready memory-status)
+        graph-ready? (and (pos? node-count)
+                          (pos? edge-count))
+        readiness (merge default-feed-forward-readiness
+                         {:graph-ready graph-ready?
+                          :memory-ready memory-ready?})
+        graph-state {:node-count node-count
+                     :capability-count edge-count
+                     :status (if graph-ready? :stable :emerging)}
+        memory-state {:entry-count memory-entry-count
+                      :status (if memory-ready? :ready :initializing)
+                      :recovery-count 0}]
+    {:readiness readiness
+     :graph-state graph-state
+     :memory-state memory-state}))
 
 (defn- feed-forward-trigger-signal
   [reason]
   (recursion/manual-trigger-signal reason {:source :runtime-command}))
 
 (defn- format-feed-forward-trigger-result
-  [result]
-  (case (:result result)
-    :accepted
-    (str "✓ Feed-forward trigger accepted"
-         "\n  cycle-id: " (:cycle-id result)
-         "\n  prompt: " recursion/feed-forward-manual-trigger-prompt-name)
+  [trigger-result orchestration]
+  (let [phase (:phase orchestration)]
+    (case (:result trigger-result)
+      :accepted
+      (str "✓ Feed-forward trigger accepted"
+           "\n  cycle-id: " (:cycle-id trigger-result)
+           "\n  prompt: " recursion/feed-forward-manual-trigger-prompt-name
+           (case phase
+             :awaiting-approval "\n  status: awaiting approval"
+             :completed "\n  status: cycle completed"
+             :trigger "\n  status: trigger accepted"
+             (str "\n  phase: " (name phase))))
 
-    :blocked
-    (str "‖ Feed-forward trigger blocked"
-         "\n  cycle-id: " (:cycle-id result)
-         "\n  reason: recursion_prerequisites_not_ready")
+      :blocked
+      (str "‖ Feed-forward trigger blocked"
+           "\n  cycle-id: " (:cycle-id trigger-result)
+           "\n  reason: recursion_prerequisites_not_ready")
 
-    :ignored
-    "… Feed-forward trigger ignored (manual hook disabled)."
+      :ignored
+      "… Feed-forward trigger ignored (manual hook disabled)."
 
-    :rejected
-    (str "✗ Feed-forward trigger rejected"
-         "\n  reason: " (name (:reason result)))
+      :rejected
+      (str "✗ Feed-forward trigger rejected"
+           "\n  reason: " (name (:reason trigger-result)))
 
-    (str result)))
+      (str trigger-result))))
 
 ;; ============================================================
 ;; Login provider selection (pure — returns data)
@@ -294,12 +314,19 @@
         (let [reason (-> (str/replace trimmed #"^/feed-forward\s*" "")
                          (str/trim)
                          (not-empty))
-              readiness (readiness-from-session ctx)
-              result (recursion/handle-trigger-in! recursion-ctx
-                                                   (feed-forward-trigger-signal reason)
-                                                   readiness)]
+              {:keys [readiness graph-state memory-state]}
+              (runtime-feed-forward-inputs ctx)
+              orchestration
+              (recursion/orchestrate-manual-trigger-in!
+               recursion-ctx
+               (feed-forward-trigger-signal reason)
+               {:system-state readiness
+                :graph-state graph-state
+                :memory-state memory-state
+                :memory-ctx (:memory-ctx ctx)})
+              trigger-result (:trigger-result orchestration)]
           {:type :text
-           :message (format-feed-forward-trigger-result result)})
+           :message (format-feed-forward-trigger-result trigger-result orchestration)})
         {:type :text
          :message "✗ Feed-forward recursion context not configured."})
 

--- a/components/agent-session/src/psi/agent_session/core.clj
+++ b/components/agent-session/src/psi/agent_session/core.clj
@@ -241,7 +241,7 @@
     :persist?          — if false, disable all disk I/O (default: true)
     :oauth-ctx         — optional OAuth context for extension auth helpers"
   ([] (create-context {}))
-  ([{:keys [initial-session compaction-fn branch-summary-fn agent-initial config cwd persist? event-queue oauth-ctx]
+  ([{:keys [initial-session compaction-fn branch-summary-fn agent-initial config cwd persist? event-queue oauth-ctx recursion-ctx]
      :or   {persist? true}}]
    (let [sc-env            (sc/create-sc-env)
          sc-session-id     (java.util.UUID/randomUUID)
@@ -273,6 +273,7 @@
                             :cwd                   resolved-cwd
                             :persist?              persist?
                             :oauth-ctx             oauth-ctx
+                            :recursion-ctx         recursion-ctx
                             :compaction-fn         (or compaction-fn compaction/stub-compaction-fn)
                             :branch-summary-fn     (or branch-summary-fn compaction/stub-branch-summary-fn)
                             :config                merged-config}

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -676,6 +676,14 @@
                      :ui-state-atom        (:ui-state-atom ctx)
                      :dispatch-fn          dispatch-fn
                      :on-interrupt-fn!     on-interrupt-fn!
+                     :on-queue-input-fn!   (fn [text _state]
+                                              (if (= :streaming (session/sc-phase-in ctx))
+                                                (do
+                                                  (session/steer-in! ctx text)
+                                                  {:message "Queued steering message."})
+                                                (do
+                                                  (session/follow-up-in! ctx text)
+                                                  {:message "Queued follow-up message."})))
                      :double-press-window-ms 500
                      :double-escape-action :none
                      :cwd                  cwd

--- a/components/agent-session/src/psi/agent_session/main.clj
+++ b/components/agent-session/src/psi/agent_session/main.clj
@@ -53,6 +53,7 @@
    [psi.ai.models :as models]
    [psi.introspection.core :as introspection]
    [psi.memory.runtime :as memory-runtime]
+   [psi.recursion.core :as recursion]
    [psi.tui.app :as tui-app])
   (:gen-class))
 
@@ -424,12 +425,15 @@
                         :skills        skills})
         developer-prompt (developer-prompt-from-env)
         ;; session context — agent-core + statechart + extension registry
+        recursion-ctx (recursion/create-context)
+        _         (recursion/register-hooks-in! recursion-ctx)
         ctx      (session/create-context
                   {:initial-session {:model {:provider (name (:provider ai-model))
                                              :id       (:id ai-model)
                                              :reasoning (:supports-reasoning ai-model)}
                                      :system-prompt   system-prompt}
-                   :oauth-ctx oauth-ctx})
+                   :oauth-ctx oauth-ctx
+                   :recursion-ctx recursion-ctx})
         ext-paths (ext/discover-extension-paths [] cwd)]
     ;; Reusable bootstrap: session file, query graph, base tools, system prompt,
     ;; mutation-driven startup loading, extension tool merge.
@@ -545,13 +549,16 @@
                         :context-files ctx-files
                         :skills        skills})
         developer-prompt (developer-prompt-from-env)
+        recursion-ctx (recursion/create-context)
+        _         (recursion/register-hooks-in! recursion-ctx)
         ctx       (session/create-context
                    {:initial-session {:model {:provider (name (:provider ai-model))
                                               :id       (:id ai-model)
                                               :reasoning (:supports-reasoning ai-model)}
                                       :system-prompt   system-prompt}
                     :event-queue event-queue
-                    :oauth-ctx oauth-ctx})
+                    :oauth-ctx oauth-ctx
+                    :recursion-ctx recursion-ctx})
         ext-paths (ext/discover-extension-paths [] cwd)
         ;; Reusable bootstrap: session file, query graph, base tools, system prompt,
         ;; mutation-driven startup loading, extension tool merge.

--- a/components/agent-session/src/psi/agent_session/resolvers.clj
+++ b/components/agent-session/src/psi/agent_session/resolvers.clj
@@ -210,6 +210,7 @@
    [psi.memory.core :as memory]
    [psi.memory.resolvers :as memory-resolvers]
    [psi.query.registry :as registry]
+   [psi.recursion.resolvers :as recursion-resolvers]
    [psi.agent-session.persistence :as persist]
    [psi.agent-session.session :as session]
    [psi.agent-session.tool-output :as tool-output]
@@ -1379,10 +1380,14 @@
 
 (defn build-env
   "Build a Pathom3 environment for querying an agent-session context.
-   Includes memory resolvers locally so :psi.memory/* attrs are queryable via
-   agent-session/query-in."
+   Includes memory + recursion resolvers locally so :psi.memory/* and
+   :psi.recursion/* attrs are queryable via agent-session/query-in."
   []
-  (pci/register (into (vec all-resolvers) memory-resolvers/all-resolvers)))
+  (->> (concat all-resolvers
+               memory-resolvers/all-resolvers
+               recursion-resolvers/all-resolvers)
+       vec
+       pci/register))
 
 (def ^:private query-env (atom nil))
 
@@ -1390,10 +1395,12 @@
   (or @query-env (reset! query-env (build-env))))
 
 (defn query-in
-  "Run EQL `q` against `ctx` using this component's Pathom graph."
+  "Run EQL `q` against `ctx` using this component's Pathom graph.
+   Seeds memory + recursion contexts from the session when available."
   [ctx q]
   (p.eql/process (ensure-query-env!)
                  {:psi/agent-session-ctx ctx
                   :psi/memory-ctx        (or (:memory-ctx ctx)
-                                             (memory/global-context))}
+                                             (memory/global-context))
+                  :psi/recursion-ctx     (:recursion-ctx ctx)}
                  q))

--- a/components/agent-session/test/psi/agent_session/commands_test.clj
+++ b/components/agent-session/test/psi/agent_session/commands_test.clj
@@ -112,7 +112,8 @@
     (is (= :text (:type result)))
     (is (str/includes? (:message result) "trigger accepted"))
     (is (str/includes? (:message result) "feed-forward-manual-trigger"))
-    (is (str/includes? (:message result) "cycle-id:"))))
+    (is (str/includes? (:message result) "cycle-id:"))
+    (is (str/includes? (:message result) "awaiting approval"))))
 
 (deftest dispatch-feed-forward-busy-test
   (let [ctx  (-> (make-test-ctx)

--- a/components/agent-session/test/psi/agent_session/commands_test.clj
+++ b/components/agent-session/test/psi/agent_session/commands_test.clj
@@ -5,7 +5,8 @@
    [psi.agent-session.commands :as commands]
    [psi.agent-session.core :as session]
    [psi.agent-session.extensions :as ext]
-   [psi.agent-core.core :as agent]))
+   [psi.agent-core.core :as agent]
+   [psi.recursion.core :as recursion]))
 
 ;; ── Test helper ─────────────────────────────────────────────
 
@@ -26,6 +27,12 @@
 
 (def ^:private cmd-opts
   {:oauth-ctx nil :ai-model test-ai-model})
+
+(defn- with-recursion-ctx
+  [ctx]
+  (let [rctx (recursion/create-context)]
+    (recursion/register-hooks-in! rctx)
+    (assoc ctx :recursion-ctx rctx)))
 
 ;; ── dispatch tests ──────────────────────────────────────────
 
@@ -84,6 +91,28 @@
         result (commands/dispatch ctx "/skills" cmd-opts)]
     (is (= :text (:type result)))
     (is (str/includes? (:message result) "Skills"))))
+
+(deftest dispatch-feed-forward-without-recursion-ctx-test
+  (let [ctx    (make-test-ctx)
+        result (commands/dispatch ctx "/feed-forward" cmd-opts)]
+    (is (= :text (:type result)))
+    (is (str/includes? (:message result) "not configured"))))
+
+(deftest dispatch-feed-forward-accepted-test
+  (let [ctx    (with-recursion-ctx (make-test-ctx))
+        result (commands/dispatch ctx "/feed-forward verify runtime" cmd-opts)]
+    (is (= :text (:type result)))
+    (is (str/includes? (:message result) "trigger accepted"))
+    (is (str/includes? (:message result) "feed-forward-manual-trigger"))
+    (is (str/includes? (:message result) "cycle-id:"))))
+
+(deftest dispatch-feed-forward-busy-test
+  (let [ctx  (with-recursion-ctx (make-test-ctx))
+        _    (commands/dispatch ctx "/feed-forward first" cmd-opts)
+        busy (commands/dispatch ctx "/feed-forward second" cmd-opts)]
+    (is (= :text (:type busy)))
+    (is (str/includes? (:message busy) "trigger rejected"))
+    (is (str/includes? (:message busy) "controller-busy"))))
 
 (deftest dispatch-not-a-command-test
   (testing "plain text returns nil"
@@ -149,7 +178,7 @@
   (let [ctx (make-test-ctx)
         s   (commands/format-help ctx)]
     (doseq [cmd ["/quit" "/status" "/history" "/new" "/resume"
-                 "/login" "/logout" "/help" "/prompts" "/skills"]]
+                 "/login" "/logout" "/feed-forward" "/help" "/prompts" "/skills"]]
       (is (str/includes? s cmd) (str "help should mention " cmd)))))
 
 (deftest format-prompts-none-test

--- a/components/agent-session/test/psi/agent_session/commands_test.clj
+++ b/components/agent-session/test/psi/agent_session/commands_test.clj
@@ -6,6 +6,7 @@
    [psi.agent-session.core :as session]
    [psi.agent-session.extensions :as ext]
    [psi.agent-core.core :as agent]
+   [psi.memory.core :as memory]
    [psi.recursion.core :as recursion]))
 
 ;; ── Test helper ─────────────────────────────────────────────
@@ -33,6 +34,11 @@
   (let [rctx (recursion/create-context)]
     (recursion/register-hooks-in! rctx)
     (assoc ctx :recursion-ctx rctx)))
+
+(defn- with-ready-memory-ctx
+  [ctx]
+  (assoc ctx :memory-ctx
+         (memory/create-context {:state-overrides {:status :ready}})))
 
 ;; ── dispatch tests ──────────────────────────────────────────
 
@@ -99,7 +105,9 @@
     (is (str/includes? (:message result) "not configured"))))
 
 (deftest dispatch-feed-forward-accepted-test
-  (let [ctx    (with-recursion-ctx (make-test-ctx))
+  (let [ctx    (-> (make-test-ctx)
+                   with-recursion-ctx
+                   with-ready-memory-ctx)
         result (commands/dispatch ctx "/feed-forward verify runtime" cmd-opts)]
     (is (= :text (:type result)))
     (is (str/includes? (:message result) "trigger accepted"))
@@ -107,12 +115,21 @@
     (is (str/includes? (:message result) "cycle-id:"))))
 
 (deftest dispatch-feed-forward-busy-test
-  (let [ctx  (with-recursion-ctx (make-test-ctx))
+  (let [ctx  (-> (make-test-ctx)
+                 with-recursion-ctx
+                 with-ready-memory-ctx)
         _    (commands/dispatch ctx "/feed-forward first" cmd-opts)
         busy (commands/dispatch ctx "/feed-forward second" cmd-opts)]
     (is (= :text (:type busy)))
     (is (str/includes? (:message busy) "trigger rejected"))
     (is (str/includes? (:message busy) "controller-busy"))))
+
+(deftest dispatch-feed-forward-blocked-when-live-readiness-fails-test
+  (let [ctx    (with-recursion-ctx (make-test-ctx))
+        result (commands/dispatch ctx "/feed-forward check live readiness" cmd-opts)]
+    (is (= :text (:type result)))
+    (is (str/includes? (:message result) "trigger blocked"))
+    (is (str/includes? (:message result) "recursion_prerequisites_not_ready"))))
 
 (deftest dispatch-not-a-command-test
   (testing "plain text returns nil"

--- a/components/agent-session/test/psi/agent_session/core_test.clj
+++ b/components/agent-session/test/psi/agent_session/core_test.clj
@@ -12,7 +12,8 @@
    [psi.agent-core.core :as agent-core]
    [psi.agent-session.extensions :as ext]
    [psi.agent-session.persistence :as persist]
-   [psi.query.core :as query])
+   [psi.query.core :as query]
+   [psi.recursion.core :as recursion])
   (:import
    (java.io File)))
 
@@ -606,6 +607,22 @@
                                     :psi.agent-session/phase])]
         (is (string? (:psi.agent-session/session-id result)))
         (is (= :idle (:psi.agent-session/phase result)))))))
+
+(deftest session-query-in-exposes-recursion-attrs-test
+  (testing "session/query-in can read recursion attrs from live session recursion-ctx"
+    (let [rctx (recursion/create-context)
+          _    (recursion/register-hooks-in! rctx)
+          ctx  (session/create-context {:recursion-ctx rctx})
+          result (session/query-in ctx
+                                   [:psi.recursion/status
+                                    :psi.recursion/paused?
+                                    :psi.recursion/current-cycle
+                                    :psi.recursion/hooks])]
+      (is (= :idle (:psi.recursion/status result)))
+      (is (false? (:psi.recursion/paused? result)))
+      (is (nil? (:psi.recursion/current-cycle result)))
+      (is (vector? (:psi.recursion/hooks result)))
+      (is (pos? (count (:psi.recursion/hooks result)))))))
 
 (deftest workflow-mutations-and-resolvers-test
   (testing "workflow mutation ops and resolver attrs are wired"

--- a/components/recursion/src/psi/recursion/core.clj
+++ b/components/recursion/src/psi/recursion/core.clj
@@ -108,6 +108,33 @@
 
 ;;; --- Trigger intake and readiness gating ---
 
+(def feed-forward-manual-trigger-prompt-name
+  "feed-forward-manual-trigger")
+
+(def feed-forward-manual-trigger-prompt
+  "Trigger a manual feed-forward cycle. Capture operator reason and current readiness context.")
+
+(defn manual-trigger-signal
+  "Build a canonical manual TriggerSignal payload shared by runtime command
+   and EQL mutation entrypoints.
+
+   Optional opts:
+   - :actor   operator/actor identity string (default: operator)
+   - :source  invocation source keyword (e.g. :runtime-command, :eql-mutation)
+   - :extra-payload map merged into payload"
+  ([reason]
+   (manual-trigger-signal reason {}))
+  ([reason {:keys [actor source extra-payload]
+            :or {actor "operator" source :unknown extra-payload {}}}]
+   {:type :manual
+    :reason (or reason "manual-trigger")
+    :payload (merge {:prompt-name feed-forward-manual-trigger-prompt-name
+                     :prompt-body feed-forward-manual-trigger-prompt
+                     :actor actor
+                     :source source}
+                    extra-payload)
+    :timestamp (java.time.Instant/now)}))
+
 (defn- new-cycle
   "Create a new cycle record for `trigger-signal` with the given initial `status`."
   [trigger-signal status]

--- a/components/recursion/src/psi/recursion/core.clj
+++ b/components/recursion/src/psi/recursion/core.clj
@@ -6,6 +6,7 @@
    observation, FUTURE_STATE synthesis, plan proposal generation,
    approval gates, execution, verification, learning, and cycle finalization."
   (:require
+   [clojure.string :as str]
    [psi.recursion.future-state :as future-state]
    [psi.recursion.policy :as policy]))
 
@@ -214,6 +215,258 @@
   "Global wrapper for `handle-trigger-in!`."
   [trigger-signal system-state]
   (handle-trigger-in! (global-context) trigger-signal system-state))
+
+(declare find-cycle)
+(declare observe-in!)
+(declare plan-in!)
+(declare apply-approval-gate-in!)
+(declare approve-proposal-in!)
+(declare reject-proposal-in!)
+(declare execute-in!)
+(declare verify-in!)
+(declare learn-in!)
+(declare update-future-state-from-outcome-in!)
+(declare finalize-cycle-in!)
+
+(defn- resolve-memory-ctx
+  "Resolve memory context for orchestration.
+   Prefers explicit `memory-ctx`, otherwise falls back to memory/global-context."
+  [memory-ctx]
+  (or memory-ctx
+      (let [global-memory-context (requiring-resolve 'psi.memory.core/global-context)]
+        (global-memory-context))))
+
+(defn- normalize-approval-decision
+  [approval-decision]
+  (cond
+    (nil? approval-decision) nil
+    (keyword? approval-decision) approval-decision
+    (string? approval-decision)
+    (keyword (str/lower-case approval-decision))
+    :else ::invalid))
+
+(defn orchestrate-manual-trigger-in!
+  "Single production orchestration entrypoint for Step 11 manual cycles.
+
+   Runs explicit sequence:
+   trigger -> observe -> plan -> approval gate -> (approve/reject/await)
+   -> execute -> verify -> learn -> update FUTURE_STATE -> finalize
+
+   Approval semantics:
+   - If gate is manual and `approval-decision` is nil, orchestration stops at
+     :awaiting-approval and returns pending approval metadata.
+   - If gate is manual and `approval-decision` is :approve, it continues.
+   - If gate is manual and `approval-decision` is :reject, it executes
+     rejection path (learn/update/finalize) without execution.
+
+   opts keys:
+   - :system-state      readiness map (defaults all true)
+   - :graph-state       graph snapshot map (optional)
+   - :memory-state      memory snapshot map (optional)
+   - :memory-ctx        memory context (optional; defaults to memory/global-context)
+   - :approver          approver/reviewer id string
+   - :approval-notes    approval/rejection notes string
+   - :approval-decision nil | :approve | :reject (or string equivalents)
+   - :hook-executor     execution hook fn
+   - :check-runner      verification check fn"
+  [ctx trigger-signal
+   {:keys [system-state graph-state memory-state memory-ctx
+           approver approval-notes approval-decision
+           hook-executor check-runner]
+    :or {system-state {:query-ready true
+                       :graph-ready true
+                       :introspection-ready true
+                       :memory-ready true}
+         graph-state {}
+         memory-state {}
+         approver "operator"
+         approval-notes ""}}]
+  (let [trigger-result (handle-trigger-in! ctx trigger-signal system-state)
+        decision (normalize-approval-decision approval-decision)]
+    (cond
+      (not= :accepted (:result trigger-result))
+      {:ok? true
+       :trigger-result trigger-result
+       :phase :trigger}
+
+      (= ::invalid decision)
+      {:ok? false
+       :error :invalid-approval-decision
+       :approval-decision approval-decision
+       :expected #{:approve :reject nil}
+       :trigger-result trigger-result}
+
+      :else
+      (let [cycle-id (:cycle-id trigger-result)
+            observe-result (observe-in! ctx cycle-id system-state graph-state memory-state)
+            plan-result (when (:ok? observe-result)
+                          (plan-in! ctx cycle-id))
+            gate-result (when (:ok? plan-result)
+                          (apply-approval-gate-in! ctx cycle-id))]
+        (cond
+          (not (:ok? observe-result))
+          {:ok? false
+           :phase :observe
+           :cycle-id cycle-id
+           :trigger-result trigger-result
+           :observe-result observe-result}
+
+          (not (:ok? plan-result))
+          {:ok? false
+           :phase :plan
+           :cycle-id cycle-id
+           :trigger-result trigger-result
+           :observe-result observe-result
+           :plan-result plan-result}
+
+          (not (contains? #{:manual :auto-approved} (:gate gate-result)))
+          ;; defensive guard in case gate fn changes contract in future
+          {:ok? false
+           :phase :approval-gate
+           :cycle-id cycle-id
+           :trigger-result trigger-result
+           :observe-result observe-result
+           :plan-result plan-result
+           :gate-result gate-result}
+
+          (and (= :manual (:gate gate-result))
+               (nil? decision))
+          {:ok? true
+           :phase :awaiting-approval
+           :cycle-id cycle-id
+           :trigger-result trigger-result
+           :observe-result observe-result
+           :plan-result plan-result
+           :gate-result gate-result
+           :approval {:required? true
+                      :pending? true
+                      :decision nil}}
+
+          :else
+          (let [approval-result (when (= :manual (:gate gate-result))
+                                  (case decision
+                                    :approve (approve-proposal-in! ctx cycle-id approver approval-notes)
+                                    :reject (reject-proposal-in! ctx cycle-id approver approval-notes)
+                                    ;; nil cannot happen here due branch above; keep defensive fallback
+                                    {:ok? false :error :approval-decision-required}))
+                state-after-approval (get-state-in ctx)
+                cycle-after-approval (find-cycle (:cycles state-after-approval) cycle-id)
+                cycle-status (:status cycle-after-approval)
+                execute-result (when (= :executing cycle-status)
+                                 (if hook-executor
+                                   (execute-in! ctx cycle-id hook-executor)
+                                   (execute-in! ctx cycle-id)))
+                verify-result (let [post-exec-state (get-state-in ctx)
+                                    post-exec-cycle (find-cycle (:cycles post-exec-state) cycle-id)]
+                                (when (= :verifying (:status post-exec-cycle))
+                                  (if check-runner
+                                    (verify-in! ctx cycle-id check-runner)
+                                    (verify-in! ctx cycle-id))))
+                learn-result (let [post-verify-state (get-state-in ctx)
+                                   post-verify-cycle (find-cycle (:cycles post-verify-state) cycle-id)]
+                               (when (= :learning (:status post-verify-cycle))
+                                 (learn-in! ctx cycle-id (resolve-memory-ctx memory-ctx))))
+                future-state-result (when (:ok? learn-result)
+                                      (update-future-state-from-outcome-in! ctx cycle-id))
+                finalize-result (when (:ok? future-state-result)
+                                  (finalize-cycle-in! ctx cycle-id))]
+            (cond
+              (and approval-result (not (:ok? approval-result)))
+              {:ok? false
+               :phase :approval
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result}
+
+              (and execute-result (not (:ok? execute-result)))
+              {:ok? false
+               :phase :execute
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result
+               :execute-result execute-result}
+
+              (and verify-result (not (:ok? verify-result)))
+              {:ok? false
+               :phase :verify
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result
+               :execute-result execute-result
+               :verify-result verify-result}
+
+              (and learn-result (not (:ok? learn-result)))
+              {:ok? false
+               :phase :learn
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result
+               :execute-result execute-result
+               :verify-result verify-result
+               :learn-result learn-result}
+
+              (and future-state-result (not (:ok? future-state-result)))
+              {:ok? false
+               :phase :future-state
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result
+               :execute-result execute-result
+               :verify-result verify-result
+               :learn-result learn-result
+               :future-state-result future-state-result}
+
+              (and finalize-result (not (:ok? finalize-result)))
+              {:ok? false
+               :phase :finalize
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result
+               :execute-result execute-result
+               :verify-result verify-result
+               :learn-result learn-result
+               :future-state-result future-state-result
+               :finalize-result finalize-result}
+
+              :else
+              {:ok? true
+               :phase :completed
+               :cycle-id cycle-id
+               :trigger-result trigger-result
+               :observe-result observe-result
+               :plan-result plan-result
+               :gate-result gate-result
+               :approval-result approval-result
+               :execute-result execute-result
+               :verify-result verify-result
+               :learn-result learn-result
+               :future-state-result future-state-result
+               :finalize-result finalize-result})))))))
+
+(defn orchestrate-manual-trigger!
+  "Global wrapper for `orchestrate-manual-trigger-in!`."
+  ([trigger-signal]
+   (orchestrate-manual-trigger! trigger-signal {}))
+  ([trigger-signal opts]
+   (orchestrate-manual-trigger-in! (global-context) trigger-signal opts)))
 
 ;;; --- Observation ---
 

--- a/components/recursion/src/psi/recursion/core.clj
+++ b/components/recursion/src/psi/recursion/core.clj
@@ -21,6 +21,7 @@
    :hooks []
    :cycles []
    :paused-reason nil
+   :paused-checkpoint nil
    :last-error nil})
 
 (defn create-context
@@ -881,6 +882,7 @@
                           (-> s
                               (assoc :status :idle)
                               (assoc :paused-reason nil)
+                              (assoc :paused-checkpoint nil)
                               (update :cycles update-cycle cycle-id
                                       #(-> %
                                            (assoc :status final-status)

--- a/components/recursion/src/psi/recursion/core.clj
+++ b/components/recursion/src/psi/recursion/core.clj
@@ -510,7 +510,8 @@
 
 (defn reject-proposal-in!
   "Reject a proposal that is awaiting approval.
-   Sets approved=false, approval-by, approval-notes.
+   Sets approved=false, approval-by, approval-notes, and an explicit
+   aborted outcome so learn/finalize preserve rejection semantics.
    Transitions cycle+controller to :learning (skip execution).
 
    Returns {:ok? true} on success."
@@ -525,7 +526,11 @@
       {:ok? false, :error :wrong-cycle-status, :status (:status cycle)}
 
       :else
-      (do
+      (let [rejection-reason (if (seq notes) notes "proposal_rejected")
+            outcome {:status :aborted
+                     :summary "proposal_rejected"
+                     :evidence #{rejection-reason}
+                     :changed-goals #{}}]
         (swap-state-in! ctx
                         (fn [s]
                           (-> s
@@ -533,6 +538,7 @@
                               (update :cycles update-cycle cycle-id
                                       #(-> %
                                            (assoc :status :learning)
+                                           (assoc :outcome outcome)
                                            (assoc-in [:proposal :approved] false)
                                            (assoc-in [:proposal :approval-by] approver)
                                            (assoc-in [:proposal :approval-notes] notes))))))

--- a/components/recursion/src/psi/recursion/resolvers.clj
+++ b/components/recursion/src/psi/recursion/resolvers.clj
@@ -109,7 +109,9 @@
                              (fn [s]
                                (-> s
                                    (assoc :status :paused)
-                                   (assoc :paused-reason (or reason "operator-pause")))))
+                                   (assoc :paused-reason (or reason "operator-pause"))
+                                   (assoc :paused-checkpoint {:status (:status s)
+                                                              :at (java.time.Instant/now)}))))
         {:psi.recursion/paused? true}))))
 
 (pco/defmutation resume!
@@ -126,9 +128,11 @@
       (do
         (core/swap-state-in! recursion-ctx
                              (fn [s]
-                               (-> s
-                                   (assoc :status :idle)
-                                   (assoc :paused-reason nil))))
+                               (let [resume-status (or (get-in s [:paused-checkpoint :status]) :idle)]
+                                 (-> s
+                                     (assoc :status resume-status)
+                                     (assoc :paused-reason nil)
+                                     (assoc :paused-checkpoint nil)))))
         {:psi.recursion/resumed? true})
       {:psi.recursion/resumed? false})))
 

--- a/components/recursion/src/psi/recursion/resolvers.clj
+++ b/components/recursion/src/psi/recursion/resolvers.clj
@@ -82,10 +82,7 @@
   {::pco/op-name 'psi.recursion/trigger!
    ::pco/params  [:psi/recursion-ctx :reason :system-state]
    ::pco/output  [:psi.recursion/trigger-result]}
-  (let [trigger-signal {:type :manual
-                        :reason (or reason "manual-trigger")
-                        :payload {}
-                        :timestamp (java.time.Instant/now)}
+  (let [trigger-signal (core/manual-trigger-signal reason {:source :eql-mutation})
         result (core/handle-trigger-in! recursion-ctx trigger-signal
                                         (or system-state
                                             {:query-ready true

--- a/components/recursion/src/psi/recursion/resolvers.clj
+++ b/components/recursion/src/psi/recursion/resolvers.clj
@@ -71,25 +71,44 @@
 ;;; --- Mutations ---
 
 (pco/defmutation trigger!
-  "Fire a manual trigger on the recursion controller.
+  "Fire a manual trigger on the recursion controller via the production
+   orchestration entrypoint.
 
    Params:
-     :psi/recursion-ctx — recursion context
-     :reason            — trigger reason string (default: \"manual-trigger\")
-     :system-state      — readiness map with :query-ready, :graph-ready,
-                          :introspection-ready, :memory-ready keys"
-  [_ {:keys [psi/recursion-ctx reason system-state]}]
+     :psi/recursion-ctx  — recursion context
+     :reason             — trigger reason string (default: \"manual-trigger\")
+     :system-state       — readiness map with :query-ready, :graph-ready,
+                           :introspection-ready, :memory-ready keys
+     :graph-state        — optional graph snapshot map for observe phase
+     :memory-state       — optional memory snapshot map for observe phase
+     :psi/memory-ctx     — optional memory context for learn phase
+     :approval-decision  — nil | :approve | :reject (or string equivalent)
+     :approver           — approver/reviewer identity
+     :approval-notes     — approval/rejection notes"
+  [_ {:keys [psi/recursion-ctx reason system-state graph-state memory-state
+             psi/memory-ctx approval-decision approver approval-notes]}]
   {::pco/op-name 'psi.recursion/trigger!
-   ::pco/params  [:psi/recursion-ctx :reason :system-state]
-   ::pco/output  [:psi.recursion/trigger-result]}
+   ::pco/params  [:psi/recursion-ctx :reason :system-state :graph-state :memory-state
+                  :psi/memory-ctx :approval-decision :approver :approval-notes]
+   ::pco/output  [:psi.recursion/trigger-result
+                  :psi.recursion/orchestration-result]}
   (let [trigger-signal (core/manual-trigger-signal reason {:source :eql-mutation})
-        result (core/handle-trigger-in! recursion-ctx trigger-signal
-                                        (or system-state
-                                            {:query-ready true
-                                             :graph-ready true
-                                             :introspection-ready true
-                                             :memory-ready true}))]
-    {:psi.recursion/trigger-result result}))
+        orchestration (core/orchestrate-manual-trigger-in!
+                       recursion-ctx
+                       trigger-signal
+                       {:system-state (or system-state
+                                          {:query-ready true
+                                           :graph-ready true
+                                           :introspection-ready true
+                                           :memory-ready true})
+                        :graph-state graph-state
+                        :memory-state memory-state
+                        :memory-ctx memory-ctx
+                        :approval-decision approval-decision
+                        :approver approver
+                        :approval-notes approval-notes})]
+    {:psi.recursion/trigger-result (:trigger-result orchestration)
+     :psi.recursion/orchestration-result orchestration}))
 
 (pco/defmutation pause!
   "Pause the recursion controller with a reason.

--- a/components/recursion/test/psi/recursion/core_test.clj
+++ b/components/recursion/test/psi/recursion/core_test.clj
@@ -313,6 +313,81 @@
       (is (= :rejected (:result result)))
       (is (= :controller-busy (:reason result))))))
 
+(deftest orchestrate-manual-trigger-awaits-explicit-approval-test
+  (testing "orchestration stops at awaiting-approval without explicit decision"
+    (let [ctx (core/create-context)
+          _ (core/register-hooks-in! ctx)
+          trigger (core/manual-trigger-signal "manual run" {:source :test})
+          result (core/orchestrate-manual-trigger-in!
+                  ctx
+                  trigger
+                  {:system-state all-ready
+                   :graph-state {:node-count 5 :capability-count 3 :status :stable}
+                   :memory-state {:entry-count 2 :status :ready :recovery-count 0}})
+          state (core/get-state-in ctx)
+          cycle (some->> (:cycles state) last)]
+      (is (true? (:ok? result)))
+      (is (= :awaiting-approval (:phase result)))
+      (is (= :accepted (get-in result [:trigger-result :result])))
+      (is (= :awaiting-approval (:status state)))
+      (is (= :awaiting-approval (:status cycle)))
+      (is (= :manual (get-in result [:gate-result :gate]))))))
+
+(deftest orchestrate-manual-trigger-approve-completes-test
+  (testing "orchestration with explicit :approve runs full cycle to finalize"
+    (let [ctx (core/create-context)
+          _ (core/register-hooks-in! ctx)
+          mem-ctx (memory/create-context
+                   {:state-overrides {:status :ready}
+                    :require-provenance-on-write? false})
+          trigger (core/manual-trigger-signal "manual approve" {:source :test})
+          result (core/orchestrate-manual-trigger-in!
+                  ctx
+                  trigger
+                  {:system-state all-ready
+                   :graph-state {:node-count 5 :capability-count 3 :status :stable}
+                   :memory-state {:entry-count 2 :status :ready :recovery-count 0}
+                   :memory-ctx mem-ctx
+                   :approval-decision :approve
+                   :approver "reviewer"
+                   :approval-notes "ship it"})
+          state (core/get-state-in ctx)
+          cycle (first (filter #(= (:cycle-id result) (:cycle-id %)) (:cycles state)))]
+      (is (true? (:ok? result)))
+      (is (= :completed (:phase result)))
+      (is (= :idle (:status state)))
+      (is (= :completed (:status cycle)))
+      (is (= true (get-in cycle [:proposal :approved])))
+      (is (= :success (get-in cycle [:outcome :status]))))))
+
+(deftest orchestrate-manual-trigger-reject-completes-with-aborted-outcome-test
+  (testing "orchestration with explicit :reject skips execution and finalizes failed"
+    (let [ctx (core/create-context)
+          _ (core/register-hooks-in! ctx)
+          mem-ctx (memory/create-context
+                   {:state-overrides {:status :ready}
+                    :require-provenance-on-write? false})
+          trigger (core/manual-trigger-signal "manual reject" {:source :test})
+          result (core/orchestrate-manual-trigger-in!
+                  ctx
+                  trigger
+                  {:system-state all-ready
+                   :graph-state {:node-count 5 :capability-count 3 :status :stable}
+                   :memory-state {:entry-count 2 :status :ready :recovery-count 0}
+                   :memory-ctx mem-ctx
+                   :approval-decision :reject
+                   :approver "reviewer"
+                   :approval-notes "not safe"})
+          state (core/get-state-in ctx)
+          cycle (first (filter #(= (:cycle-id result) (:cycle-id %)) (:cycles state)))]
+      (is (true? (:ok? result)))
+      (is (= :completed (:phase result)))
+      (is (= :idle (:status state)))
+      (is (= :failed (:status cycle)))
+      (is (= false (get-in cycle [:proposal :approved])))
+      (is (= :aborted (get-in cycle [:outcome :status])))
+      (is (empty? (:execution-attempts cycle))))))
+
 ;;; --- Observation tests ---
 
 (def ^:private sample-graph-state

--- a/components/recursion/test/psi/recursion/core_test.clj
+++ b/components/recursion/test/psi/recursion/core_test.clj
@@ -751,6 +751,32 @@
       (is (true? (get-in cycle [:proposal :approved])))
       (is (false? (get-in cycle [:proposal :requires-approval]))))))
 
+(deftest apply-approval-gate-rejects-invalid-state-test
+  ;; Verification hardening for transition guard behavior around approval gate.
+  (testing "apply-approval-gate rejects unknown cycle-id"
+    (let [ctx (core/create-context)
+          result (core/apply-approval-gate-in! ctx "nonexistent")]
+      (is (false? (:ok? result)))
+      (is (= :cycle-not-found (:error result)))))
+
+  (testing "apply-approval-gate rejects wrong cycle status"
+    (let [ctx (core/create-context)
+          cycle-id (trigger-and-get-cycle-id ctx)
+          ;; cycle is still :observing
+          result (core/apply-approval-gate-in! ctx cycle-id)]
+      (is (false? (:ok? result)))
+      (is (= :wrong-cycle-status (:error result)))
+      (is (= :observing (:status result)))))
+
+  (testing "apply-approval-gate rejects planning cycle missing proposal"
+    (let [ctx (core/create-context)
+          cycle-id (trigger-and-get-cycle-id ctx)
+          _ (core/observe-in! ctx cycle-id all-ready sample-graph-state sample-memory-state)
+          ;; cycle now in :planning, but no proposal attached
+          result (core/apply-approval-gate-in! ctx cycle-id)]
+      (is (false? (:ok? result)))
+      (is (= :no-proposal (:error result))))))
+
 (deftest approve-proposal-in-test
   ;; Approve transitions to executing
   (testing "approve transitions to executing"

--- a/components/recursion/test/psi/recursion/core_test.clj
+++ b/components/recursion/test/psi/recursion/core_test.clj
@@ -186,10 +186,12 @@
   ([ttype]
    (make-trigger ttype "test trigger"))
   ([ttype reason]
-   {:type      ttype
-    :reason    reason
-    :payload   {}
-    :timestamp (java.time.Instant/now)}))
+   (if (= :manual ttype)
+     (core/manual-trigger-signal reason {:source :test})
+     {:type      ttype
+      :reason    reason
+      :payload   {}
+      :timestamp (java.time.Instant/now)})))
 
 (deftest register-hooks-in-test
   (testing "register-hooks-in! populates hooks from config"

--- a/components/recursion/test/psi/recursion/core_test.clj
+++ b/components/recursion/test/psi/recursion/core_test.clj
@@ -815,7 +815,18 @@
       (is (= :learning (:status cycle)))
       (is (false? (get-in cycle [:proposal :approved])))
       (is (= "user@test" (get-in cycle [:proposal :approval-by])))
-      (is (= "too risky" (get-in cycle [:proposal :approval-notes])))))
+      (is (= "too risky" (get-in cycle [:proposal :approval-notes])))
+      (is (= :aborted (get-in cycle [:outcome :status])))
+      (is (= "proposal_rejected" (get-in cycle [:outcome :summary])))
+      (is (= #{"too risky"} (get-in cycle [:outcome :evidence])))))
+
+  (testing "reject sets default rejection evidence when notes are blank"
+    (let [[ctx cycle-id] (setup-planned-cycle)
+          _ (core/apply-approval-gate-in! ctx cycle-id)
+          _ (core/reject-proposal-in! ctx cycle-id "user@test" "")
+          state (core/get-state-in ctx)
+          cycle (first (filter #(= cycle-id (:cycle-id %)) (:cycles state)))]
+      (is (= #{"proposal_rejected"} (get-in cycle [:outcome :evidence])))))
 
   (testing "reject rejects wrong cycle status"
     (let [[ctx cycle-id] (setup-planned-cycle)
@@ -1189,6 +1200,22 @@
               record (first (:records mem-state))
               prov (:provenance record)]
           (is (= :failed (:outcome-status prov))))))))
+
+(deftest learn-in-preserves-aborted-outcome-test
+  (testing "learn preserves rejected/aborted outcome"
+    (let [[ctx cycle-id] (setup-planned-cycle)
+          memory-ctx (memory/create-context
+                      {:state-overrides {:status :ready}
+                       :require-provenance-on-write? false})
+          _ (core/apply-approval-gate-in! ctx cycle-id)
+          _ (core/reject-proposal-in! ctx cycle-id "reviewer" "too risky")
+          result (core/learn-in! ctx cycle-id memory-ctx)
+          state (core/get-state-in ctx)
+          cycle (first (filter #(= cycle-id (:cycle-id %)) (:cycles state)))
+          record (first (:records (memory/get-state-in memory-ctx)))]
+      (is (true? (:ok? result)))
+      (is (= :aborted (get-in cycle [:outcome :status])))
+      (is (= :aborted (get-in record [:provenance :outcome-status]))))))
 
 (deftest learn-in-rejects-wrong-status-test
   (testing "learn rejects wrong cycle status"

--- a/components/recursion/test/psi/recursion/core_test.clj
+++ b/components/recursion/test/psi/recursion/core_test.clj
@@ -38,8 +38,9 @@
         (is (= [] (:hooks state)))
         (is (= [] (:cycles state))))
 
-      (testing "no paused reason or error"
+      (testing "no paused reason/checkpoint or error"
         (is (nil? (:paused-reason state)))
+        (is (nil? (:paused-checkpoint state)))
         (is (nil? (:last-error state)))))))
 
 (deftest create-context-with-overrides
@@ -1287,8 +1288,9 @@
       (testing "controller returns to idle"
         (is (= :idle (:status state))))
 
-      (testing "paused-reason is cleared"
-        (is (nil? (:paused-reason state)))))))
+      (testing "paused pause metadata is cleared"
+        (is (nil? (:paused-reason state)))
+        (is (nil? (:paused-checkpoint state)))))))
 
 (deftest finalize-cycle-failed-test
   ;; AC #13: Failed cycle finalization
@@ -1312,16 +1314,20 @@
         (is (inst? (:ended-at cycle)))))))
 
 (deftest finalize-clears-paused-reason-test
-  ;; AC #13: Finalize clears paused-reason
-  (testing "finalize clears paused-reason even if it was set"
+  ;; AC #13: Finalize clears pause metadata
+  (testing "finalize clears paused-reason and paused-checkpoint"
     (let [[ctx cycle-id memory-ctx] (setup-verified-cycle)
           _ (core/learn-in! ctx cycle-id memory-ctx)
           _ (core/update-future-state-from-outcome-in! ctx cycle-id)
-          ;; Manually set a paused-reason
-          _ (core/swap-state-in! ctx assoc :paused-reason "some-reason")
+          ;; Manually set pause metadata
+          _ (core/swap-state-in! ctx assoc
+                                 :paused-reason "some-reason"
+                                 :paused-checkpoint {:status :planning
+                                                     :at (java.time.Instant/now)})
           _ (core/finalize-cycle-in! ctx cycle-id)
           state (core/get-state-in ctx)]
-      (is (nil? (:paused-reason state))))))
+      (is (nil? (:paused-reason state)))
+      (is (nil? (:paused-checkpoint state))))))
 
 (deftest finalize-rejects-no-outcome-test
   (testing "finalize rejects when no outcome"

--- a/components/recursion/test/psi/recursion/integration_test.clj
+++ b/components/recursion/test/psi/recursion/integration_test.clj
@@ -229,18 +229,22 @@
         (is (empty? (:execution-attempts cycle))))
 
       (testing "cycle outcome reflects rejection"
-        ;; learn-in! sets a success outcome when none exists (since rejection
-        ;; doesn't set an outcome in the reject flow). The cycle still completes
-        ;; because learn creates the outcome.
-        (is (some? (:outcome cycle))))
+        (is (= :aborted (get-in cycle [:outcome :status])))
+        (is (= "proposal_rejected" (get-in cycle [:outcome :summary])))
+        (is (= #{"too risky for now"} (get-in cycle [:outcome :evidence]))))
+
+      (testing "cycle status is failed after finalize for non-success outcome"
+        (is (= :failed (:status cycle))))
 
       (testing "controller returns to idle"
         (is (= :idle (:status state))))
 
-      (testing "memory record was written"
+      (testing "memory record was written with aborted outcome provenance"
         (let [mem-state (memory/get-state-in mem-ctx)
-              records (:records mem-state)]
-          (is (= 1 (count records))))))))
+              records (:records mem-state)
+              record (first records)]
+          (is (= 1 (count records)))
+          (is (= :aborted (get-in record [:provenance :outcome-status]))))))))
 
 (deftest integration-failed-verification-rollback-test
   ;; AC #8, #10: trusted-local auto-approve → execute → verify fail → rollback.

--- a/components/recursion/test/psi/recursion/integration_test.clj
+++ b/components/recursion/test/psi/recursion/integration_test.clj
@@ -29,10 +29,12 @@
   ([]
    (make-trigger :manual))
   ([ttype]
-   {:type ttype
-    :reason "integration-test"
-    :payload {}
-    :timestamp (java.time.Instant/now)}))
+   (if (= :manual ttype)
+     (core/manual-trigger-signal "integration-test" {:source :test})
+     {:type ttype
+      :reason "integration-test"
+      :payload {}
+      :timestamp (java.time.Instant/now)})))
 
 (defn- success-executor
   [_action]

--- a/components/recursion/test/psi/recursion/resolvers_test.clj
+++ b/components/recursion/test/psi/recursion/resolvers_test.clj
@@ -191,7 +191,7 @@
 ;;; --- Mutation tests ---
 
 (deftest trigger-mutation-creates-cycle
-  ;; Trigger mutation should create a new cycle
+  ;; Trigger mutation should create a new cycle via orchestration and stop at awaiting approval
   (testing "trigger mutation creates a cycle"
     (let [rctx (core/create-context)
           _ (core/register-hooks-in! rctx)
@@ -201,14 +201,20 @@
                                  [{(list 'psi.recursion/trigger!
                                          {:psi/recursion-ctx rctx
                                           :reason "mutation-test"
-                                          :system-state (all-readiness-true)})
-                                   [:psi.recursion/trigger-result]}])
+                                          :system-state (all-readiness-true)
+                                          :graph-state {:node-count 5 :capability-count 3 :status :stable}
+                                          :memory-state {:entry-count 2 :status :ready :recovery-count 0}})
+                                   [:psi.recursion/trigger-result
+                                    :psi.recursion/orchestration-result]}])
           trigger-result (get-in result ['psi.recursion/trigger!
                                          :psi.recursion/trigger-result])
+          orchestration (get-in result ['psi.recursion/trigger!
+                                        :psi.recursion/orchestration-result])
           cycle-id (:cycle-id trigger-result)
           state (core/get-state-in rctx)
           cycle (first (filter #(= cycle-id (:cycle-id %)) (:cycles state)))]
       (is (= :accepted (:result trigger-result)))
+      (is (= :awaiting-approval (:phase orchestration)))
       (is (= core/feed-forward-manual-trigger-prompt-name
              (get-in cycle [:trigger :payload :prompt-name])))
       (is (= :eql-mutation (get-in cycle [:trigger :payload :source]))))))

--- a/components/recursion/test/psi/recursion/resolvers_test.clj
+++ b/components/recursion/test/psi/recursion/resolvers_test.clj
@@ -234,8 +234,10 @@
                                             {:psi/recursion-ctx rctx}
                                             [:psi.recursion/status
                                              :psi.recursion/paused?])
+          raw-state-after-pause (core/get-state-in rctx)
           _ (is (= :paused (:psi.recursion/status state-after-pause)))
           _ (is (true? (:psi.recursion/paused? state-after-pause)))
+          _ (is (= :idle (get-in raw-state-after-pause [:paused-checkpoint :status])))
 
           ;; Resume
           resume-result (query/query-in qctx
@@ -250,9 +252,11 @@
           state-after-resume (query/query-in qctx
                                              {:psi/recursion-ctx rctx}
                                              [:psi.recursion/status
-                                              :psi.recursion/paused?])]
+                                              :psi.recursion/paused?])
+          raw-state-after-resume (core/get-state-in rctx)]
       (is (= :idle (:psi.recursion/status state-after-resume)))
-      (is (false? (:psi.recursion/paused? state-after-resume))))))
+      (is (false? (:psi.recursion/paused? state-after-resume)))
+      (is (nil? (:paused-checkpoint raw-state-after-resume))))))
 
 (deftest resume-from-non-paused-returns-false
   ;; Resume when not paused should return false
@@ -265,7 +269,27 @@
                                          {:psi/recursion-ctx rctx})
                                    [:psi.recursion/resumed?]}])]
       (is (false? (get-in result ['psi.recursion/resume!
-                                  :psi.recursion/resumed?]))))))
+                                  :psi.recursion/resumed?])))))
+
+  (testing "resume from paused state restores checkpoint status"
+    (let [rctx (core/create-context)
+          qctx (recursion-query-ctx)
+          _ (core/swap-state-in! rctx assoc
+                                 :status :paused
+                                 :paused-reason "checkpoint-test"
+                                 :paused-checkpoint {:status :planning
+                                                     :at (java.time.Instant/now)})
+          result (query/query-in qctx
+                                 {:psi/recursion-ctx rctx}
+                                 [{(list 'psi.recursion/resume!
+                                         {:psi/recursion-ctx rctx})
+                                   [:psi.recursion/resumed?]}])
+          state (core/get-state-in rctx)]
+      (is (true? (get-in result ['psi.recursion/resume!
+                                 :psi.recursion/resumed?])))
+      (is (= :planning (:status state)))
+      (is (nil? (:paused-reason state)))
+      (is (nil? (:paused-checkpoint state))))))
 
 (deftest current-future-state-after-planning
   ;; After planning, current-future-state should be non-nil

--- a/components/recursion/test/psi/recursion/resolvers_test.clj
+++ b/components/recursion/test/psi/recursion/resolvers_test.clj
@@ -26,10 +26,7 @@
 
 (defn- manual-trigger
   []
-  {:type :manual
-   :reason "test-trigger"
-   :payload {}
-   :timestamp (java.time.Instant/now)})
+  (core/manual-trigger-signal "test-trigger" {:source :test}))
 
 ;;; --- Resolver tests ---
 
@@ -205,11 +202,16 @@
                                          {:psi/recursion-ctx rctx
                                           :reason "mutation-test"
                                           :system-state (all-readiness-true)})
-                                   [:psi.recursion/trigger-result]}])]
-      (is (= :accepted
-             (get-in result ['psi.recursion/trigger!
-                             :psi.recursion/trigger-result
-                             :result]))))))
+                                   [:psi.recursion/trigger-result]}])
+          trigger-result (get-in result ['psi.recursion/trigger!
+                                         :psi.recursion/trigger-result])
+          cycle-id (:cycle-id trigger-result)
+          state (core/get-state-in rctx)
+          cycle (first (filter #(= cycle-id (:cycle-id %)) (:cycles state)))]
+      (is (= :accepted (:result trigger-result)))
+      (is (= core/feed-forward-manual-trigger-prompt-name
+             (get-in cycle [:trigger :payload :prompt-name])))
+      (is (= :eql-mutation (get-in cycle [:trigger :payload :source]))))))
 
 (deftest pause-resume-mutations-toggle-state
   ;; Pause and resume mutations should toggle controller state

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -204,7 +204,7 @@
             :last-escape-ms nil}})
 
 (def ^:private builtin-slash-commands
-  ["/quit" "/exit" "/resume" "/new" "/status" "/help"])
+  ["/quit" "/exit" "/resume" "/new" "/status" "/help" "/feed-forward"])
 
 (defn- input-value [state]
   (charm/text-input-value (:input state)))

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -854,6 +854,8 @@
                               returns {:messages [...], :tool-calls {...}, :tool-order [...]}
      :dispatch-fn          — (fn [text]) → command result map or nil; central command dispatch
      :on-interrupt-fn!     — (fn [state]) -> {:queued-text str? :message str?} | nil
+     :on-queue-input-fn!   — (fn [text state]) -> {:message str?} | nil
+                              called when Enter is pressed while streaming
      :double-press-window-ms — ctrl+c / escape timing window (default 500)
      :double-escape-action — :tree | :fork | :none (default :none)
      :event-queue          — shared LinkedBlockingQueue for agent + extension events"
@@ -885,6 +887,7 @@
            :ui-state-atom         ui-state-atom
            :dispatch-fn           (:dispatch-fn opts)
            :on-interrupt-fn!      (:on-interrupt-fn! opts)
+           :on-queue-input-fn!    (:on-queue-input-fn! opts)
            :double-press-window-ms (or (:double-press-window-ms opts) 500)
            :double-escape-action  (or (:double-escape-action opts) :none)
            :cwd                   (or (:cwd opts) (System/getProperty "user.dir"))
@@ -1289,6 +1292,32 @@
       [next-state (poll-cmd (:queue state))])
     [(append-assistant-status state "Interrupt unavailable in this runtime.") nil]))
 
+(defn- handle-streaming-submit
+  "Queue draft input as steering/follow-up while the agent is streaming."
+  [state]
+  (let [text     (str/trim (input-value state))
+        queue-fn (:on-queue-input-fn! state)]
+    (cond
+      (str/blank? text)
+      [state (poll-cmd (:queue state))]
+
+      queue-fn
+      (let [result  (try
+                      (queue-fn text state)
+                      (catch Exception e
+                        {:message (str "Failed to queue input: " (ex-message e))}))
+            message (or (:message result)
+                        "Queued for next turn.")]
+        [(-> state
+             (set-input-value "")
+             (clear-autocomplete)
+             (append-assistant-status message))
+         (poll-cmd (:queue state))])
+
+      :else
+      [(append-assistant-status state "Queueing input is unavailable in this runtime.")
+       (poll-cmd (:queue state))])))
+
 ;; ── Update ──────────────────────────────────────────────────
 
 (defn make-update
@@ -1488,6 +1517,29 @@
         (and (= :idle (:phase state))
              (msg/key-match? m "enter"))
         (submit-input state run-agent-fn!)
+
+      ;; Enter while streaming queues steering/follow-up input.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "enter"))
+        (handle-streaming-submit state)
+
+      ;; Backspace edits text while streaming.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "backspace"))
+        (let [[new-input cmd] (charm/text-input-update (:input state) m)]
+          [(set-input-model state new-input) cmd])
+
+      ;; Space may arrive as keyword :space while streaming.
+        (and (= :streaming (:phase state))
+             (msg/key-match? m "space"))
+        (let [[new-input cmd] (charm/text-input-update (:input state) (msg/key-press " "))]
+          [(set-input-model state new-input) cmd])
+
+      ;; Text input remains editable while streaming.
+        (and (= :streaming (:phase state))
+             (msg/key-press? m))
+        (let [[new-input cmd] (charm/text-input-update (:input state) m)]
+          [(set-input-model state new-input) cmd])
 
       ;; Backspace edits text then refreshes open autocomplete.
         (and (= :idle (:phase state))
@@ -2315,12 +2367,14 @@
             ;; Dialog replaces editor when active
             (if dialog-active?
               (render-dialog ui-state-atom)
-              (if (= :idle phase)
-                (wrap-text-input-view input term-width)
-                (charm/render dim-style
-                              (if progress-spinner-visible?
-                                "(waiting for response…)"
-                                (str spinner-char " waiting for response…")))))
+              (str (wrap-text-input-view input term-width)
+                   (when (= :streaming phase)
+                     (str "\n"
+                          (charm/render dim-style
+                                        (if progress-spinner-visible?
+                                          "(Enter queues input • Esc interrupts)"
+                                          (str spinner-char " waiting for response…")))
+                          clear-line-end-seq))))
             "\n"
             (render-separator) "\n"
             ;; Widgets below editor
@@ -2350,6 +2404,7 @@
                                                :tool-calls {...}
                                                :tool-order [...]}
                        :on-interrupt-fn!    — (fn [state]) -> {:queued-text str? :message str?}
+                       :on-queue-input-fn!  — (fn [text state]) -> {:message str?}
                        :double-press-window-ms — ctrl+c / escape timing window (default 500)
                        :double-escape-action — :tree | :fork | :none (default :none)
                        :alt-screen          — true/false (default true)"

--- a/components/tui/test/psi/tui/app_test.clj
+++ b/components/tui/test/psi/tui/app_test.clj
@@ -384,6 +384,33 @@
       (is (= "Interrupted active work."
              (:text (last (:messages s1))))))))
 
+(deftest streaming-enter-queues-input-test
+  (testing "enter during streaming queues draft text via callback and keeps streaming"
+    (let [queued    (atom nil)
+          update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state "test-model"
+                                       {:on-queue-input-fn! (fn [text _]
+                                                              (reset! queued text)
+                                                              {:message "Queued steering message."})})
+                           :phase :streaming
+                           :input (charm/text-input-set-value (:input (init-state)) "steer this"))
+          [s1 _cmd] (update-fn state (msg/key-press :enter))]
+      (is (= :streaming (:phase s1)))
+      (is (= "steer this" @queued))
+      (is (= "" (text-input/value (:input s1))))
+      (is (= "Queued steering message." (:text (last (:messages s1))))))))
+
+(deftest streaming-input-remains-editable-test
+  (testing "printable input and backspace mutate editor while streaming"
+    (let [update-fn (app/make-update (stub-agent-fn ""))
+          state     (assoc (init-state)
+                           :phase :streaming
+                           :input (charm/text-input-set-value (:input (init-state)) "ab"))
+          [s1 _]    (update-fn state (msg/key-press "c"))
+          [s2 _]    (update-fn s1 (msg/key-press :backspace))]
+      (is (= "abc" (text-input/value (:input s1))))
+      (is (= "ab" (text-input/value (:input s2)))))))
+
 (deftest double-escape-unsupported-action-is-safe-no-op-with-status-test
   (testing "unsupported double-escape action does not crash and emits status"
     (let [update-fn (app/make-update (stub-agent-fn ""))
@@ -547,12 +574,15 @@
           [s1 _]    (update-fn state (msg/key-press :tab))]
       (is (= "@\"foo\" " (text-input/value (:input s1)))))))
 
-(deftest keys-ignored-during-streaming-test
-  (testing "printable keys are ignored while streaming"
+(deftest keys-edit-input-during-streaming-test
+  (testing "printable keys edit draft input while streaming"
     (let [update-fn (app/make-update (stub-agent-fn ""))
-          streaming (assoc (init-state) :phase :streaming)
+          streaming (-> (init-state)
+                        (assoc :phase :streaming)
+                        (assoc :input (charm/text-input-set-value (:input (init-state)) "")))
           [s1 cmd]  (update-fn streaming (msg/key-press "x"))]
       (is (= :streaming (:phase s1)))
+      (is (= "x" (text-input/value (:input s1))))
       (is (nil? cmd)))))
 
 ;;;; View
@@ -624,7 +654,7 @@ clojure-lsp"}]})
     (let [state (assoc (init-state) :phase :streaming)
           out   (app/view state)]
       (is (str/includes? out "thinking"))
-      (is (str/includes? out "(waiting for response…)"))
+      (is (str/includes? out "Enter queues input"))
       (is (not (str/includes? out "⠋ waiting for response…"))))))
 
 (deftest view-shows-spinner-in-waiting-indicator-with-tool-history-test
@@ -644,7 +674,7 @@ clojure-lsp"}]})
       (is (not (str/includes? out "(waiting for response…)"))))))
 
 (deftest view-hides-waiting-spinner-when-tool-spinner-visible-test
-  (testing "waiting indicator stays static when tool list already shows spinner"
+  (testing "streaming hint remains static when tool list already shows spinner"
     (let [state (-> (init-state)
                     (assoc :phase :streaming
                            :spinner-frame 0
@@ -656,7 +686,7 @@ clojure-lsp"}]})
                                               :result nil
                                               :is-error false}}))
           out   (app/view state)]
-      (is (str/includes? out "(waiting for response…)"))
+      (is (str/includes? out "Enter queues input"))
       (is (not (str/includes? out "⠋ waiting for response…"))))))
 
 (deftest ctrl-o-toggles-tools-expanded-test

--- a/extensions/src/extensions/mcp_tasks_run.clj
+++ b/extensions/src/extensions/mcp_tasks_run.clj
@@ -765,13 +765,14 @@
        (str "Current story children snapshot (EDN):\n"
             (pr-str children) "\n\n"))
 
+     (when user-confirmation
+       (str "User confirmation context (EDN):\n"
+            (pr-str user-confirmation) "\n\n"))
+
      (when (= :wait-user-confirmation state)
-       (str "Workflow is waiting for explicit user confirmation answer.\n"
-            "Current confirmation payload (EDN):\n"
-            (pr-str user-confirmation) "\n\n"
-            "You must provide a deterministic safe answer and call:\n"
-            "mcp-tasks-run resume <run-id> <answer>\n"
-            "using available extension command mechanism if present; otherwise set answer in workflow data via CLI-supported path.\n\n"))
+       (str "This step is currently paused for explicit user confirmation.\n"
+            "If additional material clarification is required after processing the answer,\n"
+            "emit MCP_TASKS_RUN_USER_CONFIRMATION again as the last line.\n\n"))
 
      (when user-answer
        (str "Resume answer payload provided for this step (EDN):\n"
@@ -786,46 +787,59 @@
   [{:keys [run-id step-name prompt-body task-id entity-type
            project-dir worktree-dir task children state
            user-confirmation user-answer get-api-key-fn
-           category-prompt]}]
-  (let [started (now-ms)
-        model   (resolve-active-model)
-        api-key (when (fn? get-api-key-fn)
-                  (get-api-key-fn (:provider model)))
-        req     (build-step-request {:step-name step-name
-                                     :prompt-body prompt-body
-                                     :task-id task-id
-                                     :entity-type entity-type
-                                     :project-dir project-dir
-                                     :worktree-dir worktree-dir
-                                     :task task
-                                     :children children
-                                     :state state
-                                     :user-confirmation user-confirmation
-                                     :user-answer user-answer
-                                     :category-prompt category-prompt})
-        user-msg {:role      "user"
-                  :content   [{:type :text :text req}]
-                  :timestamp (java.time.Instant/now)}]
+           category-prompt resume-step-session]}]
+  (let [started          (now-ms)
+        resume?          (map? resume-step-session)
+        agent-ctx        (or (:agent-ctx resume-step-session)
+                             (create-step-agent-ctx worktree-dir))
+        step-session-ctx (or (:session-ctx resume-step-session)
+                             (create-step-session-ctx agent-ctx))
+        model            (or (:model resume-step-session)
+                             (resolve-active-model))
+        api-key          (when (fn? get-api-key-fn)
+                           (get-api-key-fn (:provider model)))
+        req              (when-not resume?
+                           (build-step-request {:step-name step-name
+                                                :prompt-body prompt-body
+                                                :task-id task-id
+                                                :entity-type entity-type
+                                                :project-dir project-dir
+                                                :worktree-dir worktree-dir
+                                                :task task
+                                                :children children
+                                                :state state
+                                                :user-confirmation user-confirmation
+                                                :user-answer user-answer
+                                                :category-prompt category-prompt}))
+        user-text        (if resume? (str (or user-answer "")) req)
+        user-msg         {:role      "user"
+                          :content   [{:type :text :text user-text}]
+                          :timestamp (java.time.Instant/now)}
+        step-session     {:agent-ctx agent-ctx
+                          :session-ctx step-session-ctx
+                          :model model
+                          :step-name step-name
+                          :step-state state}]
     (set-live-progress!
      run-id
      {:status  :running
       :state   state
       :step    step-name
-      :message (str "Executing step " step-name)})
+      :message (if resume?
+                 (str "Continuing step " step-name " with user answer")
+                 (str "Executing step " step-name))})
     (try
-      (let [agent-ctx        (create-step-agent-ctx worktree-dir)
-            step-session-ctx (create-step-session-ctx agent-ctx)
-            result           (executor/run-agent-loop!
-                              nil
-                              step-session-ctx
-                              agent-ctx
-                              model
-                              [user-msg]
-                              (cond-> {:turn-ctx-atom nil}
-                                api-key (assoc :api-key api-key)))
-            elapsed          (- (now-ms) started)
-            text             (result->text result)
-            ok?              (not= :error (:stop-reason result))]
+      (let [result  (executor/run-agent-loop!
+                     nil
+                     step-session-ctx
+                     agent-ctx
+                     model
+                     [user-msg]
+                     (cond-> {:turn-ctx-atom nil}
+                       api-key (assoc :api-key api-key)))
+            elapsed (- (now-ms) started)
+            text    (result->text result)
+            ok?     (not= :error (:stop-reason result))]
         (set-live-progress!
          run-id
          {:status  (if ok? :running :error)
@@ -835,7 +849,8 @@
         {:ok?           ok?
          :elapsed-ms    elapsed
          :text          text
-         :error-message (:error-message result)})
+         :error-message (:error-message result)
+         :step-session  step-session})
       (catch Exception e
         (set-live-progress!
          run-id
@@ -846,18 +861,26 @@
         {:ok?           false
          :elapsed-ms    (- (now-ms) started)
          :text          (str "Error: " (ex-message e))
-         :error-message (ex-message e)}))))
+         :error-message (ex-message e)
+         :step-session  step-session}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Control helpers
 ;; ---------------------------------------------------------------------------
+
+(defn- initial-control-state []
+  {:pause? false
+   :cancel? false
+   :merge? false
+   :answer nil
+   :pending-step-session nil})
 
 (defn- ensure-control!
   [run-id]
   (let [run-id (str run-id)
         a      (:run-controls @state)]
     (or (get @a run-id)
-        (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
+        (let [ctrl (atom (initial-control-state))]
           (swap! a assoc run-id ctrl)
           ctrl))))
 
@@ -1058,13 +1081,14 @@
   [{:keys [run-id task-id project-dir worktree-dir control max-steps
            current-state steps history user-confirmation user-answer
            get-api-key-fn]}]
-  (let [started-ms (now-ms)
-        max-steps* (long (or max-steps max-steps-default))
-        steps      (long (or steps 0))
-        history    (vec (or history []))
-        phase      (normalize-run-phase current-state)
-        merge?     (boolean (:merge? @control))
-        answer     (or (:answer @control) user-answer)]
+  (let [started-ms           (now-ms)
+        max-steps*           (long (or max-steps max-steps-default))
+        steps                (long (or steps 0))
+        history              (vec (or history []))
+        phase                (normalize-run-phase current-state)
+        merge?               (boolean (:merge? @control))
+        answer               (or (:answer @control) user-answer)
+        pending-step-session (:pending-step-session @control)]
     (try
       (cond
         (>= steps max-steps*)
@@ -1153,7 +1177,22 @@
                          :started-ms    started-ms
                          :error-message err})
             (let [{:keys [task children entity-type state completed-count]} derived
-                  step-state                                                (if (and (= state :wait-pr-merge) merge?) :merging-pr state)]
+                  resume-step-session
+                  (when (and (= phase :wait-user-confirmation)
+                             (seq (str answer))
+                             (map? pending-step-session))
+                    pending-step-session)
+                  step-state*
+                  (if (and (= state :wait-pr-merge) merge?) :merging-pr state)
+                  step-state
+                  (or (:step-state resume-step-session)
+                      step-state*)
+                  prompt-name
+                  (or (:step-name resume-step-session)
+                      (step-prompt-name entity-type step-state))
+                  confirmation-context
+                  (or user-confirmation
+                      (:user-confirmation resume-step-session))]
               (cond
                 (= state :terminated)
                 (run-result {:status        :done
@@ -1190,56 +1229,64 @@
                              :history           history
                              :started-ms        started-ms
                              :pause-reason      :wait-user-confirmation
-                             :user-confirmation user-confirmation})
+                             :user-confirmation confirmation-context})
 
                 :else
-                (if-let [prompt-name (step-prompt-name entity-type step-state)]
-                  (let [prompt-body    (resolve-step-prompt project-dir prompt-name)
-                        cat-prompt     (resolve-category-for-step
-                                        prompt-name task children entity-type project-dir)
-                        step-start     (now-ms)
-                        step-result    (run-step-subagent!
-                                        {:run-id run-id
-                                         :step-name prompt-name
-                                         :prompt-body prompt-body
-                                         :task-id task-id
-                                         :entity-type entity-type
-                                         :project-dir project-dir
-                                         :worktree-dir worktree-dir
-                                         :task task
-                                         :children children
-                                         :state step-state
-                                         :user-confirmation user-confirmation
-                                         :user-answer user-answer
-                                         :get-api-key-fn get-api-key-fn
-                                         :category-prompt cat-prompt})
+                (if prompt-name
+                  (let [prompt-body (resolve-step-prompt project-dir prompt-name)
+                        cat-prompt  (resolve-category-for-step
+                                     prompt-name task children entity-type project-dir)
+                        step-start  (now-ms)
+                        step-result (run-step-subagent!
+                                     {:run-id run-id
+                                      :step-name prompt-name
+                                      :prompt-body prompt-body
+                                      :task-id task-id
+                                      :entity-type entity-type
+                                      :project-dir project-dir
+                                      :worktree-dir worktree-dir
+                                      :task task
+                                      :children children
+                                      :state step-state
+                                      :user-confirmation confirmation-context
+                                      :user-answer answer
+                                      :get-api-key-fn get-api-key-fn
+                                      :category-prompt cat-prompt
+                                      :resume-step-session resume-step-session})
                         step-elapsed (- (now-ms) step-start)
                         base-entry   {:state      step-state
                                       :step       prompt-name
                                       :elapsed-ms step-elapsed
                                       :output     (task-preview (:text step-result) 500)}]
                     (if-not (:ok? step-result)
-                      (let [history' (conj history (assoc base-entry :ok? false))]
-                        (run-result {:status        :error
-                                     :run-id        run-id
-                                     :task-id       task-id
-                                     :entity-type   entity-type
-                                     :worktree-dir  worktree-dir
-                                     :current-state step-state
-                                     :steps         steps
-                                     :history       history'
-                                     :last-step     prompt-name
-                                     :last-output   (task-preview (:text step-result) 500)
-                                     :started-ms    started-ms
-                                     :error-message (or (:error-message step-result)
-                                                        (:text step-result)
-                                                        "Step failed")}))
+                      (do
+                        (when (instance? clojure.lang.IAtom control)
+                          (swap! control assoc :answer nil :pending-step-session nil))
+                        (let [history' (conj history (assoc base-entry :ok? false))]
+                          (run-result {:status        :error
+                                       :run-id        run-id
+                                       :task-id       task-id
+                                       :entity-type   entity-type
+                                       :worktree-dir  worktree-dir
+                                       :current-state step-state
+                                       :steps         steps
+                                       :history       history'
+                                       :last-step     prompt-name
+                                       :last-output   (task-preview (:text step-result) 500)
+                                       :started-ms    started-ms
+                                       :error-message (or (:error-message step-result)
+                                                          (:text step-result)
+                                                          "Step failed")})))
                       (let [confirmation (parse-user-confirmation (:text step-result))
                             history'     (conj history (assoc base-entry :ok? true))]
                         (if confirmation
                           (do
                             (when (instance? clojure.lang.IAtom control)
-                              (swap! control assoc :answer nil :pause? false))
+                              (swap! control assoc
+                                     :answer nil
+                                     :pause? false
+                                     :pending-step-session (or (:step-session step-result)
+                                                               resume-step-session)))
                             (run-result {:status            :paused
                                          :run-id            run-id
                                          :task-id           task-id
@@ -1254,53 +1301,70 @@
                                          :pause-reason      :wait-user-confirmation
                                          :user-confirmation confirmation
                                          :user-answer       nil}))
-                          (let [derived2 (derive-current! project-dir worktree-dir task-id)]
-                            (if-let [err2 (:error derived2)]
-                              (run-result {:status        :error
-                                           :run-id        run-id
-                                           :task-id       task-id
-                                           :entity-type   entity-type
-                                           :worktree-dir  worktree-dir
-                                           :current-state step-state
-                                           :steps         steps
-                                           :history       history'
-                                           :last-step     prompt-name
-                                           :last-output   (task-preview (:text step-result) 500)
-                                           :started-ms    started-ms
-                                           :error-message err2})
-                              (let [next-state     (:state derived2)
-                                    next-completed (:completed-count derived2)
-                                    next-task      (:task derived2)
-                                    next-children  (:children derived2)
-                                    pre-snapshot   (progress-snapshot entity-type
-                                                                      task
-                                                                      children
-                                                                      completed-count)
-                                    next-snapshot  (progress-snapshot entity-type
-                                                                      next-task
-                                                                      next-children
-                                                                      next-completed)
-                                    progress?      (not (no-progress? state
-                                                                      next-state
-                                                                      completed-count
-                                                                      next-completed
-                                                                      pre-snapshot
-                                                                      next-snapshot))
-                                    history-entry  (assoc base-entry
-                                                          :ok? true
-                                                          :next-state next-state
-                                                          :completed-count next-completed
-                                                          :progress? progress?)
-                                    history''      (conj history history-entry)
-                                    has-tasks-stall? (and (= state :has-tasks)
-                                                          (= next-state :has-tasks))
-                                    no-progress-streak (when has-tasks-stall?
-                                                         (has-tasks-no-progress-streak history''))]
-                                (cond
-                                  progress?
-                                  (do
-                                    (when (= step-state :merging-pr)
-                                      (swap! control assoc :merge? false))
+                          (do
+                            (when (instance? clojure.lang.IAtom control)
+                              (swap! control assoc :answer nil :pending-step-session nil))
+                            (let [derived2 (derive-current! project-dir worktree-dir task-id)]
+                              (if-let [err2 (:error derived2)]
+                                (run-result {:status        :error
+                                             :run-id        run-id
+                                             :task-id       task-id
+                                             :entity-type   entity-type
+                                             :worktree-dir  worktree-dir
+                                             :current-state step-state
+                                             :steps         steps
+                                             :history       history'
+                                             :last-step     prompt-name
+                                             :last-output   (task-preview (:text step-result) 500)
+                                             :started-ms    started-ms
+                                             :error-message err2})
+                                (let [next-state     (:state derived2)
+                                      next-completed (:completed-count derived2)
+                                      next-task      (:task derived2)
+                                      next-children  (:children derived2)
+                                      pre-snapshot   (progress-snapshot entity-type
+                                                                        task
+                                                                        children
+                                                                        completed-count)
+                                      next-snapshot  (progress-snapshot entity-type
+                                                                        next-task
+                                                                        next-children
+                                                                        next-completed)
+                                      progress?      (not (no-progress? state
+                                                                        next-state
+                                                                        completed-count
+                                                                        next-completed
+                                                                        pre-snapshot
+                                                                        next-snapshot))
+                                      history-entry  (assoc base-entry
+                                                            :ok? true
+                                                            :next-state next-state
+                                                            :completed-count next-completed
+                                                            :progress? progress?)
+                                      history''      (conj history history-entry)
+                                      has-tasks-stall? (and (= state :has-tasks)
+                                                            (= next-state :has-tasks))
+                                      no-progress-streak (when has-tasks-stall?
+                                                           (has-tasks-no-progress-streak history''))]
+                                  (cond
+                                    progress?
+                                    (do
+                                      (when (= step-state :merging-pr)
+                                        (swap! control assoc :merge? false))
+                                      (run-result {:status        :running
+                                                   :run-id        run-id
+                                                   :task-id       task-id
+                                                   :entity-type   entity-type
+                                                   :worktree-dir  worktree-dir
+                                                   :current-state :derive-state
+                                                   :steps         (inc steps)
+                                                   :history       history''
+                                                   :last-step     prompt-name
+                                                   :last-output   (task-preview (:text step-result) 500)
+                                                   :started-ms    started-ms}))
+
+                                    (and has-tasks-stall?
+                                         (< no-progress-streak max-has-tasks-no-progress-default))
                                     (run-result {:status        :running
                                                  :run-id        run-id
                                                  :task-id       task-id
@@ -1311,40 +1375,26 @@
                                                  :history       history''
                                                  :last-step     prompt-name
                                                  :last-output   (task-preview (:text step-result) 500)
-                                                 :started-ms    started-ms}))
+                                                 :started-ms    started-ms})
 
-                                  (and has-tasks-stall?
-                                       (< no-progress-streak max-has-tasks-no-progress-default))
-                                  (run-result {:status        :running
-                                               :run-id        run-id
-                                               :task-id       task-id
-                                               :entity-type   entity-type
-                                               :worktree-dir  worktree-dir
-                                               :current-state :derive-state
-                                               :steps         (inc steps)
-                                               :history       history''
-                                               :last-step     prompt-name
-                                               :last-output   (task-preview (:text step-result) 500)
-                                               :started-ms    started-ms})
-
-                                  :else
-                                  (run-result {:status        :error
-                                               :run-id        run-id
-                                               :task-id       task-id
-                                               :entity-type   entity-type
-                                               :worktree-dir  worktree-dir
-                                               :current-state next-state
-                                               :steps         (inc steps)
-                                               :history       history''
-                                               :last-step     prompt-name
-                                               :last-output   (task-preview (:text step-result) 500)
-                                               :started-ms    started-ms
-                                               :error-message (if has-tasks-stall?
-                                                                (str "No progress after step " prompt-name
-                                                                     ", state remained " (name next-state)
-                                                                     " for " no-progress-streak " consecutive attempt(s)")
-                                                                (str "No progress after step " prompt-name
-                                                                     ", state remained " (name next-state)))})))))))))
+                                    :else
+                                    (run-result {:status        :error
+                                                 :run-id        run-id
+                                                 :task-id       task-id
+                                                 :entity-type   entity-type
+                                                 :worktree-dir  worktree-dir
+                                                 :current-state next-state
+                                                 :steps         (inc steps)
+                                                 :history       history''
+                                                 :last-step     prompt-name
+                                                 :last-output   (task-preview (:text step-result) 500)
+                                                 :started-ms    started-ms
+                                                 :error-message (if has-tasks-stall?
+                                                                  (str "No progress after step " prompt-name
+                                                                       ", state remained " (name next-state)
+                                                                       " for " no-progress-streak " consecutive attempt(s)")
+                                                                  (str "No progress after step " prompt-name
+                                                                       ", state remained " (name next-state)))}))))))))))
                   (run-result {:status        :error
                                :run-id        run-id
                                :task-id       task-id
@@ -1387,7 +1437,7 @@
         control (or (control-for run-id)
                     (ensure-control! run-id))]
     (when (instance? clojure.lang.IAtom control)
-      (reset! control {:pause? false :cancel? false :merge? false :answer nil}))
+      (reset! control (initial-control-state)))
     (set-live-progress!
      run-id
      {:status  :running
@@ -1522,7 +1572,7 @@
         control (or (control-for run-id)
                     (ensure-control! run-id))]
     (when (instance? clojure.lang.IAtom control)
-      (swap! control assoc :pause? false :cancel? false :merge? false :answer nil))
+      (reset! control (initial-control-state)))
     (set-live-progress!
      run-id
      {:status  :running
@@ -1852,8 +1902,16 @@
 
       (= "resume" cmd)
       (if-let [rid (second parts)]
-        (let [arg3 (nth parts 2 nil)]
-          (resume-run! rid (= "merge" arg3) (when (and arg3 (not= "merge" arg3)) arg3)))
+        (let [resume-args (drop 2 parts)
+              arg3        (first resume-args)
+              merge?      (= "merge" arg3)
+              answer      (when (seq resume-args)
+                            (if merge?
+                              (some->> (next resume-args)
+                                       seq
+                                       (str/join " "))
+                              (str/join " " resume-args)))]
+          (resume-run! rid merge? answer))
         (println "Usage: /mcp-tasks-run resume <run-id> [merge|<answer>]"))
 
       (= "cancel" cmd)

--- a/extensions/test/extensions/mcp_tasks_run_test.clj
+++ b/extensions/test/extensions/mcp_tasks_run_test.clj
@@ -345,7 +345,12 @@
 
 (deftest workflow-user-confirmation-wait-and-resume-test
   (testing "run-loop-job pauses explicitly on user confirmation marker"
-    (let [ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
+    (let [pending-session {:agent-ctx :ctx
+                           :session-ctx :session
+                           :model {:id "test"}
+                           :step-name "review-story-implementation"
+                           :step-state :done}
+          ctrl (atom {:pause? false :cancel? false :merge? false :answer nil})]
       (with-redefs [sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
                                           {:task {:id 42 :type :task}
                                            :children []
@@ -355,6 +360,7 @@
                     sut/resolve-step-prompt (fn [_project-dir _prompt-name] "prompt")
                     sut/run-step-subagent! (fn [_]
                                              {:ok? true
+                                              :step-session pending-session
                                               :text "MCP_TASKS_RUN_USER_CONFIRMATION: {:question \"Continue?\" :expected-answer :yes-no}"})]
         (let [res (#'sut/run-loop-job {:run-id "run-1"
                                        :task-id 42
@@ -370,7 +376,61 @@
           (is (= :paused (:status res)))
           (is (= :wait-user-confirmation (:current-state res)))
           (is (= :wait-user-confirmation (:pause-reason res)))
-          (is (= "Continue?" (get-in res [:user-confirmation :question]))))))))
+          (is (= "Continue?" (get-in res [:user-confirmation :question])))
+          (is (= pending-session (:pending-step-session @ctrl))))))))
+
+(deftest workflow-user-confirmation-resume-routes-to-asking-session-test
+  (testing "resume answer is sent back to the session that asked"
+    (let [pending-session {:agent-ctx :ctx
+                           :session-ctx :session
+                           :model {:id "test"}
+                           :step-name "review-story-implementation"
+                           :step-state :done}
+          ctrl            (atom {:pause? false
+                                 :cancel? false
+                                 :merge? false
+                                 :answer "create follow-up tasks"
+                                 :pending-step-session pending-session})
+          captured        (atom nil)
+          derived-states  (atom [{:task {:id 42 :type :story :status :open :meta {:refined "true"}}
+                                  :children [{:id 1 :status :done :meta {:refined "true"}}]
+                                  :entity-type :story
+                                  :state :done
+                                  :completed-count 1}
+                                 {:task {:id 42 :type :story :status :open :meta {:refined "true"}}
+                                  :children [{:id 1 :status :done :meta {:refined "true"}}
+                                             {:id 2 :status :open :meta {}}]
+                                  :entity-type :story
+                                  :state :has-tasks
+                                  :completed-count 1}])]
+      (with-redefs [sut/derive-current! (fn [_project-dir _worktree-dir _task-id]
+                                          (let [entry (first @derived-states)]
+                                            (swap! derived-states #(if (seq %) (vec (rest %)) %))
+                                            entry))
+                    sut/resolve-step-prompt (fn [_project-dir _prompt-name] "prompt")
+                    sut/run-step-subagent! (fn [args]
+                                             (reset! captured args)
+                                             {:ok? true
+                                              :step-session pending-session
+                                              :text "Processed answer and created new story tasks."})]
+        (let [res (#'sut/run-loop-job {:run-id "run-1"
+                                       :task-id 42
+                                       :project-dir "/tmp"
+                                       :worktree-dir "/tmp/wt"
+                                       :control ctrl
+                                       :current-state :wait-user-confirmation
+                                       :steps 1
+                                       :history []
+                                       :user-confirmation {:question "Which review items should be added?"}
+                                       :user-answer nil
+                                       :max-steps 10})]
+          (is (= :running (:status res)))
+          (is (= :derive-state (:current-state res)))
+          (is (= pending-session (:resume-step-session @captured)))
+          (is (= "create follow-up tasks" (:user-answer @captured)))
+          (is (= "review-story-implementation" (:step-name @captured)))
+          (is (nil? (:pending-step-session @ctrl)))
+          (is (nil? (:answer @ctrl))))))))
 
 (deftest start-run-admission-policy-test
   (testing "allows concurrent runs for distinct task IDs"
@@ -512,10 +572,12 @@
                :psi.extension.workflow/phase :paused
                :psi.extension.workflow/data {:run/pause-reason :wait-user-confirmation})
         (let [before (count (send-events))]
-          (with-out-str (handler "resume run-1 yes"))
+          (with-out-str (handler "resume run-1 add review-item-1 and review-item-2"))
           (let [events (drop before (send-events))]
             (is (= 1 (count events)))
-            (is (= "run-1" (get-in (first events) [:params :id])))))
+            (is (= "run-1" (get-in (first events) [:params :id])))
+            (is (= "add review-item-1 and review-item-2"
+                   (get-in (first events) [:params :data :answer])))))
 
         (swap! state update-in [:workflows "run-1"]
                assoc
@@ -843,3 +905,51 @@
           (is (= fake-model (nth @captured 3)))
           (is (= "user" (get-in (nth @captured 4) [0 :role])))
           (is (= {:turn-ctx-atom nil} (nth @captured 5))))))))
+
+(deftest run-step-subagent-resume-session-test
+  (testing "run-step-subagent reuses the pending asking session on resume"
+    (let [captured         (atom nil)
+          fake-agent-ctx   {:fake :agent-ctx}
+          fake-session-ctx {:agent-ctx fake-agent-ctx
+                            :session-data-atom (atom {:tool-output-overrides {}})
+                            :tool-output-stats-atom (atom {:calls []
+                                                           :aggregates {:total-context-bytes 0
+                                                                        :by-tool {}
+                                                                        :limit-hits-by-tool {}}})}
+          fake-model       {:provider "anthropic" :id "sonnet"}
+          resume-session   {:agent-ctx fake-agent-ctx
+                            :session-ctx fake-session-ctx
+                            :model fake-model
+                            :step-name "review-story-implementation"
+                            :step-state :done}]
+      (with-redefs [sut/set-live-progress! (fn [& _])
+                    sut/create-step-agent-ctx (fn [_]
+                                                (throw (ex-info "should not create a new agent ctx" {})))
+                    sut/create-step-session-ctx (fn [_]
+                                                  (throw (ex-info "should not create a new session ctx" {})))
+                    executor/run-agent-loop! (fn [& args]
+                                               (reset! captured args)
+                                               {:role "assistant"
+                                                :stop-reason :stop
+                                                :content [{:type :text :text "ok"}]})]
+        (let [result (#'sut/run-step-subagent!
+                      {:run-id "run-1"
+                       :step-name "review-story-implementation"
+                       :prompt-body "prompt"
+                       :task-id 42
+                       :entity-type :story
+                       :project-dir "/tmp"
+                       :worktree-dir "/tmp/wt"
+                       :task {:id 42 :type :story}
+                       :children [{:id 1 :status :done}]
+                       :state :done
+                       :user-answer "Create two follow-up tasks first."
+                       :resume-step-session resume-session})]
+          (is (:ok? result))
+          (is (= 6 (count @captured)))
+          (is (= fake-session-ctx (nth @captured 1)))
+          (is (= fake-agent-ctx (nth @captured 2)))
+          (is (= fake-model (nth @captured 3)))
+          (is (= "Create two follow-up tasks first."
+                 (get-in (nth @captured 4) [0 :content 0 :text])))
+          (is (= resume-session (:step-session result))))))))

--- a/spec/coding-agent.allium
+++ b/spec/coding-agent.allium
@@ -642,6 +642,8 @@ surface RpcApi {
         -- Commands, responses, events, and errors use canonical EDN envelopes over stdio.
         -- Events are interleaved with responses; callers match by :id where present.
         -- The RpcClient may integrate as a library or over stdio.
+        -- query_eql is the discovery path for live graph + memory surfaces
+        -- (for example :psi.graph/* and :psi.memory/* attributes).
         -- Canonical frame shapes, event payload catalog, and MUST/SHOULD compatibility/versioning policy are specified in rpc-edn.allium.
         -- Emacs-specific parity behavior is specified in emacs-frontend.allium.
 }

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -236,6 +236,8 @@ surface EmacsSessionApi {
         -- behavior values for prompt_while_streaming: queue | steer | follow_up | reject.
         -- Emacs mode is not headless fallback: extension UI operations are active.
         -- /resume parity requires list_sessions + resume_session with rehydrated tool rows.
+        -- query_eql should expose runtime graph + memory attrs when available,
+        -- e.g. :psi.graph/domain-coverage and :psi.memory/status.
         -- Wire protocol details (canonical envelopes, event payloads, versioning policy)
         -- are defined in rpc-edn.allium.
 }

--- a/spec/feed-forward-recursion.allium
+++ b/spec/feed-forward-recursion.allium
@@ -250,6 +250,11 @@ config {
         "manual", "session_end", "graph_changed", "memory_updated", "verification_failed"
     }
 
+    -- Internal manual-trigger prompt definition (spec-owned, not external).
+    internal_manual_trigger_prompt_name: String = "feed-forward-manual-trigger"
+    internal_manual_trigger_prompt: String =
+        "Trigger a manual feed-forward cycle. Capture operator reason and current readiness context."
+
     required_recursion_eql_attrs: Set<String> = {
         ":psi.recursion/status",
         ":psi.recursion/paused?",
@@ -600,7 +605,26 @@ surface FeedForwardControlApi {
         graph/CapabilityGraphApi(ActiveCapabilityGraph())
 }
 
+surface FeedForwardManualTriggerApi {
+    -- Explicit manual-trigger surface for operator-initiated feed-forward cycles.
+    for operator: FeedForwardOperator
+
+    context controller: FeedForwardController
+
+    provides:
+        TriggerFeedForward(operator, reason)
+            when controller.canStartCycle
+            when "manual" in config.enabled_trigger_hooks
+
+    guidance:
+        -- Emits TriggerSignal.type = manual.
+        -- Prompt name: config.internal_manual_trigger_prompt_name
+        -- Prompt body: config.internal_manual_trigger_prompt
+        -- This prompt is internally defined by this spec (not an external /template).
+}
+
 -- Resolved: Step 11 uses explicit/manual + event-driven hooks (no periodic cadence).
 -- Hook activation is controlled by config.enabled_trigger_hooks.
 -- Resolved: manual approval remains default; low-risk auto-approval is opt-in
 -- via trusted_local_mode_enabled + auto_approve_low_risk_in_trusted_local_mode.
+-- Manual-trigger prompt note: internal prompt "feed-forward-manual-trigger" (spec-defined).

--- a/spec/rpc-edn.allium
+++ b/spec/rpc-edn.allium
@@ -648,11 +648,20 @@ surface RpcTransportApi {
         --   {:id "42" :kind :request :op "prompt" :params {:message "Summarize this ns"}}
         -- Example response frame:
         --   {:id "42" :kind :response :op "prompt" :ok true :data {:message-id "msg_9"}}
+        -- Example query_eql request frame:
+        --   {:id "43" :kind :request :op "query_eql"
+        --    :params {:query "[:psi.graph/domain-coverage :psi.memory/status]"}}
+        -- Example query_eql response frame:
+        --   {:id "43" :kind :response :op "query_eql" :ok true
+        --    :data {:result {:psi.graph/domain-coverage [...]
+        --                    :psi.memory/status :ready}}}
         -- Example event frame:
         --   {:kind :event :event "tool/start" :seq 18 :data {:tool-id "tc_1" :tool-name "read"}}
         -- Example error frame:
         --   {:kind :error :id "42" :op "prompt" :error-code "transport/not-ready"
         --    :error-message "handshake required" :retryable true}
+        -- Handshake feature strings are implementation-defined; deployments MAY
+        -- advertise discovery hints such as "eql-graph" and "eql-memory".
         -- Keep stdout protocol-only; write logs/diagnostics to stderr.
 }
 


### PR DESCRIPTION
## Summary
Completes Story #77: **Complete feed-forward runtime integration and orchestration**.

Implements full Step 11 manual feed-forward runtime integration so operators can trigger and run a guarded end-to-end cycle against live runtime context.

## Story scope delivered
- Manual trigger surface via runtime command and API/mutation
- Internal prompt binding to `feed-forward-manual-trigger`
- Unified orchestration path: observe -> plan -> approval -> execute -> verify -> learn -> FUTURE_STATE update -> finalize
- Single-active-cycle busy guard and operator guardrails (approval/rejection, pause/resume, blocked-readiness)
- Recursion EQL visibility for controller/cycle/outcome state
- Learning writeback + FUTURE_STATE evolution semantics
- Unit and integration coverage for happy path + guardrail/error cases

## Design notes
- Uses a single production orchestration entrypoint to avoid duplicated sequencing logic
- Keeps explicit approval gate semantics by default
- Preserves rejection semantics as explicit aborted outcomes with provenance
- Integrates readiness with live session query/graph/memory context

## Commit summary
- ab1738d Add single production feed-forward orchestration entrypoint with explicit approval gate
- ce6a975 Align rejection outcome semantics for feed-forward cycles
- b432427 Integrate feed-forward trigger with live session readiness + recursion EQL
- c5d1c12 Implement pause/resume checkpoint guardrails
- e0d9be4 Add `/feed-forward` runtime command and shared manual trigger payload
- 933dc39 Add approval-gate transition guard tests

## Additional context
Story context token: `77`
