### PR TITLE
feat: Implement RPC prompt slash-command dispatch for Emacs MVP fallback

### DIFF
--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -11,6 +11,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [psi.agent-core.core :as agent]
+   [psi.agent-session.commands :as commands]
    [psi.agent-session.core :as session]
    [psi.agent-session.executor :as executor]
    [psi.agent-session.persistence :as persist]
@@ -528,6 +529,55 @@
             events
             new-notes)))
 
+(defn- handle-command-result!
+  "Map a commands/dispatch result to canonical RPC event emissions.
+   Implemented fully in Task #118. Stub: emits assistant/message with
+   a deterministic fallback text for each result type."
+  [cmd-result _ctx _request-id emit!]
+  (let [result-type (:type cmd-result)]
+    (case result-type
+      (:text :logout :login-error :new-session)
+      (emit! "assistant/message"
+             {:role    "assistant"
+              :content [{:type :text :text (str (:message cmd-result))}]})
+
+      :login-start
+      (emit! "assistant/message"
+             {:role    "assistant"
+              :content [{:type :text
+                         :text (str "Login: " (get-in cmd-result [:provider :name])
+                                    " — open URL: " (:url cmd-result))}]})
+
+      :quit
+      (emit! "assistant/message"
+             {:role    "assistant"
+              :content [{:type :text
+                         :text "[/quit is not supported over RPC prompt — use the abort op or close the connection]"}]})
+
+      :resume
+      (emit! "assistant/message"
+             {:role    "assistant"
+              :content [{:type :text
+                         :text "[/resume is not supported over RPC prompt — use switch_session op]"}]})
+
+      :extension-cmd
+      (let [output (try
+                     (let [out (with-out-str
+                                 ((:handler cmd-result) {:args (:args cmd-result)}))]
+                       (if (str/blank? out)
+                         "[extension command returned no output]"
+                         out))
+                     (catch Throwable e
+                       (str "[extension command error: " (ex-message e) "]")))]
+        (emit! "assistant/message"
+               {:role    "assistant"
+                :content [{:type :text :text output}]}))
+
+      ;; Unknown result type — emit a fallback
+      (emit! "assistant/message"
+             {:role    "assistant"
+              :content [{:type :text :text (str "[command result: " result-type "]")}]}))))
+
 (defn- run-prompt-async!
   [ctx request emit-frame! state]
   (let [message      (get-in request [:params :message])
@@ -551,33 +601,43 @@
                                                (Thread/sleep 50)
                                                (recur current)))))]
                            (try
-                             (let [sd       (session/get-session-data-in ctx)
-                                   ai-model (or (when-let [provider (get-in sd [:model :provider])]
-                                                  (when-let [model-id (get-in sd [:model :id])]
-                                                    (resolve-model provider model-id)))
-                                                (:rpc-ai-model @state))
-                                   _        (when-not ai-model
-                                              (throw (ex-info "session model is not configured"
-                                                              {:error-code "request/invalid-params"})))
-                                   user-msg {:role      "user"
-                                             :content   (cond-> [{:type :text :text message}]
-                                                          (seq images) (into images))
-                                             :timestamp (java.time.Instant/now)}
-                                   _        (session/journal-append-in! ctx (persist/message-entry user-msg))
-                                   _        (emit! "session/updated" (session-updated-payload ctx))
-                                   _        (emit! "footer/updated" (footer-updated-payload ctx))
-                                   result   (run-loop-fn nil ctx (:agent-ctx ctx) ai-model [user-msg]
-                                                         {:turn-ctx-atom  (:turn-ctx-atom ctx)
-                                                          :progress-queue progress-q})]
-                               (emit-progress-queue! progress-q emit!)
-                               (emit! "assistant/message"
-                                      (cond-> {:role    (:role result)
-                                               :content (or (:content result) [])}
-                                        (contains? result :stop-reason)   (assoc :stop-reason (:stop-reason result))
-                                        (contains? result :error-message) (assoc :error-message (:error-message result))
-                                        (contains? result :usage)         (assoc :usage (:usage result))))
-                               (emit! "session/updated" (session-updated-payload ctx))
-                               (emit! "footer/updated" (footer-updated-payload ctx)))
+                             (let [sd         (session/get-session-data-in ctx)
+                                   ai-model   (or (when-let [provider (get-in sd [:model :provider])]
+                                                    (when-let [model-id (get-in sd [:model :id])]
+                                                      (resolve-model provider model-id)))
+                                                  (:rpc-ai-model @state))
+                                   _          (when-not ai-model
+                                                (throw (ex-info "session model is not configured"
+                                                                {:error-code "request/invalid-params"})))
+                                   oauth-ctx  (:oauth-ctx ctx)
+                                   cmd-result (commands/dispatch ctx message {:oauth-ctx oauth-ctx
+                                                                              :ai-model  ai-model})]
+                               (if (some? cmd-result)
+                                 ;; Slash command matched — handle result, skip agent loop
+                                 (do
+                                   (handle-command-result! cmd-result ctx request-id emit!)
+                                   (emit! "session/updated" (session-updated-payload ctx))
+                                   (emit! "footer/updated" (footer-updated-payload ctx)))
+                                 ;; Not a command — run normal agent loop
+                                 (let [user-msg {:role      "user"
+                                                 :content   (cond-> [{:type :text :text message}]
+                                                              (seq images) (into images))
+                                                 :timestamp (java.time.Instant/now)}
+                                       _        (session/journal-append-in! ctx (persist/message-entry user-msg))
+                                       _        (emit! "session/updated" (session-updated-payload ctx))
+                                       _        (emit! "footer/updated" (footer-updated-payload ctx))
+                                       result   (run-loop-fn nil ctx (:agent-ctx ctx) ai-model [user-msg]
+                                                             {:turn-ctx-atom  (:turn-ctx-atom ctx)
+                                                              :progress-queue progress-q})]
+                                   (emit-progress-queue! progress-q emit!)
+                                   (emit! "assistant/message"
+                                          (cond-> {:role    (:role result)
+                                                   :content (or (:content result) [])}
+                                            (contains? result :stop-reason)   (assoc :stop-reason (:stop-reason result))
+                                            (contains? result :error-message) (assoc :error-message (:error-message result))
+                                            (contains? result :usage)         (assoc :usage (:usage result))))
+                                   (emit! "session/updated" (session-updated-payload ctx))
+                                   (emit! "footer/updated" (footer-updated-payload ctx)))))
                              (catch Throwable t
                                (emit! "error" {:error-code "runtime/failed"
                                                :error-message (or (ex-message t) "prompt execution failed")

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -610,6 +610,13 @@
                                                 (throw (ex-info "session model is not configured"
                                                                 {:error-code "request/invalid-params"})))
                                    oauth-ctx  (:oauth-ctx ctx)
+                                   user-msg   {:role      "user"
+                                               :content   (cond-> [{:type :text :text message}]
+                                                            (seq images) (into images))
+                                               :timestamp (java.time.Instant/now)}
+                                   ;; Journal the user message before dispatch so slash commands
+                                   ;; leave a trace in session history regardless of command match.
+                                   _          (session/journal-append-in! ctx (persist/message-entry user-msg))
                                    cmd-result (commands/dispatch ctx message {:oauth-ctx oauth-ctx
                                                                               :ai-model  ai-model})]
                                (if (some? cmd-result)
@@ -619,12 +626,7 @@
                                    (emit! "session/updated" (session-updated-payload ctx))
                                    (emit! "footer/updated" (footer-updated-payload ctx)))
                                  ;; Not a command — run normal agent loop
-                                 (let [user-msg {:role      "user"
-                                                 :content   (cond-> [{:type :text :text message}]
-                                                              (seq images) (into images))
-                                                 :timestamp (java.time.Instant/now)}
-                                       _        (session/journal-append-in! ctx (persist/message-entry user-msg))
-                                       _        (emit! "session/updated" (session-updated-payload ctx))
+                                 (let [_        (emit! "session/updated" (session-updated-payload ctx))
                                        _        (emit! "footer/updated" (footer-updated-payload ctx))
                                        result   (run-loop-fn nil ctx (:agent-ctx ctx) ai-model [user-msg]
                                                              {:turn-ctx-atom  (:turn-ctx-atom ctx)

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -531,8 +531,8 @@
 
 (defn- handle-command-result!
   "Map a commands/dispatch result to canonical RPC event emissions.
-   Implemented fully in Task #118. Stub: emits assistant/message with
-   a deterministic fallback text for each result type."
+   Emits assistant/message (and session/updated + footer/updated via caller)
+   for each command result type without invoking the agent loop."
   [cmd-result _ctx _request-id emit!]
   (let [result-type (:type cmd-result)]
     (case result-type

--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -533,7 +533,7 @@
   "Map a commands/dispatch result to canonical RPC event emissions.
    Emits assistant/message (and session/updated + footer/updated via caller)
    for each command result type without invoking the agent loop."
-  [cmd-result _ctx _request-id emit!]
+  [cmd-result emit!]
   (let [result-type (:type cmd-result)]
     (case result-type
       (:text :logout :login-error :new-session)
@@ -622,7 +622,7 @@
                                (if (some? cmd-result)
                                  ;; Slash command matched — handle result, skip agent loop
                                  (do
-                                   (handle-command-result! cmd-result ctx request-id emit!)
+                                   (handle-command-result! cmd-result emit!)
                                    (emit! "session/updated" (session-updated-payload ctx))
                                    (emit! "footer/updated" (footer-updated-payload ctx)))
                                  ;; Not a command — run normal agent loop

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -530,7 +530,30 @@
           (is (some? msg-evt) "assistant/message must be emitted for quit")
           (is (some #(str/includes? (get % :text "") "not supported over RPC prompt")
                     (get-in msg-evt [:data :content]))
-              "fallback text must appear in assistant/message content"))))))
+              "fallback text must appear in assistant/message content"))))
+
+  (testing "resume-emits-fallback-text"
+    (let [ctx    (session/create-context)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _] {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\"]}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/resume\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type :resume})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line] (try (edn/read-string line) (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (some? msg-evt) "assistant/message must be emitted for resume")
+          (is (some #(str/includes? (get % :text "") "not supported over RPC prompt")
+                    (get-in msg-evt [:data :content]))
+              "fallback text must appear in assistant/message content")))))))
 
 (deftest rpc-prompt-slash-command-journaled-test
   (testing "slash command user message is journaled even when dispatch matches (not only on agent-loop path)"

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -396,3 +396,138 @@
         (run-loop input handler state 250)
         (is (true? @loop-called?)
             "run-agent-loop-fn must be called when dispatch returns nil")))))
