### PR TITLE
feat: Implement shared Extension UI parity in Emacs frontend

### DIFF
--- a/components/agent-session/src/psi/agent_session/rpc.clj
+++ b/components/agent-session/src/psi/agent_session/rpc.clj
@@ -51,7 +51,9 @@
    "get_messages"
    "get_session_stats"
    "subscribe"
-   "unsubscribe"])
+   "unsubscribe"
+   "resolve_dialog"
+   "cancel_dialog"])
 
 (defn response-frame
   ([id op ok]
@@ -312,6 +314,52 @@
       (throw (ex-info "query must be an EDN vector"
                       {:error-code "request/invalid-query"})))
     q))
+
+(defn- dialog-result-valid?
+  [v]
+  (or (nil? v) (boolean? v) (string? v)))
+
+(defn- active-dialog-or-error!
+  [ctx]
+  (let [ui-state-atom (:ui-state-atom ctx)
+        active        (when ui-state-atom (ext-ui/active-dialog ui-state-atom))]
+    (when-not (map? active)
+      (throw (ex-info "no active dialog"
+                      {:error-code "request/no-active-dialog"})))
+    active))
+
+(defn- handle-resolve-dialog!
+  [ctx request params]
+  (let [dialog-id (req-arg! request params :dialog-id #(and (string? %) (not (str/blank? %))) "non-empty string")
+        result    (get params :result ::missing)
+        _         (when (= ::missing result)
+                    (throw (ex-info "invalid request parameter :result: boolean, string, or nil"
+                                    {:error-code "request/invalid-params"})))
+        _         (when-not (dialog-result-valid? result)
+                    (throw (ex-info "invalid request parameter :result: boolean, string, or nil"
+                                    {:error-code "request/invalid-params"})))
+        active    (active-dialog-or-error! ctx)
+        active-id (:id active)]
+    (when-not (= dialog-id active-id)
+      (throw (ex-info "dialog-id mismatch"
+                      {:error-code "request/dialog-id-mismatch"})))
+    (when-not (ext-ui/resolve-dialog! (:ui-state-atom ctx) dialog-id result)
+      (throw (ex-info "no active dialog"
+                      {:error-code "request/no-active-dialog"})))
+    (response-frame (:id request) "resolve_dialog" true {:accepted true})))
+
+(defn- handle-cancel-dialog!
+  [ctx request params]
+  (let [dialog-id (req-arg! request params :dialog-id #(and (string? %) (not (str/blank? %))) "non-empty string")
+        active    (active-dialog-or-error! ctx)
+        active-id (:id active)]
+    (when-not (= dialog-id active-id)
+      (throw (ex-info "dialog-id mismatch"
+                      {:error-code "request/dialog-id-mismatch"})))
+    (when-not (ext-ui/cancel-dialog! (:ui-state-atom ctx))
+      (throw (ex-info "no active dialog"
+                      {:error-code "request/no-active-dialog"})))
+    (response-frame (:id request) "cancel_dialog" true {:accepted true})))
 
 (defn- normalize-provider [provider]
   (cond
@@ -829,6 +877,12 @@
               (swap! state update :subscribed-topics (fn [s] (apply disj (or s #{}) topics*)))
               (swap! state assoc :subscribed-topics #{}))
             (response-frame (:id request) op true {:subscribed (->> (:subscribed-topics @state) sort vec)}))
+
+          "resolve_dialog"
+          (handle-resolve-dialog! ctx request params)
+
+          "cancel_dialog"
+          (handle-cancel-dialog! ctx request params)
 
           (error-frame {:id            (:id request)
                         :op            op

--- a/components/agent-session/test/psi/agent_session/rpc_test.clj
+++ b/components/agent-session/test/psi/agent_session/rpc_test.clj
@@ -201,10 +201,13 @@
           (run-loop "{:id \"u1\" :kind :request :op \"nope\"}\n"
                     handler
                     state)
-          frame   (-> out-lines first edn/read-string)]
+          frame   (-> out-lines first edn/read-string)
+          supported (get-in frame [:data :supported-ops])]
       (is (= :error (:kind frame)))
       (is (= "request/op-not-supported" (:error-code frame)))
-      (is (vector? (get-in frame [:data :supported-ops])))))
+      (is (vector? supported))
+      (is (some #(= "resolve_dialog" %) supported))
+      (is (some #(= "cancel_dialog" %) supported))))
 
   (testing "subscribe/unsubscribe update shared state and return subscribed topics"
     (let [ctx     (session/create-context)
@@ -238,6 +241,95 @@
       (is (= "1.0" (:protocol-version info)))
       (is (contains? info :session-id))
       (is (= ["eql-graph" "eql-memory"] (:features info))))))
+
+(deftest rpc-dialog-response-ops-test
+  (testing "resolve_dialog succeeds with active dialog and matching id"
+    (let [ctx     (session/create-context)
+          ui      (:ui-state-atom ctx)
+          _       (ext-ui/enqueue-dialog! ui {:id "d1" :kind :confirm :title "Confirm" :promise (promise)})
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"r1\" :kind :request :op \"resolve_dialog\" :params {:dialog-id \"d1\" :result true}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :response (:kind frame)))
+      (is (= "resolve_dialog" (:op frame)))
+      (is (= true (:ok frame)))
+      (is (= {:accepted true} (:data frame)))
+      (is (nil? (ext-ui/active-dialog ui)))))
+
+  (testing "cancel_dialog succeeds with active dialog and matching id"
+    (let [ctx     (session/create-context)
+          ui      (:ui-state-atom ctx)
+          _       (ext-ui/enqueue-dialog! ui {:id "d2" :kind :input :title "Input" :promise (promise)})
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"c1\" :kind :request :op \"cancel_dialog\" :params {:dialog-id \"d2\"}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :response (:kind frame)))
+      (is (= "cancel_dialog" (:op frame)))
+      (is (= true (:ok frame)))
+      (is (= {:accepted true} (:data frame)))
+      (is (nil? (ext-ui/active-dialog ui)))))
+
+  (testing "resolve_dialog invalid params are deterministic"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"r2\" :kind :request :op \"resolve_dialog\" :params {:dialog-id \"d1\" :result 42}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "resolve_dialog" (:op frame)))
+      (is (= "request/invalid-params" (:error-code frame)))))
+
+  (testing "resolve_dialog no active dialog returns deterministic error"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"r3\" :kind :request :op \"resolve_dialog\" :params {:dialog-id \"d1\" :result true}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "resolve_dialog" (:op frame)))
+      (is (= "request/no-active-dialog" (:error-code frame)))))
+
+  (testing "cancel_dialog no active dialog returns deterministic error"
+    (let [ctx     (session/create-context)
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"c2\" :kind :request :op \"cancel_dialog\" :params {:dialog-id \"d1\"}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "cancel_dialog" (:op frame)))
+      (is (= "request/no-active-dialog" (:error-code frame)))))
+
+  (testing "dialog-id mismatch returns deterministic error"
+    (let [ctx     (session/create-context)
+          ui      (:ui-state-atom ctx)
+          _       (ext-ui/enqueue-dialog! ui {:id "d-real" :kind :confirm :title "Confirm" :promise (promise)})
+          state   (atom {:ready? true :pending {}})
+          handler (rpc/make-session-request-handler ctx)
+          {:keys [out-lines]}
+          (run-loop "{:id \"r4\" :kind :request :op \"resolve_dialog\" :params {:dialog-id \"d-wrong\" :result true}}\n"
+                    handler
+                    state)
+          frame   (-> out-lines first edn/read-string)]
+      (is (= :error (:kind frame)))
+      (is (= "resolve_dialog" (:op frame)))
+      (is (= "request/dialog-id-mismatch" (:error-code frame))))))
 
 (deftest rpc-prompt-streams-events-and-interleaves-test
   (testing "prompt emits canonical events that interleave with accepted response"

--- a/components/emacs-ui/README.md
+++ b/components/emacs-ui/README.md
@@ -7,7 +7,8 @@ This frontend runs psi over `--rpc-edn` in a dedicated Emacs buffer.
 When the frontend is **idle** (not streaming), these built-in slash commands are intercepted locally and do **not** fall through to `prompt` RPC:
 
 - `/quit`, `/exit` — close the frontend buffer/process
-- `/resume` — explicit MVP fallback message (`resume selector unavailable in Emacs MVP`)
+- `/resume` — resume prior session (`/resume <path>`), or open selector when no path is provided
+  - set `psi-emacs-enable-resume-parity` to `nil` to force MVP fallback message
 - `/new` — request `new_session`, reset transcript/session rendering state, and continue in the new session
 - `/status` — append deterministic frontend/session diagnostics text
 - `/help`, `/?` — render slash command help

--- a/components/emacs-ui/README.md
+++ b/components/emacs-ui/README.md
@@ -1,6 +1,23 @@
-# psi Emacs frontend (MVP)
+# psi Emacs frontend
 
 This frontend runs psi over `--rpc-edn` in a dedicated Emacs buffer.
+
+## Extension UI parity gate
+
+Extension UI parity is controlled by `psi-emacs-enable-extension-ui-parity` (default `nil`).
+
+- `nil` (default): subscribe to `psi-rpc-mvp-topics` only (MVP behavior)
+- non-`nil`: subscribe to `psi-rpc-parity-topics` (MVP + extension UI/footer topics)
+
+Exact parity extension topics:
+
+- `ui/dialog-requested`
+- `ui/widgets-updated`
+- `ui/status-updated`
+- `ui/notification`
+- `footer/updated`
+
+When parity is disabled, UI/footer topic handling is not subscribed.
 
 ## Idle slash commands
 
@@ -45,6 +62,28 @@ Streaming send/queue behavior:
 - watchdog timeout sends `abort`, upserts a deterministic transcript error line, and sets run-state to `error`
 
 Idle slash interception applies only to idle compose send/queue paths.
+
+## Extension dialog response flow (parity)
+
+On `ui/dialog-requested`, Emacs maps dialog kinds to prompts and sends exactly one response op:
+
+- confirm => yes/no prompt -> `resolve_dialog`
+- select => completion over option labels (returns selected option `value`) -> `resolve_dialog`
+- input => text prompt -> `resolve_dialog`
+- user quit/cancel (`C-g`) -> `cancel_dialog`
+
+RPC request shapes:
+
+- `resolve_dialog`: `{:dialog-id <string> :result <boolean|string|null>}`
+- `cancel_dialog`: `{:dialog-id <string>}`
+
+`dialog-id` is always echoed from the inbound event; Emacs never invents IDs.
+
+## Renderer boundary (explicit)
+
+Emacs does **not** execute extension-provided renderer functions from extension UI state.
+For parity mode, tool/message payload text is treated as display-ready text.
+Renderer registration/query metadata remains read-only via `query_eql`.
 
 ## Error surface
 

--- a/components/emacs-ui/psi-rpc.el
+++ b/components/emacs-ui/psi-rpc.el
@@ -13,7 +13,7 @@
   "Non-nil when parseedn is available for EDN parsing/printing.")
 
 (defconst psi-rpc-protocol-version "1.0"
-  "Supported rpc-edn protocol version for Emacs MVP transport.")
+  "Supported rpc-edn protocol version for Emacs transport.")
 
 (defconst psi-rpc-mvp-topics
   '("assistant/delta"
@@ -26,6 +26,18 @@
     "session/updated"
     "error")
   "MVP topic subscription set for Emacs frontend.")
+
+(defconst psi-rpc-parity-extension-ui-topics
+  '("ui/dialog-requested"
+    "ui/widgets-updated"
+    "ui/status-updated"
+    "ui/notification"
+    "footer/updated")
+  "Extension UI parity topics for Emacs frontend.")
+
+(defconst psi-rpc-parity-topics
+  (append psi-rpc-mvp-topics psi-rpc-parity-extension-ui-topics)
+  "Parity topic subscription set for Emacs frontend.")
 
 (cl-defstruct psi-rpc-client
   process

--- a/components/emacs-ui/psi.el
+++ b/components/emacs-ui/psi.el
@@ -33,11 +33,11 @@ Used to detect stalled streaming runs and transition to deterministic recovery."
   :type 'number
   :group 'psi-emacs)
 
-(defcustom psi-emacs-enable-resume-parity nil
+(defcustom psi-emacs-enable-resume-parity t
   "Enable parity-mode `/resume` routing in Emacs frontend.
 
-When nil (default), `/resume` always uses the MVP fallback message.
-When non-nil, `/resume` routes to parity entry points (implemented incrementally)."
+When non-nil (default), `/resume` routes to parity entry points.
+When nil, `/resume` uses the MVP fallback message."
   :type 'boolean
   :group 'psi-emacs)
 
@@ -438,12 +438,14 @@ USED-REGION-P non-nil means compose came from region and anchor is untouched."
 (defun psi-emacs--idle-slash-help-text ()
   "Return deterministic help text for supported idle slash commands."
   (string-join
-   '("Supported slash commands:"
-     "/quit, /exit  Exit this psi buffer"
-     "/resume       Resume selector unavailable in Emacs MVP"
-     "/new          Start a fresh backend session"
-     "/status       Show frontend diagnostics"
-     "/help, /?     Show this help")
+   (list "Supported slash commands:"
+         "/quit, /exit  Exit this psi buffer"
+         (if psi-emacs-enable-resume-parity
+             "/resume [path] Resume a prior session (selector when path omitted)"
+           "/resume       Resume selector unavailable in this frontend")
+         "/new          Start a fresh backend session"
+         "/status       Show frontend diagnostics"
+         "/help, /?     Show this help")
    "\n"))
 
 (defun psi-emacs--reset-transcript-for-new-session ()
@@ -537,14 +539,42 @@ Return nil for no argument. Otherwise return trimmed argument string."
      ((not (string-empty-p path)) (file-name-nondirectory path))
      (t "(unnamed session)"))))
 
+(defun psi-emacs--resume-session-modified-seconds (session)
+  "Return SESSION modified timestamp as seconds since epoch.
+
+Unreadable/missing timestamps normalize to 0."
+  (let ((modified (alist-get :psi.session-info/modified session nil nil #'equal)))
+    (cond
+     ((numberp modified) (float modified))
+     ((stringp modified)
+      (or (ignore-errors (float-time (date-to-time modified))) 0.0))
+     (t
+      (or (ignore-errors (float-time modified)) 0.0)))))
+
+(defun psi-emacs--resume-session-path (session)
+  "Return trimmed canonical session path for SESSION, or empty string."
+  (string-trim (or (alist-get :psi.session-info/path session nil nil #'equal) "")))
+
+(defun psi-emacs--sort-resume-sessions (sessions)
+  "Sort SESSIONS by modified desc (newest first), then path asc."
+  (sort (copy-sequence sessions)
+        (lambda (a b)
+          (let ((am (psi-emacs--resume-session-modified-seconds a))
+                (bm (psi-emacs--resume-session-modified-seconds b))
+                (ap (psi-emacs--resume-session-path a))
+                (bp (psi-emacs--resume-session-path b)))
+            (if (/= am bm)
+                (> am bm)
+              (string< ap bp))))))
+
 (defun psi-emacs--resume-session-candidates (sessions)
   "Build deterministic selector candidates from SESSIONS.
 
 Returns list of cons cells (DISPLAY . CANONICAL-PATH)."
   (let ((seen (make-hash-table :test #'equal))
         (candidates nil))
-    (dolist (session sessions)
-      (let* ((path (string-trim (or (alist-get :psi.session-info/path session nil nil #'equal) ""))))
+    (dolist (session (psi-emacs--sort-resume-sessions sessions))
+      (let ((path (psi-emacs--resume-session-path session)))
         (when (not (string-empty-p path))
           (let* ((description (psi-emacs--resume-session-description session))
                  (base (format "%s — %s" description path))

--- a/components/emacs-ui/psi.el
+++ b/components/emacs-ui/psi.el
@@ -1129,12 +1129,23 @@ Renders according to the current global tool-output-view-mode."
 
 (defun psi-emacs--projection-footer-text (data)
   "Extract deterministic footer projection text from event DATA."
-  (let ((value (psi-emacs--event-data-get data
-                                          '(:text text :message message :footer footer :content content))))
-    (cond
-     ((stringp value) value)
-     ((null value) nil)
-     (t (format "%s" value)))))
+  (let* ((path-line (psi-emacs--event-data-get data '(:path-line path-line :pathLine pathLine)))
+         (stats-line (psi-emacs--event-data-get data '(:stats-line stats-line :statsLine statsLine)))
+         (status-line (psi-emacs--event-data-get data '(:status-line status-line :statusLine statusLine)))
+         (canonical-lines (delq nil
+                                (mapcar (lambda (line)
+                                          (when (and (stringp line)
+                                                     (not (string-empty-p line)))
+                                            line))
+                                        (list path-line stats-line status-line)))))
+    (if canonical-lines
+        (string-join canonical-lines " | ")
+      (let ((value (psi-emacs--event-data-get data
+                                              '(:text text :message message :footer footer :content content))))
+        (cond
+         ((stringp value) value)
+         ((null value) nil)
+         (t (format "%s" value)))))))
 
 (defun psi-emacs--cancel-notification-timer (state notification-id)
   "Cancel notification timer for NOTIFICATION-ID in STATE, if present."

--- a/components/emacs-ui/psi.el
+++ b/components/emacs-ui/psi.el
@@ -61,6 +61,10 @@ When non-nil, subscribe to `psi-rpc-parity-topics`."
   assistant-in-progress
   assistant-range
   tool-rows
+  projection-widgets
+  projection-statuses
+  projection-footer
+  projection-range
   draft-anchor
   rpc-client
   tool-output-view-mode)
@@ -117,6 +121,10 @@ Prefers `markdown-mode' when available, otherwise `text-mode'."
    :assistant-in-progress nil
    :assistant-range nil
    :tool-rows (make-hash-table :test #'equal)
+   :projection-widgets nil
+   :projection-statuses nil
+   :projection-footer nil
+   :projection-range nil
    :draft-anchor nil
    :rpc-client nil
    :tool-output-view-mode 'collapsed))
@@ -370,6 +378,10 @@ COMMAND is a list suitable for `make-process'."
              (consp (psi-emacs-state-assistant-range psi-emacs--state)))
     (set-marker (car (psi-emacs-state-assistant-range psi-emacs--state)) nil)
     (set-marker (cdr (psi-emacs-state-assistant-range psi-emacs--state)) nil))
+  (when (and psi-emacs--state
+             (consp (psi-emacs-state-projection-range psi-emacs--state)))
+    (set-marker (car (psi-emacs-state-projection-range psi-emacs--state)) nil)
+    (set-marker (cdr (psi-emacs-state-projection-range psi-emacs--state)) nil))
   (when psi-emacs--state
     (maphash (lambda (_ row)
                (when (markerp (plist-get row :start))
@@ -471,6 +483,13 @@ USED-REGION-P non-nil means compose came from region and anchor is untouched."
     (setf (psi-emacs-state-assistant-in-progress psi-emacs--state) nil)
     (setf (psi-emacs-state-assistant-range psi-emacs--state) nil)
     (clrhash (psi-emacs-state-tool-rows psi-emacs--state))
+    (setf (psi-emacs-state-projection-widgets psi-emacs--state) nil)
+    (setf (psi-emacs-state-projection-statuses psi-emacs--state) nil)
+    (setf (psi-emacs-state-projection-footer psi-emacs--state) nil)
+    (when (consp (psi-emacs-state-projection-range psi-emacs--state))
+      (set-marker (car (psi-emacs-state-projection-range psi-emacs--state)) nil)
+      (set-marker (cdr (psi-emacs-state-projection-range psi-emacs--state)) nil))
+    (setf (psi-emacs-state-projection-range psi-emacs--state) nil)
     (setf (psi-emacs-state-draft-anchor psi-emacs--state)
           (copy-marker (point-max) nil))
     (psi-emacs--set-run-state psi-emacs--state 'idle)
@@ -1046,6 +1065,127 @@ Renders according to the current global tool-output-view-mode."
       (when follow-anchor
         (psi-emacs--set-draft-anchor-to-end)))))
 
+(defun psi-emacs--projection-seq (value)
+  "Normalize VALUE into a proper list sequence."
+  (cond
+   ((vectorp value) (append value nil))
+   ((listp value) value)
+   (t nil)))
+
+(defun psi-emacs--projection-item-key (item keys)
+  "Return deterministic sort/display key from ITEM over KEYS."
+  (let ((value (and (listp item)
+                    (psi-emacs--event-data-get item keys))))
+    (if (stringp value)
+        value
+      (format "%s" (or value "")))))
+
+(defun psi-emacs--projection-item-text (item)
+  "Return display text for projection ITEM."
+  (let ((value (and (listp item)
+                    (psi-emacs--event-data-get item
+                                               '(:text text :message message :value value :content content)))))
+    (cond
+     ((stringp value) value)
+     ((null value) "")
+     (t (format "%s" value)))))
+
+(defun psi-emacs--projection-sort-widgets (widgets)
+  "Return WIDGETS sorted by [placement, extension-id, widget-id]."
+  (sort (copy-sequence widgets)
+        (lambda (a b)
+          (let ((ap (psi-emacs--projection-item-key a '(:placement placement)))
+                (bp (psi-emacs--projection-item-key b '(:placement placement)))
+                (ae (psi-emacs--projection-item-key a '(:extension-id extension-id :extensionId extensionId)))
+                (be (psi-emacs--projection-item-key b '(:extension-id extension-id :extensionId extensionId)))
+                (aw (psi-emacs--projection-item-key a '(:widget-id widget-id :widgetId widgetId)))
+                (bw (psi-emacs--projection-item-key b '(:widget-id widget-id :widgetId widgetId))))
+            (cond
+             ((string< ap bp) t)
+             ((string< bp ap) nil)
+             ((string< ae be) t)
+             ((string< be ae) nil)
+             (t (string< aw bw)))))))
+
+(defun psi-emacs--projection-sort-statuses (statuses)
+  "Return STATUSES sorted by extension-id."
+  (sort (copy-sequence statuses)
+        (lambda (a b)
+          (string< (psi-emacs--projection-item-key a '(:extension-id extension-id :extensionId extensionId))
+                   (psi-emacs--projection-item-key b '(:extension-id extension-id :extensionId extensionId))))))
+
+(defun psi-emacs--projection-footer-text (data)
+  "Extract deterministic footer projection text from event DATA."
+  (let ((value (psi-emacs--event-data-get data
+                                          '(:text text :message message :footer footer :content content))))
+    (cond
+     ((stringp value) value)
+     ((null value) nil)
+     (t (format "%s" value)))))
+
+(defun psi-emacs--projection-render-block (state)
+  "Render deterministic projection block from STATE."
+  (let ((widgets (or (psi-emacs-state-projection-widgets state) '()))
+        (statuses (or (psi-emacs-state-projection-statuses state) '()))
+        (footer (psi-emacs-state-projection-footer state))
+        (lines nil))
+    (when widgets
+      (push "Extension Widgets:" lines)
+      (dolist (widget widgets)
+        (push (format "- [%s/%s/%s] %s"
+                      (psi-emacs--projection-item-key widget '(:placement placement))
+                      (psi-emacs--projection-item-key widget '(:extension-id extension-id :extensionId extensionId))
+                      (psi-emacs--projection-item-key widget '(:widget-id widget-id :widgetId widgetId))
+                      (psi-emacs--projection-item-text widget))
+              lines)))
+    (when statuses
+      (push "Extension Statuses:" lines)
+      (dolist (status statuses)
+        (push (format "- [%s] %s"
+                      (psi-emacs--projection-item-key status '(:extension-id extension-id :extensionId extensionId))
+                      (psi-emacs--projection-item-text status))
+              lines)))
+    (when (and (stringp footer)
+               (not (string-empty-p footer)))
+      (push (format "Footer: %s" footer) lines))
+    (if lines
+        (concat (string-join (nreverse lines) "\n") "\n")
+      "")))
+
+(defun psi-emacs--upsert-projection-block ()
+  "Upsert deterministic projection block from current state."
+  (when psi-emacs--state
+    (let* ((follow-anchor (psi-emacs--draft-anchor-at-end-p))
+           (range (psi-emacs-state-projection-range psi-emacs--state))
+           (start (and (consp range) (car range)))
+           (end (and (consp range) (cdr range)))
+           (rendered (psi-emacs--projection-render-block psi-emacs--state)))
+      (if (and (markerp start)
+               (markerp end)
+               (marker-buffer start)
+               (marker-buffer end))
+          (save-excursion
+            (goto-char start)
+            (delete-region start end)
+            (if (string-empty-p rendered)
+                (progn
+                  (set-marker start nil)
+                  (set-marker end nil)
+                  (setf (psi-emacs-state-projection-range psi-emacs--state) nil))
+              (insert rendered)
+              (set-marker end (point))))
+        (unless (string-empty-p rendered)
+          (save-excursion
+            (psi-emacs--ensure-newline-before-append)
+            (let ((new-start (copy-marker (point) nil))
+                  (new-end (copy-marker (point) t)))
+              (insert rendered)
+              (set-marker new-end (point))
+              (setf (psi-emacs-state-projection-range psi-emacs--state)
+                    (cons new-start new-end))))))
+      (when follow-anchor
+        (psi-emacs--set-draft-anchor-to-end)))))
+
 (defun psi-emacs--handle-rpc-event (frame)
   "Handle inbound rpc-edn event FRAME for transcript rendering."
   (let* ((event (alist-get :event frame nil nil #'equal))
@@ -1068,6 +1208,27 @@ Renders according to the current global tool-output-view-mode."
              (stage (replace-regexp-in-string "^tool/" "" event)))
          (psi-emacs--reset-stream-watchdog psi-emacs--state)
          (psi-emacs--upsert-tool-row tool-id stage text)))
+      ("ui/widgets-updated"
+       (when psi-emacs--state
+         (setf (psi-emacs-state-projection-widgets psi-emacs--state)
+               (psi-emacs--projection-sort-widgets
+                (psi-emacs--projection-seq
+                 (or (psi-emacs--event-data-get data '(:widgets widgets))
+                     (psi-emacs--event-data-get data '(:items items))))))
+         (psi-emacs--upsert-projection-block)))
+      ("ui/status-updated"
+       (when psi-emacs--state
+         (setf (psi-emacs-state-projection-statuses psi-emacs--state)
+               (psi-emacs--projection-sort-statuses
+                (psi-emacs--projection-seq
+                 (or (psi-emacs--event-data-get data '(:statuses statuses))
+                     (psi-emacs--event-data-get data '(:items items))))))
+         (psi-emacs--upsert-projection-block)))
+      ("footer/updated"
+       (when psi-emacs--state
+         (setf (psi-emacs-state-projection-footer psi-emacs--state)
+               (psi-emacs--projection-footer-text data))
+         (psi-emacs--upsert-projection-block)))
       (_ nil))))
 
 (defun psi-emacs--buffer-modified-p ()
@@ -1092,6 +1253,13 @@ reconnect the user starts with the default collapsed view."
     (setf (psi-emacs-state-assistant-in-progress psi-emacs--state) nil)
     (setf (psi-emacs-state-assistant-range psi-emacs--state) nil)
     (clrhash (psi-emacs-state-tool-rows psi-emacs--state))
+    (setf (psi-emacs-state-projection-widgets psi-emacs--state) nil)
+    (setf (psi-emacs-state-projection-statuses psi-emacs--state) nil)
+    (setf (psi-emacs-state-projection-footer psi-emacs--state) nil)
+    (when (consp (psi-emacs-state-projection-range psi-emacs--state))
+      (set-marker (car (psi-emacs-state-projection-range psi-emacs--state)) nil)
+      (set-marker (cdr (psi-emacs-state-projection-range psi-emacs--state)) nil))
+    (setf (psi-emacs-state-projection-range psi-emacs--state) nil)
     (setf (psi-emacs-state-draft-anchor psi-emacs--state)
           (copy-marker (point-max) nil))
     (setf (psi-emacs-state-tool-output-view-mode psi-emacs--state) 'collapsed)

--- a/components/emacs-ui/psi.el
+++ b/components/emacs-ui/psi.el
@@ -1186,6 +1186,87 @@ Renders according to the current global tool-output-view-mode."
       (when follow-anchor
         (psi-emacs--set-draft-anchor-to-end)))))
 
+(defun psi-emacs--dialog-result-normalize (value)
+  "Normalize dialog VALUE to the shared RPC result domain."
+  (cond
+   ((or (null value) (booleanp value) (stringp value)) value)
+   (t (format "%s" value))))
+
+(defun psi-emacs--dialog-send-resolve (dialog-id result)
+  "Send `resolve_dialog` for DIALOG-ID with RESULT."
+  (psi-emacs--dispatch-request
+   "resolve_dialog"
+   `((:dialog-id . ,dialog-id)
+     (:result . ,(psi-emacs--dialog-result-normalize result)))))
+
+(defun psi-emacs--dialog-send-cancel (dialog-id)
+  "Send `cancel_dialog` for DIALOG-ID."
+  (psi-emacs--dispatch-request
+   "cancel_dialog"
+   `((:dialog-id . ,dialog-id))))
+
+(defun psi-emacs--dialog-prompt-text (data fallback)
+  "Return deterministic prompt text from DATA, else FALLBACK."
+  (let ((value (psi-emacs--event-data-get data
+                                          '(:prompt prompt :message message :text text :title title))))
+    (if (and (stringp value)
+             (not (string-empty-p value)))
+        value
+      fallback)))
+
+(defun psi-emacs--dialog-option-candidates (options)
+  "Convert OPTIONS into selector candidates of (LABEL . VALUE)."
+  (let ((candidates nil))
+    (dolist (item (psi-emacs--projection-seq options))
+      (when (listp item)
+        (let ((label (psi-emacs--event-data-get item '(:label label :name name :text text)))
+              (value (psi-emacs--event-data-get item '(:value value :id id))))
+          (when (and (stringp label)
+                     (not (string-empty-p label)))
+            (push (cons label (psi-emacs--dialog-result-normalize value))
+                  candidates)))))
+    (nreverse candidates)))
+
+(defun psi-emacs--handle-dialog-requested (data)
+  "Handle `ui/dialog-requested` DATA with one deterministic response op."
+  (let* ((dialog-id (psi-emacs--event-data-get data '(:dialog-id dialog-id :dialogId dialogId)))
+         (kind* (psi-emacs--event-data-get data '(:kind kind)))
+         (kind (if (symbolp kind*) (symbol-name kind*) kind*)))
+    (if (not (and (stringp dialog-id) (not (string-empty-p dialog-id))))
+        (psi-emacs--append-assistant-message
+         "Ignored malformed ui/dialog-requested event: missing dialog-id.")
+      (condition-case _
+          (pcase kind
+            ("confirm"
+             (let ((answer (y-or-n-p
+                            (format "%s "
+                                    (psi-emacs--dialog-prompt-text data "Confirm?")))))
+               (psi-emacs--dialog-send-resolve dialog-id answer)))
+            ("select"
+             (let* ((candidates (psi-emacs--dialog-option-candidates
+                                 (or (psi-emacs--event-data-get data '(:options options))
+                                     (psi-emacs--event-data-get data '(:items items)))))
+                    (labels (mapcar #'car candidates)))
+               (if (null candidates)
+                   (psi-emacs--dialog-send-cancel dialog-id)
+                 (let* ((choice (completing-read
+                                 (format "%s "
+                                         (psi-emacs--dialog-prompt-text data "Select an option:"))
+                                 labels nil t))
+                        (selected (assoc choice candidates)))
+                   (if selected
+                       (psi-emacs--dialog-send-resolve dialog-id (cdr selected))
+                     (psi-emacs--dialog-send-cancel dialog-id))))))
+            ("input"
+             (let ((answer (read-string
+                            (format "%s "
+                                    (psi-emacs--dialog-prompt-text data "Input:")))))
+               (psi-emacs--dialog-send-resolve dialog-id answer)))
+            (_
+             (psi-emacs--dialog-send-cancel dialog-id)))
+        (quit
+         (psi-emacs--dialog-send-cancel dialog-id))))))
+
 (defun psi-emacs--handle-rpc-event (frame)
   "Handle inbound rpc-edn event FRAME for transcript rendering."
   (let* ((event (alist-get :event frame nil nil #'equal))
@@ -1208,6 +1289,8 @@ Renders according to the current global tool-output-view-mode."
              (stage (replace-regexp-in-string "^tool/" "" event)))
          (psi-emacs--reset-stream-watchdog psi-emacs--state)
          (psi-emacs--upsert-tool-row tool-id stage text)))
+      ("ui/dialog-requested"
+       (psi-emacs--handle-dialog-requested data))
       ("ui/widgets-updated"
        (when psi-emacs--state
          (setf (psi-emacs-state-projection-widgets psi-emacs--state)

--- a/components/emacs-ui/psi.el
+++ b/components/emacs-ui/psi.el
@@ -49,6 +49,11 @@ When non-nil, subscribe to `psi-rpc-parity-topics`."
   :type 'boolean
   :group 'psi-emacs)
 
+(defcustom psi-emacs-notification-timeout-seconds 5
+  "Seconds before a projected extension notification auto-dismisses."
+  :type 'number
+  :group 'psi-emacs)
+
 (cl-defstruct psi-emacs-state
   process
   process-state
@@ -64,6 +69,9 @@ When non-nil, subscribe to `psi-rpc-parity-topics`."
   projection-widgets
   projection-statuses
   projection-footer
+  projection-notifications
+  projection-notification-seq
+  projection-notification-timers
   projection-range
   draft-anchor
   rpc-client
@@ -124,6 +132,9 @@ Prefers `markdown-mode' when available, otherwise `text-mode'."
    :projection-widgets nil
    :projection-statuses nil
    :projection-footer nil
+   :projection-notifications nil
+   :projection-notification-seq 0
+   :projection-notification-timers (make-hash-table :test #'equal)
    :projection-range nil
    :draft-anchor nil
    :rpc-client nil
@@ -382,6 +393,7 @@ COMMAND is a list suitable for `make-process'."
              (consp (psi-emacs-state-projection-range psi-emacs--state)))
     (set-marker (car (psi-emacs-state-projection-range psi-emacs--state)) nil)
     (set-marker (cdr (psi-emacs-state-projection-range psi-emacs--state)) nil))
+  (psi-emacs--clear-notification-lifecycle psi-emacs--state)
   (when psi-emacs--state
     (maphash (lambda (_ row)
                (when (markerp (plist-get row :start))
@@ -486,6 +498,7 @@ USED-REGION-P non-nil means compose came from region and anchor is untouched."
     (setf (psi-emacs-state-projection-widgets psi-emacs--state) nil)
     (setf (psi-emacs-state-projection-statuses psi-emacs--state) nil)
     (setf (psi-emacs-state-projection-footer psi-emacs--state) nil)
+    (psi-emacs--clear-notification-lifecycle psi-emacs--state)
     (when (consp (psi-emacs-state-projection-range psi-emacs--state))
       (set-marker (car (psi-emacs-state-projection-range psi-emacs--state)) nil)
       (set-marker (cdr (psi-emacs-state-projection-range psi-emacs--state)) nil))
@@ -1123,10 +1136,88 @@ Renders according to the current global tool-output-view-mode."
      ((null value) nil)
      (t (format "%s" value)))))
 
+(defun psi-emacs--cancel-notification-timer (state notification-id)
+  "Cancel notification timer for NOTIFICATION-ID in STATE, if present."
+  (when (and state notification-id)
+    (let* ((timers (psi-emacs-state-projection-notification-timers state))
+           (timer (and (hash-table-p timers)
+                       (gethash notification-id timers))))
+      (when (timerp timer)
+        (cancel-timer timer))
+      (when (hash-table-p timers)
+        (remhash notification-id timers)))))
+
+(defun psi-emacs--clear-notification-lifecycle (state)
+  "Clear projected notification state and cancel all lifecycle timers in STATE."
+  (when state
+    (let ((timers (psi-emacs-state-projection-notification-timers state)))
+      (when (hash-table-p timers)
+        (maphash (lambda (_id timer)
+                   (when (timerp timer)
+                     (cancel-timer timer)))
+                 timers)
+        (clrhash timers)))
+    (setf (psi-emacs-state-projection-notifications state) nil)
+    (setf (psi-emacs-state-projection-notification-seq state) 0)))
+
+(defun psi-emacs--projection-notification-line (notification)
+  "Render deterministic line for projected NOTIFICATION item."
+  (format "- [%s] %s"
+          (or (plist-get notification :extension-id) "")
+          (or (plist-get notification :text) "")))
+
+(defun psi-emacs--notification-remove-by-id (state notification-id)
+  "Remove projected notification by NOTIFICATION-ID from STATE and re-render."
+  (when (and state notification-id)
+    (let* ((notifications (or (psi-emacs-state-projection-notifications state) '()))
+           (next (cl-remove-if (lambda (item)
+                                 (equal (plist-get item :id) notification-id))
+                               notifications)))
+      (psi-emacs--cancel-notification-timer state notification-id)
+      (setf (psi-emacs-state-projection-notifications state) next)
+      (when (eq state psi-emacs--state)
+        (psi-emacs--upsert-projection-block)))))
+
+(defun psi-emacs--schedule-notification-dismiss (state notification-id)
+  "Schedule auto-dismiss timer for NOTIFICATION-ID in STATE."
+  (when (and state notification-id)
+    (psi-emacs--cancel-notification-timer state notification-id)
+    (let ((timer (run-at-time psi-emacs-notification-timeout-seconds nil
+                              (lambda (buffer st id)
+                                (when (and (buffer-live-p buffer) st)
+                                  (with-current-buffer buffer
+                                    (psi-emacs--notification-remove-by-id st id))))
+                              (current-buffer)
+                              state
+                              notification-id)))
+      (puthash notification-id timer
+               (psi-emacs-state-projection-notification-timers state)))))
+
+(defun psi-emacs--handle-notification-event (data)
+  "Apply `ui/notification` DATA to local projection lifecycle state."
+  (when psi-emacs--state
+    (let* ((seq (1+ (or (psi-emacs-state-projection-notification-seq psi-emacs--state) 0)))
+           (extension-id (psi-emacs--projection-item-key data '(:extension-id extension-id :extensionId extensionId)))
+           (text (psi-emacs--projection-item-text data))
+           (notification-id (format "n-%s" seq))
+           (entry (list :id notification-id :seq seq :extension-id extension-id :text text))
+           (existing (or (psi-emacs-state-projection-notifications psi-emacs--state) '()))
+           (next (append existing (list entry))))
+      (setf (psi-emacs-state-projection-notification-seq psi-emacs--state) seq)
+      ;; enforce max visible 3, keeping oldest->newest order
+      (while (> (length next) 3)
+        (let ((drop (car next)))
+          (setq next (cdr next))
+          (psi-emacs--cancel-notification-timer psi-emacs--state (plist-get drop :id))))
+      (setf (psi-emacs-state-projection-notifications psi-emacs--state) next)
+      (psi-emacs--schedule-notification-dismiss psi-emacs--state notification-id)
+      (psi-emacs--upsert-projection-block))))
+
 (defun psi-emacs--projection-render-block (state)
   "Render deterministic projection block from STATE."
   (let ((widgets (or (psi-emacs-state-projection-widgets state) '()))
         (statuses (or (psi-emacs-state-projection-statuses state) '()))
+        (notifications (or (psi-emacs-state-projection-notifications state) '()))
         (footer (psi-emacs-state-projection-footer state))
         (lines nil))
     (when widgets
@@ -1145,6 +1236,10 @@ Renders according to the current global tool-output-view-mode."
                       (psi-emacs--projection-item-key status '(:extension-id extension-id :extensionId extensionId))
                       (psi-emacs--projection-item-text status))
               lines)))
+    (when notifications
+      (push "Extension Notifications:" lines)
+      (dolist (notification notifications)
+        (push (psi-emacs--projection-notification-line notification) lines)))
     (when (and (stringp footer)
                (not (string-empty-p footer)))
       (push (format "Footer: %s" footer) lines))
@@ -1307,6 +1402,8 @@ Renders according to the current global tool-output-view-mode."
                  (or (psi-emacs--event-data-get data '(:statuses statuses))
                      (psi-emacs--event-data-get data '(:items items))))))
          (psi-emacs--upsert-projection-block)))
+      ("ui/notification"
+       (psi-emacs--handle-notification-event data))
       ("footer/updated"
        (when psi-emacs--state
          (setf (psi-emacs-state-projection-footer psi-emacs--state)
@@ -1339,6 +1436,7 @@ reconnect the user starts with the default collapsed view."
     (setf (psi-emacs-state-projection-widgets psi-emacs--state) nil)
     (setf (psi-emacs-state-projection-statuses psi-emacs--state) nil)
     (setf (psi-emacs-state-projection-footer psi-emacs--state) nil)
+    (psi-emacs--clear-notification-lifecycle psi-emacs--state)
     (when (consp (psi-emacs-state-projection-range psi-emacs--state))
       (set-marker (car (psi-emacs-state-projection-range psi-emacs--state)) nil)
       (set-marker (cdr (psi-emacs-state-projection-range psi-emacs--state)) nil))

--- a/components/emacs-ui/psi.el
+++ b/components/emacs-ui/psi.el
@@ -41,6 +41,14 @@ When nil, `/resume` uses the MVP fallback message."
   :type 'boolean
   :group 'psi-emacs)
 
+(defcustom psi-emacs-enable-extension-ui-parity nil
+  "Enable extension UI parity topic subscription in Emacs frontend.
+
+When nil (default), subscribe to `psi-rpc-mvp-topics` only.
+When non-nil, subscribe to `psi-rpc-parity-topics`."
+  :type 'boolean
+  :group 'psi-emacs)
+
 (cl-defstruct psi-emacs-state
   process
   process-state
@@ -316,7 +324,12 @@ and transition to `error'."
                      :on-rpc-error (lambda (code message-text frame)
                                      (psi-emacs--on-rpc-error buffer code message-text frame)))))
         (setf (psi-emacs-state-rpc-client psi-emacs--state) client)
-        (psi-rpc-start! client psi-emacs--spawn-process-function psi-emacs-command)
+        (psi-rpc-start! client
+                        psi-emacs--spawn-process-function
+                        psi-emacs-command
+                        (if psi-emacs-enable-extension-ui-parity
+                            psi-rpc-parity-topics
+                          psi-rpc-mvp-topics))
         (setf (psi-emacs-state-process psi-emacs--state) (psi-rpc-client-process client))
         (setq psi-emacs--owned-process (psi-rpc-client-process client))
         (psi-emacs--refresh-header-line)))))

--- a/components/emacs-ui/test/psi-rpc-test.el
+++ b/components/emacs-ui/test/psi-rpc-test.el
@@ -8,6 +8,30 @@
              (expand-file-name "../" (file-name-directory (or load-file-name buffer-file-name))))
 (require 'psi-rpc)
 
+(ert-deftest psi-rpc-topic-profiles-remain-explicit-and-stable ()
+  (should
+   (equal
+    '("assistant/delta"
+      "assistant/message"
+      "tool/start"
+      "tool/delta"
+      "tool/executing"
+      "tool/update"
+      "tool/result"
+      "session/updated"
+      "error")
+    psi-rpc-mvp-topics))
+  (should
+   (equal
+    '("ui/dialog-requested"
+      "ui/widgets-updated"
+      "ui/status-updated"
+      "ui/notification"
+      "footer/updated")
+    psi-rpc-parity-extension-ui-topics))
+  (should (equal (append psi-rpc-mvp-topics psi-rpc-parity-extension-ui-topics)
+                 psi-rpc-parity-topics)))
+
 (defun psi-rpc-test--spawn-cat (_command)
   "Spawn a long-lived process used in rpc transport tests."
   (make-process

--- a/components/emacs-ui/test/psi-rpc-test.el
+++ b/components/emacs-ui/test/psi-rpc-test.el
@@ -159,6 +159,8 @@
                                (psi-rpc-client-transport-state client))))
           (should (equal "1.0" (psi-rpc-client-protocol-version client)))
           (should (equal psi-rpc-mvp-topics (psi-rpc-client-subscribed-topics client)))
+          (dolist (topic psi-rpc-parity-extension-ui-topics)
+            (should-not (member topic (psi-rpc-client-subscribed-topics client))))
           (should (null errors))
           (should (member '(running handshaking) states))
           (should (member '(running ready) states)))
@@ -193,6 +195,52 @@
                                (psi-rpc-client-transport-state client))))
           (should (= 1 (length errors)))
           (should (equal "protocol/unsupported-version" (caar errors))))
+      (when (and process (process-live-p process))
+        (delete-process process)))))
+
+(ert-deftest psi-rpc-startup-lifecycle-ready-path-with-parity-topics ()
+  (let* ((states nil)
+         (errors nil)
+         (subscribed-topics nil)
+         (client (psi-rpc-make-client
+                  :on-state-change (lambda (c)
+                                     (push (list (psi-rpc-client-process-state c)
+                                                 (psi-rpc-client-transport-state c))
+                                           states))
+                  :on-rpc-error (lambda (code message _frame)
+                                  (push (list code message) errors))))
+         (process nil))
+    (setf (psi-rpc-client-send-function client)
+          (lambda (_proc payload)
+            (pcase (psi-rpc--parse-line (string-trim-right payload))
+              (`(:ok ,frame)
+               (let ((id (alist-get :id frame))
+                     (op (alist-get :op frame)))
+                 (cond
+                  ((equal op "handshake")
+                   (psi-rpc--handle-frame
+                    client
+                    `((:id . ,id) (:kind . :response) (:op . "handshake") (:ok . t)
+                      (:data . ((:server-info . ((:protocol-version . "1.0"))))))))
+                  ((equal op "subscribe")
+                   (setq subscribed-topics (append (alist-get :topics (alist-get :params frame)) nil))
+                   (psi-rpc--handle-frame
+                    client
+                    `((:id . ,id) (:kind . :response) (:op . "subscribe") (:ok . t)
+                      (:data . ((:subscribed . []))))))))))))
+    (unwind-protect
+        (progn
+          (psi-rpc-start! client #'psi-rpc-test--spawn-cat '("cat") psi-rpc-parity-topics)
+          (setq process (psi-rpc-client-process client))
+          (sleep-for 0.02)
+          (should (equal '(running ready)
+                         (list (psi-rpc-client-process-state client)
+                               (psi-rpc-client-transport-state client))))
+          (should (equal psi-rpc-parity-topics (psi-rpc-client-subscribed-topics client)))
+          (should (equal psi-rpc-parity-topics subscribed-topics))
+          (should (null errors))
+          (should (member '(running handshaking) states))
+          (should (member '(running ready) states)))
       (when (and process (process-live-p process))
         (delete-process process)))))
 

--- a/components/emacs-ui/test/psi-test.el
+++ b/components/emacs-ui/test/psi-test.el
@@ -1275,6 +1275,63 @@
         (psi-emacs--start-rpc-client (current-buffer)))
       (should (equal psi-rpc-parity-topics captured-topics)))))
 
+(ert-deftest psi-extension-ui-widgets-updated-replaces-and-sorts-projection ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (psi-emacs--handle-rpc-event
+     '((:event . "ui/widgets-updated")
+       (:data . ((:widgets . [((:placement . "right") (:extension-id . "ext-b") (:widget-id . "w-2") (:text . "B"))
+                              ((:placement . "left") (:extension-id . "ext-b") (:widget-id . "w-1") (:text . "A"))
+                              ((:placement . "left") (:extension-id . "ext-a") (:widget-id . "w-3") (:text . "C"))])))))
+    (let ((buf (buffer-string)))
+      (should (string-match-p "Extension Widgets:" buf))
+      (should (< (string-match-p "\\[left/ext-a/w-3\\]" buf)
+                 (string-match-p "\\[left/ext-b/w-1\\]" buf)))
+      (should (< (string-match-p "\\[left/ext-b/w-1\\]" buf)
+                 (string-match-p "\\[right/ext-b/w-2\\]" buf))))
+    (psi-emacs--handle-rpc-event
+     '((:event . "ui/widgets-updated")
+       (:data . ((:widgets . [((:placement . "left") (:extension-id . "ext-c") (:widget-id . "w-1") (:text . "Only"))])))))
+    (let ((buf (buffer-string)))
+      (should (string-match-p "\\[left/ext-c/w-1\\] Only" buf))
+      (should-not (string-match-p "\\[left/ext-a/w-3\\] C" buf))
+      (should-not (string-match-p "\\[right/ext-b/w-2\\] B" buf)))))
+
+(ert-deftest psi-extension-ui-status-updated-replaces-and-sorts-by-extension-id ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (psi-emacs--handle-rpc-event
+     '((:event . "ui/status-updated")
+       (:data . ((:statuses . [((:extension-id . "ext-z") (:text . "Zeta"))
+                               ((:extension-id . "ext-a") (:text . "Alpha"))])))))
+    (let ((buf (buffer-string)))
+      (should (string-match-p "Extension Statuses:" buf))
+      (should (< (string-match-p "\\[ext-a\\] Alpha" buf)
+                 (string-match-p "\\[ext-z\\] Zeta" buf))))
+    (psi-emacs--handle-rpc-event
+     '((:event . "ui/status-updated")
+       (:data . ((:statuses . [((:extension-id . "ext-b") (:text . "Only status"))])))))
+    (let ((buf (buffer-string)))
+      (should (string-match-p "\\[ext-b\\] Only status" buf))
+      (should-not (string-match-p "\\[ext-a\\] Alpha" buf)))))
+
+(ert-deftest psi-extension-ui-footer-updated-updates-projection-and-preserves-transcript ()
+  (with-temp-buffer
+    (insert "Assistant: hello\n")
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (setf (psi-emacs-state-draft-anchor psi-emacs--state) (copy-marker (point-max) nil))
+    (let ((before-anchor (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))))
+      (psi-emacs--handle-rpc-event
+       '((:event . "footer/updated") (:data . ((:text . "mode: parity")))))
+      (should (string-match-p "Assistant: hello" (buffer-string)))
+      (should (string-match-p "Footer: mode: parity" (buffer-string)))
+      (should (= (point-max) (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))))
+      (should (>= (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))
+                  before-anchor)))))
+
 (provide 'psi-test)
 
 ;;; psi-test.el ends here

--- a/components/emacs-ui/test/psi-test.el
+++ b/components/emacs-ui/test/psi-test.el
@@ -377,7 +377,8 @@
     (psi-emacs-mode)
     (setq-local psi-emacs--state (psi-emacs--initialize-state (psi-test--spawn-long-lived-process)))
     (unwind-protect
-        (let ((rpc-calls nil))
+        (let ((rpc-calls nil)
+              (psi-emacs-enable-resume-parity nil))
           (insert " /resume ")
           (setf (psi-emacs-state-draft-anchor psi-emacs--state) (copy-marker 1 nil))
           (cl-letf (((symbol-value 'psi-emacs--send-request-function)
@@ -502,6 +503,22 @@
           (should-not (string-match-p "Assistant:" (buffer-string))))
       (when (process-live-p (psi-emacs-state-process psi-emacs--state))
         (delete-process (psi-emacs-state-process psi-emacs--state))))))
+
+(ert-deftest psi-resume-session-candidates-sort-newest-first-by-modified ()
+  (let* ((sessions (list '((:psi.session-info/path . "/tmp/sessions/older.ndedn")
+                           (:psi.session-info/name . "Older")
+                           (:psi.session-info/modified . "2025-01-01T01:00:00Z"))
+                         '((:psi.session-info/path . "/tmp/sessions/newer.ndedn")
+                           (:psi.session-info/name . "Newer")
+                           (:psi.session-info/modified . "2025-01-01T02:00:00Z"))
+                         '((:psi.session-info/path . "/tmp/sessions/newest.ndedn")
+                           (:psi.session-info/name . "Newest")
+                           (:psi.session-info/modified . "2025-01-01T03:00:00Z"))))
+         (candidates (psi-emacs--resume-session-candidates sessions)))
+    (should (equal '(("Newest — /tmp/sessions/newest.ndedn" . "/tmp/sessions/newest.ndedn")
+                     ("Newer — /tmp/sessions/newer.ndedn" . "/tmp/sessions/newer.ndedn")
+                     ("Older — /tmp/sessions/older.ndedn" . "/tmp/sessions/older.ndedn"))
+                   candidates))))
 
 (ert-deftest psi-idle-resume-parity-explicit-path-dispatches-switch-session-and-bypasses-prompt ()
   (with-temp-buffer

--- a/components/emacs-ui/test/psi-test.el
+++ b/components/emacs-ui/test/psi-test.el
@@ -1332,6 +1332,25 @@
       (should (>= (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))
                   before-anchor)))))
 
+(ert-deftest psi-extension-ui-footer-updated-uses-canonical-payload-shape ()
+  (with-temp-buffer
+    (insert "Assistant: hello\n")
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (setf (psi-emacs-state-draft-anchor psi-emacs--state) (copy-marker (point-max) nil))
+    (let ((before-anchor (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))))
+      (psi-emacs--handle-rpc-event
+       '((:event . "footer/updated")
+         (:data . ((:path-line . "~/psi-main")
+                   (:stats-line . "latency 12ms")
+                   (:status-line . "connected")))))
+      (should (string-match-p "Assistant: hello" (buffer-string)))
+      (should (string-match-p "Footer: ~/psi-main | latency 12ms | connected" (buffer-string)))
+      (should-not (string-match-p "Footer: mode: parity" (buffer-string)))
+      (should (= (point-max) (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))))
+      (should (>= (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))
+                  before-anchor)))))
+
 (ert-deftest psi-extension-ui-dialog-requested-confirm-sends-resolve-boolean ()
   (with-temp-buffer
     (psi-emacs-mode)

--- a/components/emacs-ui/test/psi-test.el
+++ b/components/emacs-ui/test/psi-test.el
@@ -1419,6 +1419,60 @@
       (should (equal '() calls))
       (should (string-match-p "Ignored malformed ui/dialog-requested event" (buffer-string))))))
 
+(ert-deftest psi-extension-ui-notification-adds-visible-entry-in-receive-order ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (cl-letf (((symbol-function 'run-at-time)
+               (lambda (&rest _args) nil)))
+      (psi-emacs--handle-rpc-event
+       '((:event . "ui/notification")
+         (:data . ((:extension-id . "ext-a") (:text . "First")))))
+      (psi-emacs--handle-rpc-event
+       '((:event . "ui/notification")
+         (:data . ((:extension-id . "ext-b") (:text . "Second"))))))
+    (let ((buf (buffer-string)))
+      (should (string-match-p "Extension Notifications:" buf))
+      (should (< (string-match-p "\\[ext-a\\] First" buf)
+                 (string-match-p "\\[ext-b\\] Second" buf))))))
+
+(ert-deftest psi-extension-ui-notification-enforces-max-visible-three ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (cl-letf (((symbol-function 'run-at-time)
+               (lambda (&rest _args) nil)))
+      (dotimes (i 4)
+        (psi-emacs--handle-rpc-event
+         `((:event . "ui/notification")
+           (:data . ((:extension-id . "ext") (:text . ,(format "N%s" (1+ i)))))))))
+    (let ((buf (buffer-string)))
+      (should-not (string-match-p "\\[ext\\] N1" buf))
+      (should (string-match-p "\\[ext\\] N2" buf))
+      (should (string-match-p "\\[ext\\] N3" buf))
+      (should (string-match-p "\\[ext\\] N4" buf)))))
+
+(ert-deftest psi-extension-ui-notification-auto-dismisses-after-timeout ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((scheduled-seconds nil)
+          (scheduled-callback nil)
+          (scheduled-args nil))
+      (cl-letf (((symbol-function 'run-at-time)
+                 (lambda (seconds _repeat fn &rest args)
+                   (setq scheduled-seconds seconds)
+                   (setq scheduled-callback fn)
+                   (setq scheduled-args args)
+                   nil)))
+        (psi-emacs--handle-rpc-event
+         '((:event . "ui/notification")
+           (:data . ((:extension-id . "ext-t") (:text . "Temp"))))))
+      (should (= psi-emacs-notification-timeout-seconds scheduled-seconds))
+      (should (string-match-p "\\[ext-t\\] Temp" (buffer-string)))
+      (apply scheduled-callback scheduled-args)
+      (should-not (string-match-p "\\[ext-t\\] Temp" (buffer-string))))))
+
 (provide 'psi-test)
 
 ;;; psi-test.el ends here

--- a/components/emacs-ui/test/psi-test.el
+++ b/components/emacs-ui/test/psi-test.el
@@ -1332,6 +1332,93 @@
       (should (>= (marker-position (psi-emacs-state-draft-anchor psi-emacs--state))
                   before-anchor)))))
 
+(ert-deftest psi-extension-ui-dialog-requested-confirm-sends-resolve-boolean ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((calls nil))
+      (cl-letf (((symbol-function 'y-or-n-p)
+                 (lambda (&rest _args) t))
+                ((symbol-value 'psi-emacs--send-request-function)
+                 (lambda (_state op params &optional _callback)
+                   (push (list op params) calls))))
+        (psi-emacs--handle-rpc-event
+         '((:event . "ui/dialog-requested")
+           (:data . ((:dialog-id . "d-1") (:kind . "confirm") (:prompt . "Proceed?"))))))
+      (setq calls (nreverse calls))
+      (should (equal '(("resolve_dialog" ((:dialog-id . "d-1") (:result . t))))
+                     calls)))))
+
+(ert-deftest psi-extension-ui-dialog-requested-select-sends-selected-option-value ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((calls nil))
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (&rest _args) "Beta"))
+                ((symbol-value 'psi-emacs--send-request-function)
+                 (lambda (_state op params &optional _callback)
+                   (push (list op params) calls))))
+        (psi-emacs--handle-rpc-event
+         '((:event . "ui/dialog-requested")
+           (:data . ((:dialog-id . "d-2")
+                     (:kind . "select")
+                     (:prompt . "Pick")
+                     (:options . [((:label . "Alpha") (:value . "a"))
+                                  ((:label . "Beta") (:value . "b"))]))))))
+      (setq calls (nreverse calls))
+      (should (equal '(("resolve_dialog" ((:dialog-id . "d-2") (:result . "b"))))
+                     calls)))))
+
+(ert-deftest psi-extension-ui-dialog-requested-input-sends-resolve-string ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((calls nil))
+      (cl-letf (((symbol-function 'read-string)
+                 (lambda (&rest _args) "typed value"))
+                ((symbol-value 'psi-emacs--send-request-function)
+                 (lambda (_state op params &optional _callback)
+                   (push (list op params) calls))))
+        (psi-emacs--handle-rpc-event
+         '((:event . "ui/dialog-requested")
+           (:data . ((:dialog-id . "d-3") (:kind . "input") (:prompt . "Enter"))))))
+      (setq calls (nreverse calls))
+      (should (equal '(("resolve_dialog" ((:dialog-id . "d-3") (:result . "typed value"))))
+                     calls)))))
+
+(ert-deftest psi-extension-ui-dialog-requested-cancel-on-quit-sends-cancel-dialog ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((calls nil))
+      (cl-letf (((symbol-function 'y-or-n-p)
+                 (lambda (&rest _args)
+                   (signal 'quit nil)))
+                ((symbol-value 'psi-emacs--send-request-function)
+                 (lambda (_state op params &optional _callback)
+                   (push (list op params) calls))))
+        (psi-emacs--handle-rpc-event
+         '((:event . "ui/dialog-requested")
+           (:data . ((:dialog-id . "d-4") (:kind . "confirm") (:prompt . "Proceed?"))))))
+      (setq calls (nreverse calls))
+      (should (equal '(("cancel_dialog" ((:dialog-id . "d-4"))))
+                     calls)))))
+
+(ert-deftest psi-extension-ui-dialog-requested-malformed-payload-no-rpc-response ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((calls nil))
+      (cl-letf (((symbol-value 'psi-emacs--send-request-function)
+                 (lambda (_state op params &optional _callback)
+                   (push (list op params) calls))))
+        (psi-emacs--handle-rpc-event
+         '((:event . "ui/dialog-requested")
+           (:data . ((:kind . "input") (:prompt . "missing id"))))))
+      (should (equal '() calls))
+      (should (string-match-p "Ignored malformed ui/dialog-requested event" (buffer-string))))))
+
 (provide 'psi-test)
 
 ;;; psi-test.el ends here

--- a/components/emacs-ui/test/psi-test.el
+++ b/components/emacs-ui/test/psi-test.el
@@ -1247,6 +1247,34 @@
     ;; Mode must still be expanded
     (should (eq 'expanded (psi-emacs-state-tool-output-view-mode psi-emacs--state)))))
 
+(ert-deftest psi-start-rpc-client-uses-mvp-topics-when-extension-ui-parity-disabled ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((captured-topics :unset)
+          (psi-emacs-enable-extension-ui-parity nil))
+      (cl-letf (((symbol-function 'psi-rpc-start!)
+                 (lambda (client _spawn-fn _command &optional topics)
+                   (setq captured-topics topics)
+                   client)))
+        (psi-emacs--start-rpc-client (current-buffer)))
+      (should (equal psi-rpc-mvp-topics captured-topics))
+      (dolist (topic psi-rpc-parity-extension-ui-topics)
+        (should-not (member topic captured-topics))))))
+
+(ert-deftest psi-start-rpc-client-uses-parity-topics-when-extension-ui-parity-enabled ()
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (let ((captured-topics :unset)
+          (psi-emacs-enable-extension-ui-parity t))
+      (cl-letf (((symbol-function 'psi-rpc-start!)
+                 (lambda (client _spawn-fn _command &optional topics)
+                   (setq captured-topics topics)
+                   client)))
+        (psi-emacs--start-rpc-client (current-buffer)))
+      (should (equal psi-rpc-parity-topics captured-topics)))))
+
 (provide 'psi-test)
 
 ;;; psi-test.el ends here

--- a/components/recursion/src/psi/recursion/core.clj
+++ b/components/recursion/src/psi/recursion/core.clj
@@ -1153,6 +1153,94 @@
   [cycle-id]
   (finalize-cycle-in! (global-context) cycle-id))
 
+;;; --- Continue / resume an approved cycle ---
+
+(defn continue-cycle-in!
+  "Continue a non-terminal cycle from its current status through completion.
+
+   Useful when a cycle is already in :executing/:verifying/:learning (e.g. after
+   manual approval) and needs to run the remaining phases with default hooks.
+
+   opts keys:
+   - :memory-ctx    memory context (optional; defaults to memory/global-context)
+   - :hook-executor execution hook fn
+   - :check-runner  verification check fn"
+  [ctx cycle-id {:keys [memory-ctx hook-executor check-runner]}]
+  (let [state (get-state-in ctx)
+        cycle (find-cycle (:cycles state) cycle-id)]
+    (cond
+      (nil? cycle)
+      {:ok? false :error :cycle-not-found}
+
+      (= :awaiting-approval (:status cycle))
+      {:ok? false :error :awaiting-approval}
+
+      (contains? #{:completed :failed :aborted :blocked} (:status cycle))
+      {:ok? true :phase :terminal :status (:status cycle)}
+
+      :else
+      (let [execute-result (when (= :executing (:status cycle))
+                             (if hook-executor
+                               (execute-in! ctx cycle-id hook-executor)
+                               (execute-in! ctx cycle-id)))
+            cycle-after-exec (find-cycle (:cycles (get-state-in ctx)) cycle-id)
+            verify-result (when (= :verifying (:status cycle-after-exec))
+                            (if check-runner
+                              (verify-in! ctx cycle-id check-runner)
+                              (verify-in! ctx cycle-id)))
+            cycle-after-verify (find-cycle (:cycles (get-state-in ctx)) cycle-id)
+            learn-result (when (= :learning (:status cycle-after-verify))
+                           (learn-in! ctx cycle-id (resolve-memory-ctx memory-ctx)))
+            future-state-result (when (:ok? learn-result)
+                                  (update-future-state-from-outcome-in! ctx cycle-id))
+            finalize-result (when (:ok? future-state-result)
+                              (finalize-cycle-in! ctx cycle-id))]
+        (cond
+          (and execute-result (not (:ok? execute-result)))
+          {:ok? false :phase :execute :execute-result execute-result}
+
+          (and verify-result (not (:ok? verify-result)))
+          {:ok? false :phase :verify
+           :execute-result execute-result
+           :verify-result verify-result}
+
+          (and learn-result (not (:ok? learn-result)))
+          {:ok? false :phase :learn
+           :execute-result execute-result
+           :verify-result verify-result
+           :learn-result learn-result}
+
+          (and future-state-result (not (:ok? future-state-result)))
+          {:ok? false :phase :future-state
+           :execute-result execute-result
+           :verify-result verify-result
+           :learn-result learn-result
+           :future-state-result future-state-result}
+
+          (and finalize-result (not (:ok? finalize-result)))
+          {:ok? false :phase :finalize
+           :execute-result execute-result
+           :verify-result verify-result
+           :learn-result learn-result
+           :future-state-result future-state-result
+           :finalize-result finalize-result}
+
+          :else
+          {:ok? true
+           :phase :completed
+           :execute-result execute-result
+           :verify-result verify-result
+           :learn-result learn-result
+           :future-state-result future-state-result
+           :finalize-result finalize-result})))))
+
+(defn continue-cycle!
+  "Global wrapper for `continue-cycle-in!`."
+  ([cycle-id]
+   (continue-cycle! cycle-id {}))
+  ([cycle-id opts]
+   (continue-cycle-in! (global-context) cycle-id opts)))
+
 ;;; --- EQL resolver registration ---
 
 (defn register-resolvers-in!

--- a/components/tui/src/psi/tui/app.clj
+++ b/components/tui/src/psi/tui/app.clj
@@ -806,31 +806,33 @@
    - {:type :agent-event ...}       ; progress events
    - {:type :external-message ...}  ; async extension transcript message
    "
-  [^LinkedBlockingQueue queue]
-  (charm/cmd
-   (fn []
-     (if-let [event (.poll queue 120 TimeUnit/MILLISECONDS)]
-       (cond
-         (= :done (:kind event))
-         {:type :agent-result :result (:result event)}
+  ([^LinkedBlockingQueue queue]
+   (poll-cmd queue 120))
+  ([^LinkedBlockingQueue queue timeout-ms]
+   (charm/cmd
+    (fn []
+      (if-let [event (.poll queue timeout-ms TimeUnit/MILLISECONDS)]
+        (cond
+          (= :done (:kind event))
+          {:type :agent-result :result (:result event)}
 
-         (= :error (:kind event))
-         {:type :agent-error :error (:message event)}
+          (= :error (:kind event))
+          {:type :agent-error :error (:message event)}
 
-         (= :aborted (:kind event))
-         {:type :agent-aborted
-          :message (:message event)
-          :queued-text (:queued-text event)}
+          (= :aborted (:kind event))
+          {:type :agent-aborted
+           :message (:message event)
+           :queued-text (:queued-text event)}
 
-         (= :agent-event (:type event))
-         event
+          (= :agent-event (:type event))
+          event
 
-         (= :external-message (:type event))
-         event
+          (= :external-message (:type event))
+          event
 
-         :else
-         {:type :agent-poll})
-       {:type :agent-poll}))))
+          :else
+          {:type :agent-poll})
+        {:type :agent-poll})))))
 
 ;; ── Init ────────────────────────────────────────────────────
 
@@ -1215,11 +1217,13 @@
      (poll-cmd (:queue state))]))
 
 (defn- handle-agent-poll
-  "Agent still running — advance spinner, keep polling."
+  "Agent still running — advance spinner, keep polling.
+
+   Uses a slightly slower poll cadence to reduce idle CPU while streaming."
   [state]
   (let [n (count spinner-frames)]
     [(update state :spinner-frame #(mod (inc %) n))
-     (poll-cmd (:queue state))]))
+     (poll-cmd (:queue state) 300)]))
 
 (defn- handle-ctrl-c
   [state]

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -1004,6 +1004,76 @@ surface EmacsSessionApi {
 }
 
 ------------------------------------------------------------
+-- Extension UI Specification Integration
+------------------------------------------------------------
+
+-- Derived from ui-extension-points.allium for Emacs integration.
+-- Provides a consistent interface across TUI and Emacs UI.
+
+surface EmacsExtensionUI {
+    -- UI methods available to extensions when Emacs frontend is active.
+    for ext: ExtensionModule
+
+    context session: AgentSession
+
+    exposes:
+        session.uiState.dialogQueue.is_empty
+        session.uiState.visible_notifications
+
+    provides:
+        -- Dialogs (blocking — extension thread waits for user response)
+        confirm(title, message)                     → Boolean
+        select(title, options: List<DialogOption>)   → String?
+        input(title, placeholder?)                   → String?
+
+        -- Widgets (persistent until cleared)
+        set_widget(widgetId, placement, content: List<String>)
+        clear_widget(widgetId)
+
+        -- Status (single-line footer)
+        set_status(text)
+        clear_status()
+
+        -- Notifications (fire-and-forget)
+        notify(message, level)
+
+        -- Render registration
+        register_tool_renderer(toolName, renderCallFn, renderResultFn)
+        register_message_renderer(customType, renderFn)
+
+    guidance:
+        -- Dialog methods block the calling extension thread.
+        -- In Emacs, dialogs integrate with the process-buffer.
+        -- One dialog active at a time; others queue FIFO.
+        -- Widgets and status are ANSI-styled strings.
+        -- Extension to check (:ui ctx) before calling UI methods.
+        -- Derived from ui-extension-points.allium for TUI consistency.
+}
+
+surface EmacsExtensionUIQuery {
+    -- EQL query surface for extension UI state (read-only introspection).
+    for caller: ExtensionModule
+
+    context session: AgentSession
+
+    exposes:
+        :psi.ui/dialog-queue-empty?
+        :psi.ui/active-dialog
+        :psi.ui/pending-dialog-count
+        :psi.ui/widgets
+        :psi.ui/statuses
+        :psi.ui/visible-notifications
+        :psi.ui/tool-renderers
+        :psi.ui/message-renderers
+
+    guidance:
+        -- All attributes are read-only.
+        -- Query via (query-in ctx [:psi.ui/widgets :psi.ui/statuses])
+        -- or from nREPL for live introspection.
+}
+
+related: ui/ExtensionUI(frontend.session)
+------------------------------------------------------------
 -- Open Questions (Parity Phase)
 ------------------------------------------------------------
 

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -16,6 +16,7 @@
 --
 -- Delegates to:
 --   EDN RPC transport protocol (rpc-edn.allium)
+--   Shared extension UI contract (ui-extension-points.allium)
 --   Shared tool display lifecycle (tool-output-display.allium)
 --   Shared tool renderer contract (tool-output-rendering.allium)
 --   Shared prompt autocomplete semantics (prompt-input-autocomplete.allium)
@@ -836,6 +837,16 @@ rule ParityPhaseEnablesExtensionUiAndFooter {
     ensures: EventStreamIncludes(frontend.rpc, "footer/updated")
 }
 
+rule ParityExtensionUiUsesSharedContract {
+    when: FrontendPhaseChanged(frontend, phase)
+
+    requires: phase = parity
+    requires: frontend.extensionUiEnabled
+
+    ensures: ui/ExtensionUI(frontend.session) governs extension UI methods
+    ensures: ui/ExtensionUIQuery(frontend.session) governs extension UI state introspection
+}
+
 rule ParityPhaseEnablesSessionAndModelControls {
     when: FrontendPhaseChanged(frontend, phase)
 
@@ -1003,76 +1014,6 @@ surface EmacsSessionApi {
         -- are defined in rpc-edn.allium.
 }
 
-------------------------------------------------------------
--- Extension UI Specification Integration
-------------------------------------------------------------
-
--- Derived from ui-extension-points.allium for Emacs integration.
--- Provides a consistent interface across TUI and Emacs UI.
-
-surface EmacsExtensionUI {
-    -- UI methods available to extensions when Emacs frontend is active.
-    for ext: ExtensionModule
-
-    context session: AgentSession
-
-    exposes:
-        session.uiState.dialogQueue.is_empty
-        session.uiState.visible_notifications
-
-    provides:
-        -- Dialogs (blocking — extension thread waits for user response)
-        confirm(title, message)                     → Boolean
-        select(title, options: List<DialogOption>)   → String?
-        input(title, placeholder?)                   → String?
-
-        -- Widgets (persistent until cleared)
-        set_widget(widgetId, placement, content: List<String>)
-        clear_widget(widgetId)
-
-        -- Status (single-line footer)
-        set_status(text)
-        clear_status()
-
-        -- Notifications (fire-and-forget)
-        notify(message, level)
-
-        -- Render registration
-        register_tool_renderer(toolName, renderCallFn, renderResultFn)
-        register_message_renderer(customType, renderFn)
-
-    guidance:
-        -- Dialog methods block the calling extension thread.
-        -- In Emacs, dialogs integrate with the process-buffer.
-        -- One dialog active at a time; others queue FIFO.
-        -- Widgets and status are ANSI-styled strings.
-        -- Extension to check (:ui ctx) before calling UI methods.
-        -- Derived from ui-extension-points.allium for TUI consistency.
-}
-
-surface EmacsExtensionUIQuery {
-    -- EQL query surface for extension UI state (read-only introspection).
-    for caller: ExtensionModule
-
-    context session: AgentSession
-
-    exposes:
-        :psi.ui/dialog-queue-empty?
-        :psi.ui/active-dialog
-        :psi.ui/pending-dialog-count
-        :psi.ui/widgets
-        :psi.ui/statuses
-        :psi.ui/visible-notifications
-        :psi.ui/tool-renderers
-        :psi.ui/message-renderers
-
-    guidance:
-        -- All attributes are read-only.
-        -- Query via (query-in ctx [:psi.ui/widgets :psi.ui/statuses])
-        -- or from nREPL for live introspection.
-}
-
-related: ui/ExtensionUI(frontend.session)
 ------------------------------------------------------------
 -- Open Questions (Parity Phase)
 ------------------------------------------------------------

--- a/spec/ui-extension-points.allium
+++ b/spec/ui-extension-points.allium
@@ -1,18 +1,19 @@
 -- ui-extension-points.allium
 --
--- Scope: UI extension points — the bridge between the extension system
---        and the TUI layer, enabling extensions to show dialogs, contribute
---        widgets, display notifications, and register custom renderers.
+-- Scope: UI extension points — shared contract between the extension system
+--        and interactive frontends (TUI, Emacs), enabling extensions to show
+--        dialogs, contribute widgets, display notifications, and register
+--        custom renderers.
 --
 -- Design decisions:
---   1. Extension UI state lives in the charm app state atom (centralized Elm model)
---   2. Dialogs use a promise bridge: extension thread blocks, TUI resolves
+--   1. Extension UI state is owned by AgentSession and projected into each frontend
+--   2. Dialogs use a promise bridge: extension thread blocks, active frontend resolves
 --   3. Dialogs are queued FIFO, one active at a time
 --   4. Widgets placed above-editor or below-editor, keyed by extension id
 --   5. Status is a single-line widget variant in the footer
 --   6. Custom rendering via registered render fns keyed by tool-name or custom-type
---   7. Render fns return ANSI strings (matching charm.clj view model)
---   8. UI context (:ui key) present only when TUI is active
+--   7. Render fns return ANSI strings (shared renderer contract for TUI + Emacs)
+--   8. UI context (:ui key) present only when an interactive frontend is active
 --   9. All extension UI state is EQL-queryable (read-only)
 --  10. Screen takeover (custom components) deferred
 --
@@ -26,7 +27,7 @@
 --   EQL resolver surface for extension UI state
 --
 -- Excludes:
---   TUI rendering internals, component protocols, terminal I/O (see tui.allium)
+--   Frontend rendering internals (TUI/charm layout, Emacs process-buffer mechanics)
 --   Extension lifecycle, event dispatch, tool wrapping (see extension-system.allium)
 --   AgentSession orchestration (see coding-agent.allium)
 --   Screen takeover / custom component injection (deferred)
@@ -79,7 +80,7 @@ entity Dialog {
     extensionPath: String
     kind: ConfirmDialog | SelectDialog | InputDialog
     -- Promise bridge: the requesting extension thread blocks on this.
-    -- The TUI update loop resolves it when the user responds.
+    -- The active frontend event loop resolves it when the user responds.
     resolved: Boolean
 }
 
@@ -161,11 +162,11 @@ entity MessageRenderer {
     -- render-fn: (fn [message opts] → String)
 }
 
--- ── UI State (aggregate in charm app state) ────────────
+-- ── UI State (shared extension-ui aggregate) ───────────
 
 entity ExtensionUIState {
     -- Aggregate of all extension-contributed UI elements.
-    -- Lives inside the charm app state atom.
+    -- Owned by AgentSession and projected into each frontend model.
     dialogQueue: DialogQueue
     widgets: List<Widget>
     statuses: List<StatusEntry>
@@ -197,7 +198,7 @@ config {
 
 rule DialogRequested {
     -- Extension requests a dialog. It is queued and the extension
-    -- thread blocks on a promise until the TUI resolves it.
+    -- thread blocks on a promise until the active frontend resolves it.
     when: DialogRequested(session, dialog)
 
     requires: session.uiState.dialogQueue.pending.count < config.dialog_queue_max
@@ -380,8 +381,8 @@ rule MessageRendererRegistered {
 -- ── UI availability ────────────────────────────────────
 
 rule UIContextProvided {
-    -- When TUI is active, extension event handlers and tool execute fns
-    -- receive a :ui key in their context map.
+    -- When an interactive frontend is active (currently tracked by session.tui_active),
+    -- extension event handlers and tool execute fns receive a :ui key in context.
     -- When headless (REPL mode), :ui is nil.
     when: ExtensionHandlerInvoked(session, handler, event)
 
@@ -393,7 +394,7 @@ rule UIContextProvided {
 }
 
 rule HeadlessDialogFallback {
-    -- In headless mode, dialog methods return defaults immediately.
+    -- With no interactive frontend, dialog methods return defaults immediately.
     -- confirm → false, select → nil, input → nil.
     when: DialogRequested(session, dialog)
 
@@ -445,7 +446,7 @@ actor ExtensionModule {
 ------------------------------------------------------------
 
 surface ExtensionUI {
-    -- UI methods available to extensions when TUI is active.
+    -- UI methods available to extensions when an interactive frontend is active.
     -- Passed as the :ui key in extension handler and tool contexts.
     for ext: ExtensionModule
 
@@ -478,10 +479,10 @@ surface ExtensionUI {
 
     guidance:
         -- Dialog methods block the calling extension thread.
-        -- The TUI update loop shows the dialog and resolves the promise.
+        -- The active frontend update loop shows the dialog and resolves the promise.
         -- Only one dialog is active at a time; others queue FIFO.
         --
-        -- In headless mode (no TUI), all dialog methods return defaults:
+        -- In headless mode (no interactive frontend), all dialog methods return defaults:
         --   confirm → false, select → nil, input → nil.
         -- Fire-and-forget methods (notify, set_status, set_widget) are no-ops.
         --


### PR DESCRIPTION
## Summary
Implements shared Extension UI parity in the Emacs frontend behind an explicit gate, preserving MVP defaults when parity is disabled.

## Story
- Story #136: Implement shared Extension UI parity in Emacs frontend

## What changed
- Added parity-gated Emacs RPC topic profiles (`psi-emacs-enable-extension-ui-parity`, default `nil`) with exact parity topic set.
- Added backend RPC operations `resolve_dialog` and `cancel_dialog` with deterministic validation and error envelopes.
- Implemented deterministic Emacs projection rendering for widgets/status/footer with replace semantics and ordering guarantees.
- Added Emacs dialog request handling bridge for `confirm`/`select`/`input` with exact resolve/cancel behavior.
- Implemented Emacs notification lifecycle projection policy (5s auto-dismiss, max visible 3, deterministic redraw).
- Added parity regression coverage and updated Emacs UI documentation.
- Aligned footer projection parsing with canonical backend payload keys and added regression coverage.

## Commit summary
- b3e321a ⚒ Δ Add Emacs extension UI parity topic gate and subscription tests
- 50a3741 ⚒ Add resolve_dialog/cancel_dialog RPC ops with deterministic errors
- 5ed8c84 ⚒ Δ Implement task #139 deterministic Emacs extension UI projection rendering
- bb27493 ⚒ Add Emacs ui/dialog-requested bridge for resolve_dialog/cancel_dialog
- 5376ea3 ⚒ Implement Emacs notification lifecycle projection parity
- 26c6ab0 ⚒ Δ Add parity docs + explicit topic profile regression test
- 0e5ed63 ⚒ Δ Align Emacs footer projection with backend payload keys
- 77619ea ⚒ Add footer/updated canonical payload regression test

## Validation
- Agent-session RPC tests for resolve/cancel success + failure paths
- Emacs ERT parity and regression coverage (including footer canonical payload shape)