### PR TITLE
Harden agent-session EQL introspection telemetry resolvers

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -63,6 +63,17 @@ eql_query(query: "[{:psi.agent-session/stats [:total-messages :context-tokens]}]
 eql_query(query: "[:psi.tool/names :psi.skill/names]")
 ```
 
+Canonical agent-session telemetry query path (direct top-level attrs):
+```
+eql_query(query: "[:psi.agent-session/messages-count]")
+eql_query(query: "[:psi.agent-session/tool-call-count]")
+eql_query(query: "[:psi.agent-session/start-time]")
+eql_query(query: "[:psi.agent-session/current-time]")
+eql_query(query: "[:psi.agent-session/messages-count :psi.agent-session/tool-call-count :psi.agent-session/start-time :psi.agent-session/current-time]")
+```
+
+Live verification (2026-03-01): all 5 queries above return successfully with no resolver error; counts return integers and both time attrs return `java.time.Instant`.
+
 nREPL introspection (from connected REPL):
 ```clojure
 @psi.agent-session.main/session-state   ;; → {:ctx ... :ai-model ...}
@@ -168,8 +179,6 @@ Caught by `jline-terminal-keymap-test` smoke test.
 
 ## Open Questions
 
-- Session introspection: some `:psi.agent-session/*` attrs are discoverable but not consistently resolvable via direct EQL queries (observed: `messages-count`, `tool-call-count`, `start-time`, `current-time` query errors in-session)
-- Session introspection: should canonical telemetry be exposed only as top-level attrs, or via a single stable stats map plus top-level aliases?
 - TUI: per-token streaming (currently shows spinner until agent done)
 - TUI: tool execution status display during agent loop
 - Extension UI: should dialogs support auto-dismiss timeout?

--- a/components/agent-session/src/psi/agent_session/resolvers.clj
+++ b/components/agent-session/src/psi/agent_session/resolvers.clj
@@ -37,6 +37,10 @@
    :psi.agent-session/context-tokens
    :psi.agent-session/context-window
    :psi.agent-session/context-fraction    — nil or 0.0–1.0
+   :psi.agent-session/messages-count
+   :psi.agent-session/tool-call-count
+   :psi.agent-session/start-time
+   :psi.agent-session/current-time
    :psi.agent-session/stats               — SessionStats snapshot
    :psi.agent-session/tool-call-history   — [{:psi.tool-call/*}], nested tool call entities
    :psi.agent-session/tool-call-history-count — number of tool calls
@@ -607,24 +611,53 @@
 
 ;; ── Stats snapshot ──────────────────────────────────────
 
+(defn- stats-snapshot
+  "Build canonical session telemetry stats from current session/journal state."
+  [agent-session-ctx]
+  (let [sd      @(:session-data-atom agent-session-ctx)
+        journal @(:journal-atom agent-session-ctx)
+        msgs    (keep #(when (= :message (:kind %)) (get-in % [:data :message])) journal)]
+    {:session-id         (:session-id sd)
+     :session-file       (:session-file sd)
+     :user-messages      (count (filter #(= "user" (:role %)) msgs))
+     :assistant-messages (count (filter #(= "assistant" (:role %)) msgs))
+     :tool-calls         (count (filter #(= "toolResult" (:role %)) msgs))
+     :total-messages     (count msgs)
+     :entry-count        (count journal)
+     :context-tokens     (:context-tokens sd)
+     :context-window     (:context-window sd)}))
+
+(defn- canonical-start-time
+  [agent-session-ctx]
+  (let [sd      @(:session-data-atom agent-session-ctx)
+        startup (:startup-bootstrap sd)
+        journal @(:journal-atom agent-session-ctx)
+        first-ts (:timestamp (first journal))]
+    (or (:timestamp startup)
+        first-ts
+        (java.time.Instant/now))))
+
+(pco/defresolver agent-session-canonical-telemetry
+  "Resolve canonical top-level telemetry attrs from the same source as :psi.agent-session/stats.
+   Time attrs intentionally return java.time.Instant for stable in-process representation."
+  [{:keys [psi/agent-session-ctx]}]
+  {::pco/input  [:psi/agent-session-ctx]
+   ::pco/output [:psi.agent-session/messages-count
+                 :psi.agent-session/tool-call-count
+                 :psi.agent-session/start-time
+                 :psi.agent-session/current-time]}
+  (let [stats (stats-snapshot agent-session-ctx)]
+    {:psi.agent-session/messages-count  (:total-messages stats)
+     :psi.agent-session/tool-call-count (:tool-calls stats)
+     :psi.agent-session/start-time      (canonical-start-time agent-session-ctx)
+     :psi.agent-session/current-time    (java.time.Instant/now)}))
+
 (pco/defresolver agent-session-stats
   "Resolve a SessionStats snapshot."
   [{:keys [psi/agent-session-ctx]}]
   {::pco/input  [:psi/agent-session-ctx]
    ::pco/output [:psi.agent-session/stats]}
-  (let [sd      @(:session-data-atom agent-session-ctx)
-        journal @(:journal-atom agent-session-ctx)
-        msgs    (keep #(when (= :message (:kind %)) (get-in % [:data :message])) journal)]
-    {:psi.agent-session/stats
-     {:session-id        (:session-id sd)
-      :session-file      (:session-file sd)
-      :user-messages     (count (filter #(= "user" (:role %)) msgs))
-      :assistant-messages (count (filter #(= "assistant" (:role %)) msgs))
-      :tool-calls        (count (filter #(= "toolResult" (:role %)) msgs))
-      :total-messages    (count msgs)
-      :entry-count       (count journal)
-      :context-tokens    (:context-tokens sd)
-      :context-window    (:context-window sd)}}))
+  {:psi.agent-session/stats (stats-snapshot agent-session-ctx)})
 
 ;; ── Tool call history ───────────────────────────────────
 ;;
@@ -1331,6 +1364,7 @@
    tool-output-calls
    tool-output-stats
    agent-session-journal
+   agent-session-canonical-telemetry
    agent-session-stats
    ;; Session-derived usage/git attrs
    agent-session-cwd

--- a/components/agent-session/test/psi/agent_session/core_test.clj
+++ b/components/agent-session/test/psi/agent_session/core_test.clj
@@ -73,7 +73,7 @@
   (testing "resume-session-in! keeps current model when resumed journal has no model entry"
     (let [initial-model {:provider "openai" :id "gpt-5.3-codex" :reasoning true}
           ctx           (session/create-context {:initial-session {:model initial-model
-                                                                  :thinking-level :high}})
+                                                                   :thinking-level :high}})
           f             (File/createTempFile "psi-resume-no-model" ".ndedn")
           entries       [(persist/thinking-level-entry :minimal)
                          (persist/message-entry {:role "user"
@@ -316,6 +316,19 @@
       (is (map? (:psi.agent-session/stats result)))
       (is (contains? (:psi.agent-session/stats result) :session-id))))
 
+  (testing "query-in resolves canonical telemetry attrs directly"
+    (let [ctx    (session/create-context)
+          result (session/query-in ctx [:psi.agent-session/messages-count
+                                        :psi.agent-session/tool-call-count
+                                        :psi.agent-session/start-time
+                                        :psi.agent-session/current-time])]
+      (is (int? (:psi.agent-session/messages-count result)))
+      (is (int? (:psi.agent-session/tool-call-count result)))
+      (is (instance? java.time.Instant (:psi.agent-session/start-time result)))
+      (is (instance? java.time.Instant (:psi.agent-session/current-time result)))
+      (is (<= 0 (:psi.agent-session/messages-count result)))
+      (is (<= 0 (:psi.agent-session/tool-call-count result)))))
+
   (testing "query-in resolves usage aggregates from journal assistant usage"
     (let [ctx (session/create-context)
           assistant-1 {:role "assistant"
@@ -348,7 +361,7 @@
         (is (= 50 (:psi.agent-session/usage-cache-read result)))
         (is (= 10 (:psi.agent-session/usage-cache-write result)))
         (is (< (Math/abs (- 0.173 (double (:psi.agent-session/usage-cost-total result))))
-               1.0e-9))))))
+               1.0e-9)))))
 
   (testing "query-in resolves model provider/id/reasoning attrs"
     (let [ctx (session/create-context)
@@ -372,7 +385,7 @@
       (let [summary (session/query-in ctx [:psi.tool/count :psi.tool/names :psi.tool/summary])]
         (is (= 1 (:psi.tool/count summary)))
         (is (= ["foo"] (:psi.tool/names summary)))
-        (is (= "foo" (get-in summary [:psi.tool/summary :tools 0 :name]))))))
+        (is (= "foo" (get-in summary [:psi.tool/summary :tools 0 :name])))))))
 
 (deftest tool-output-eql-introspection-test
   (testing "query-in resolves tool-output policy defaults and overrides"
@@ -629,14 +642,14 @@
     (let [ctx    (session/create-context)
           qctx   (query/create-query-context)
           chart  (chart/statechart {:id :wf-test}
-                   (ele/state {:id :idle}
-                     (ele/transition {:event :workflow/start :target :running}))
-                   (ele/state {:id :running}
-                     (ele/transition {:event :workflow/finish :target :done}
-                       (ele/script {:expr (fn [_ data]
-                                            [{:op :assign
-                                              :data {:result (get-in data [:_event :data :result])}}])})))
-                   (ele/final {:id :done}))
+                                   (ele/state {:id :idle}
+                                              (ele/transition {:event :workflow/start :target :running}))
+                                   (ele/state {:id :running}
+                                              (ele/transition {:event :workflow/finish :target :done}
+                                                              (ele/script {:expr (fn [_ data]
+                                                                                   [{:op :assign
+                                                                                     :data {:result (get-in data [:_event :data :result])}}])})))
+                                   (ele/final {:id :done}))
           mutate (fn [op params]
                    (get (query/query-in qctx
                                         {:psi/agent-session-ctx ctx}

--- a/components/agent-session/test/psi/agent_session/core_test.clj
+++ b/components/agent-session/test/psi/agent_session/core_test.clj
@@ -317,6 +317,15 @@
       (is (contains? (:psi.agent-session/stats result) :session-id))))
 
   (testing "query-in resolves canonical telemetry attrs directly"
+    (let [ctx (session/create-context)]
+      (doseq [attr [:psi.agent-session/messages-count
+                    :psi.agent-session/tool-call-count
+                    :psi.agent-session/start-time
+                    :psi.agent-session/current-time]]
+        (let [result (session/query-in ctx [attr])]
+          (is (contains? result attr))
+          (is (not (contains? result :com.wsscode.pathom3.connect.runner/attribute-errors))))))
+
     (let [ctx    (session/create-context)
           result (session/query-in ctx [:psi.agent-session/messages-count
                                         :psi.agent-session/tool-call-count


### PR DESCRIPTION
## Summary
Harden canonical `:psi.agent-session/*` telemetry resolvers so direct in-session EQL introspection is deterministic.

Story #101: Harden agent-session EQL introspection telemetry resolvers.

## What changed
- Added canonical top-level resolvers for:
  - `:psi.agent-session/messages-count`
  - `:psi.agent-session/tool-call-count`
  - `:psi.agent-session/start-time`
  - `:psi.agent-session/current-time`
- Added direct single-attribute and aggregate EQL assertions in `psi.agent-session.core-test`.
- Documented the canonical direct `eql_query` path in `STATE.md` and recorded live verification outputs.

## Design notes
- Top-level telemetry attrs are wired to a canonical stats snapshot source to keep behavior consistent.
- Time attrs use a consistent representation and are verified in tests.

## Verification
- `clojure -M:test --focus psi.agent-session.core-test/eql-introspection-test`
- `clojure -M:test --focus psi.agent-session.core-test`
- Live `eql_query` checks for all 4 single attrs plus combined query.

## Commits
- 84d3733 ⚒ Document canonical eql_query telemetry path and live verification for story 101
- 70773a4 ⚒ Add direct single-attr EQL telemetry assertions for task 103
- 5d7f526 ⚒ Add canonical :psi.agent-session telemetry resolvers for direct EQL