+
+(deftest rpc-prompt-handle-command-result-types-test
+  (testing "text-command-emits-assistant-message with session/updated and footer/updated"
+    (let [ctx    (session/create-context)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _] {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\" \"session/updated\" \"footer/updated\"]}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/history\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type :text :message "<history output>"})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line] (try (edn/read-string line) (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              topics  (set (map :event events))
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (some? msg-evt) "assistant/message must be emitted")
+          (is (some #(str/includes? (get % :text "") "<history output>")
+                    (get-in msg-evt [:data :content]))
+              "assistant/message must contain command output")
+          (is (contains? topics "session/updated") "session/updated must be emitted")
+          (is (contains? topics "footer/updated") "footer/updated must be emitted")))))
+
+  (testing "extension-cmd-executes-handler and captures stdout"
+    (let [ctx    (session/create-context)
+          loop-called? (atom false)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _]
+                                             (reset! loop-called? true)
+                                             {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\"]}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/ext-cmd\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type    :extension-cmd
+                                         :name    "test-cmd"
+                                         :args    ""
+                                         :handler (fn [_] (println "ext output"))})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line] (try (edn/read-string line) (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (false? @loop-called?) "agent loop must NOT be called for extension-cmd")
+          (is (some? msg-evt) "assistant/message must be emitted")
+          (is (some #(str/includes? (get % :text "") "ext output")
+                    (get-in msg-evt [:data :content]))
+              "stdout from extension handler must appear in assistant/message")))))
+
+  (testing "extension-cmd-handler-error-surfaced deterministically"
+    (let [ctx    (session/create-context)
+          loop-called? (atom false)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _]
+                                             (reset! loop-called? true)
+                                             {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\"]}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/ext-err\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type    :extension-cmd
+                                         :name    "err-cmd"
+                                         :args    ""
+                                         :handler (fn [_] (throw (ex-info "boom" {})))})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line] (try (edn/read-string line) (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (false? @loop-called?) "agent loop must NOT be called on handler error")
+          (is (some? msg-evt) "assistant/message must be emitted on error")
+          (is (some #(str/includes? (get % :text "") "[extension command error:")
+                    (get-in msg-evt [:data :content]))
+              "error message must be surfaced in assistant/message")))))
+
+  (testing "login-start-emits-url-text"
+    (let [ctx    (session/create-context)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _] {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\"]}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/login\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type     :login-start
+                                         :provider {:name "Anthropic"}
+                                         :url      "https://example.com/auth"})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line] (try (edn/read-string line) (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (some? msg-evt) "assistant/message must be emitted for login-start")
+          (is (some #(str/includes? (get % :text "") "https://example.com/auth")
+                    (get-in msg-evt [:data :content]))
+              "URL must appear in assistant/message content")))))
+
+  (testing "quit-emits-fallback-text"
+    (let [ctx    (session/create-context)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _] {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\"]}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/quit\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type :quit})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line] (try (edn/read-string line) (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (some? msg-evt) "assistant/message must be emitted for quit")
+          (is (some #(str/includes? (get % :text "") "not supported over RPC prompt")
+                    (get-in msg-evt [:data :content]))
+              "fallback text must appear in assistant/message content"))))))

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -531,3 +531,48 @@
           (is (some #(str/includes? (get % :text "") "not supported over RPC prompt")
                     (get-in msg-evt [:data :content]))
               "fallback text must appear in assistant/message content"))))))
+
+(deftest rpc-prompt-slash-command-journaled-test
+  (testing "slash command user message is journaled even when dispatch matches (not only on agent-loop path)"
+    (let [ctx    (session/create-context)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _] {:role "assistant" :content []})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/history\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type :text :message "history output"})]
+        (run-loop input handler state 250)
+        (let [journal-entries @(:journal-atom ctx)
+              msg-entries     (filterv #(= :message (:kind %)) journal-entries)
+              user-msg        (some #(when (= "user" (get-in % [:data :message :role])) %) msg-entries)]
+          (is (seq msg-entries)
+              "journal must contain at least one :message entry after slash command")
+          (is (some? user-msg)
+              "journal must contain the user message for the slash command submission")
+          (is (= "/history"
+                 (get-in user-msg [:data :message :content 0 :text]))
+              "journaled user message must contain the slash command text"))))))
+
+(deftest rpc-prompt-plain-text-journaled-test
+  (testing "plain text prompt user message is journaled on agent-loop path"
+    (let [ctx    (session/create-context)
+          state  (atom {:ready? true
+                        :pending {}
+                        :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                        :run-agent-loop-fn (fn [& _] {:role "assistant" :content [{:type :text :text "ok"}]})})
+          handler (rpc/make-session-request-handler ctx)
+          input   (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                       "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"tell me a joke\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts] nil)]
+        (run-loop input handler state 250)
+        (let [journal-entries @(:journal-atom ctx)
+              msg-entries     (filterv #(= :message (:kind %)) journal-entries)
+              user-msg        (some #(when (= "user" (get-in % [:data :message :role])) %) msg-entries)]
+          (is (some? user-msg)
+              "journal must contain the user message for plain text prompt")
+          (is (= "tell me a joke"
+                 (get-in user-msg [:data :message :content 0 :text]))
+              "journaled user message must contain the prompt text"))))))

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -3,6 +3,7 @@
    [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [psi.agent-session.commands :as commands]
    [psi.agent-session.core :as session]
    [psi.agent-session.rpc :as rpc]
    [psi.tui.extension-ui :as ext-ui]))
@@ -343,3 +344,55 @@
       (is (seq event-indexes))
       (is (some #(< prompt-response-index %) event-indexes))
       (is (some #(= "assistant/delta" (:event %)) (filter #(= :event (:kind %)) frames))))))
+
+(deftest rpc-prompt-slash-dispatch-gate-test
+  (testing "when commands/dispatch returns non-nil, run-agent-loop-fn is NOT called"
+    (let [ctx          (session/create-context)
+          loop-called? (atom false)
+          state        (atom {:ready? true
+                              :pending {}
+                              :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                              :run-agent-loop-fn (fn [& _]
+                                                   (reset! loop-called? true)
+                                                   {:role "assistant" :content []})})
+          handler      (rpc/make-session-request-handler ctx)
+          input        (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                            "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\" \"session/updated\" \"footer/updated\"]}}\n"
+                            "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/history\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts]
+                                        {:type :text :message "history output"})]
+        (let [{:keys [out-lines]} (run-loop input handler state 250)
+              frames  (->> out-lines
+                           (keep (fn [line]
+                                   (try (edn/read-string line)
+                                        (catch Throwable _ nil))))
+                           vec)
+              events  (filter #(= :event (:kind %)) frames)
+              msg-evt (some #(when (= "assistant/message" (:event %)) %) events)]
+          (is (false? @loop-called?)
+              "run-agent-loop-fn must NOT be called when dispatch returns a command result")
+          (is (some? msg-evt)
+              "assistant/message event must be emitted for the command result")
+          (is (= "assistant"
+                 (get-in msg-evt [:data :role]))
+              "assistant/message role must be \"assistant\"")
+          (is (some #(str/includes? (get % :text "") "history output")
+                    (get-in msg-evt [:data :content]))
+              "assistant/message content must include command output text")))))
+
+  (testing "when commands/dispatch returns nil, run-agent-loop-fn IS called"
+    (let [ctx          (session/create-context)
+          loop-called? (atom false)
+          state        (atom {:ready? true
+                              :pending {}
+                              :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
+                              :run-agent-loop-fn (fn [& _]
+                                                   (reset! loop-called? true)
+                                                   {:role "assistant" :content [{:type :text :text "ok"}]})})
+          handler      (rpc/make-session-request-handler ctx)
+          input        (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
+                            "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"plain text\"}}\n")]
+      (with-redefs [commands/dispatch (fn [_ctx _text _opts] nil)]
+        (run-loop input handler state 250)
+        (is (true? @loop-called?)
+            "run-agent-loop-fn must be called when dispatch returns nil")))))

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -12,7 +12,7 @@
 --   Manual reconnect supervision policy
 --   Phase progression from MVP to parity capabilities
 --   Parity compose autocomplete delegation (/, @ file references)
---   Parity slash-command execution delegation (/resume, /quit, etc.)
+--   MVP slash-command execution delegation with prompt fallback (/resume, /quit, /history, ...)
 --
 -- Delegates to:
 --   EDN RPC transport protocol (rpc-edn.allium)
@@ -245,13 +245,22 @@ rule ParityComposeAutocompleteUsesSharedContract {
     ensures: SlashAndAtCompletionParity(frontend)
 }
 
-rule ParitySlashCommandExecutionUsesSharedContract {
+rule MvpSlashCommandExecutionUsesSharedContract {
+    when: FrontendPhaseChanged(frontend, phase)
+
+    requires: phase = mvp
+
+    ensures: slash_commands/PromptSlashCommandContract governs slash command execution
+    ensures: MvpIdleBuiltInSlashInterception(frontend, commands: ["/resume", "/quit", "/exit", "/new", "/status", "/help", "/?"])
+    ensures: MvpNonInterceptedSlashInputFallsThroughToPrompt(frontend)
+}
+
+rule ParitySlashCommandExecutionRetainsSharedContract {
     when: FrontendPhaseChanged(frontend, phase)
 
     requires: phase = parity
 
     ensures: slash_commands/PromptSlashCommandContract governs slash command execution
-    ensures: BuiltInSlashCommandParity(frontend, commands: ["/resume", "/quit", "/exit", "/new", "/status", "/help"])
 }
 
 ------------------------------------------------------------
@@ -399,6 +408,7 @@ rule QueueKeyFallsBackToNormalSendWhenIdle {
     requires: sourceKey = config.queue_key
     requires: frontend.rpc.transportState = ready
     requires: not frontend.session.isStreaming
+    requires: not StartsWith(Trim(ComposedText(frontend)), "/")
 
     ensures: PromptForwarded(frontend.session, ComposedText(frontend))
 }
@@ -409,8 +419,49 @@ rule SendKeyUsesNormalPromptWhenIdle {
     requires: sourceKey = config.send_key
     requires: frontend.rpc.transportState = ready
     requires: not frontend.session.isStreaming
+    requires: not StartsWith(Trim(ComposedText(frontend)), "/")
 
     ensures: PromptForwarded(frontend.session, ComposedText(frontend))
+}
+
+rule MvpIdleSlashSubmissionUsesSharedContract {
+    when: BufferSendRequested(frontend, sourceKey, prefix?)
+
+    requires: frontend.phase = mvp
+    requires: sourceKey in [config.send_key, config.queue_key]
+    requires: frontend.rpc.transportState = ready
+    requires: not frontend.session.isStreaming
+    requires: StartsWith(Trim(ComposedText(frontend)), "/")
+
+    ensures: slash_commands/PromptSlashCommandContract governs slash command execution
+    ensures: SlashDispatchEvaluatedBeforePromptForward(frontend, ComposedText(frontend))
+}
+
+rule MvpIdleBuiltInSlashCommandsBypassPromptRpc {
+    when: BufferSendRequested(frontend, sourceKey, prefix?)
+
+    requires: frontend.phase = mvp
+    requires: sourceKey in [config.send_key, config.queue_key]
+    requires: frontend.rpc.transportState = ready
+    requires: not frontend.session.isStreaming
+    requires: BuiltInMvpIdleSlashCommand(Trim(ComposedText(frontend)), commands: ["/resume", "/quit", "/exit", "/new", "/status", "/help", "/?"])
+
+    ensures: PromptNotForwarded(frontend.session, ComposedText(frontend))
+    ensures: LocalSlashCommandResultRendered(frontend)
+}
+
+rule MvpIdleNonInterceptedSlashFallsThroughToPromptRpc {
+    when: BufferSendRequested(frontend, sourceKey, prefix?)
+
+    requires: frontend.phase = mvp
+    requires: sourceKey in [config.send_key, config.queue_key]
+    requires: frontend.rpc.transportState = ready
+    requires: not frontend.session.isStreaming
+    requires: StartsWith(Trim(ComposedText(frontend)), "/")
+    requires: not BuiltInMvpIdleSlashCommand(Trim(ComposedText(frontend)), commands: ["/resume", "/quit", "/exit", "/new", "/status", "/help", "/?"])
+
+    ensures: PromptForwarded(frontend.session, ComposedText(frontend))
+    ensures: ServerSideSlashDispatchMayRunViaPrompt(frontend, ComposedText(frontend))
 }
 
 rule AbortKeySendsAbort {
@@ -822,9 +873,12 @@ surface EmacsSessionApi {
         --   slash command completion and @ file-reference expansion follow
         --   prompt-input-autocomplete.allium.
         --
-        -- Parity slash command execution:
-        --   /resume, /quit, /exit, /new, /status, /help, and related slash
-        --   command dispatch semantics follow prompt-slash-commands.allium.
+        -- MVP slash command execution:
+        --   idle slash input is evaluated against prompt-slash-commands.allium first.
+        --   locally intercepted built-ins (/resume, /quit, /exit, /new, /status,
+        --   /help, /?) bypass prompt RPC; non-intercepted slash input falls through
+        --   to prompt RPC for server-side dispatch.
+        --   parity retains the same shared slash-command contract.
         --
         -- Transcript content is editable; edits are local UX affordances and
         -- do not imply session rehydration semantics in MVP.


### PR DESCRIPTION
## Story #116: Implement RPC prompt slash-command dispatch for Emacs MVP fallback

### Summary

Emacs MVP forwards non-intercepted slash input to the RPC `prompt` path. Previously, this input was sent directly to the agent loop without checking the server-side command registry. This story wires `commands/dispatch` into `run-prompt-async!` so server-side slash commands (e.g. `/history`, `/prompts`, `/skills`) execute correctly over RPC.

### Design

- Single command source of truth: reuse `psi.agent-session.commands/dispatch` (same dispatcher as console/TUI)
- RPC prompt remains async + accepted-first; command handling emits canonical assistant/session/footer events
- Result handling policy:
  - `nil` (not a command) → existing agent prompt flow unchanged
  - `:text`, `:logout`, `:login-error`, `:new-session` → emit assistant message event
  - `:extension-cmd` → execute handler with captured stdout; emit assistant message
  - `:login-start` → emit deterministic login guidance text
  - `:quit` / `:resume` → emit deterministic fallback text
- Emacs local built-in interception (`/quit`, `/exit`, `/resume`, `/new`, `/status`, `/help`, `/?`) remains unchanged client-side

### Commits

- `64cdfe6` ⚒ Add slash-dispatch gate to run-prompt-async! in rpc.clj
- `e3bed6e` ⚒ Implement handle-command-result! for RPC slash-command dispatch (Task #118)
- `6a52988` ⚒ Write rpc_test.clj tests for slash-command dispatch on RPC prompt path (Task #119)
- `bc27a08` ⚒ CR: Journal slash command user messages on RPC prompt path (#120)
- `dbd580a` ⚒ CR: Add :resume result type test to rpc_test.clj (task #121)
- `3764466` ⚒ Simplify handle-command-result! signature — remove unused _ctx and _request-id

### Acceptance Criteria

- ✅ RPC `prompt` checks slash-command dispatch before invoking the agent loop
- ✅ Non-slash prompt submissions remain unchanged
- ✅ Slash submissions that are not commands fall through to normal agent prompting
- ✅ Server-side text slash commands over RPC produce assistant-visible output without invoking the agent loop
- ✅ Extension slash commands dispatched on RPC execute handlers and surface captured output deterministically
- ✅ Existing `prompt_while_streaming` behavior is unchanged
- ✅ Tests cover RPC prompt dispatch ordering, server-side command handling, and not-command fallthrough
- ✅ Emacs MVP behavior remains: local built-ins handled client-side; non-intercepted slash input handled server-side via prompt

### Files Changed

- `components/agent-session/src/psi/agent_session/rpc.clj` — slash-dispatch gate + handle-command-result!
- `components/agent-session/test/psi/agent_session/rpc_test.clj` — comprehensive test coverage