### PR TITLE
Distill TUI footer behavior into shared specs and link Emacs footer parity

### DIFF
--- a/spec/default-footer.allium
+++ b/spec/default-footer.allium
@@ -258,14 +258,14 @@ rule RightStatsAlwaysIncludesProvider {
 
 rule ThinkingLevelNormalization {
     -- Query may surface thinking level as keyword or string.
-    -- Footer display always uses plain lowercase text.
+    -- Runtime uses Clojure name/string conversion without case normalization.
     when: ThinkingLevelNormalized(level)
 
     ensures:
         if level = null:
             NormalizeThinkingLevel(level) = "off"
         else:
-            NormalizeThinkingLevel(level) = Lowercase(KeywordNameOrString(level))
+            NormalizeThinkingLevel(level) = KeywordNameOrString(level)
 }
 
 rule StatsLineLayoutFallback {
@@ -402,9 +402,4 @@ surface DefaultFooterView {
 deferred FooterRenderer.ansi_styles        -- dim/warn/error styling choices
 deferred FooterQueryExecution.error_policy -- query-fn exception handling internals
 
-------------------------------------------------------------
--- Open Questions
-------------------------------------------------------------
-
-open_question "Should provider prefix remain always visible, or hide when only one provider is configured?"
-open_question "Should footer status line wrap to multiple rows instead of truncating at terminal width?"
+-- Distilled as-is from current runtime behavior; no unresolved behavior questions in this contract.

--- a/spec/default-footer.allium
+++ b/spec/default-footer.allium
@@ -1,24 +1,23 @@
 -- default-footer.allium
 --
--- Scope: Built-in interactive footer for the coding agent TUI.
+-- Scope: Built-in footer rendered in the interactive TUI.
 --
 -- Source distillation:
---   ~/src/pi-mono/packages/coding-agent/src/modes/interactive/components/footer.ts
---   ~/src/pi-mono/packages/coding-agent/src/core/footer-data-provider.ts
+--   - components/tui/src/psi/tui/app.clj
+--   - components/agent-session/src/psi/agent_session/resolvers.clj
+--   - components/tui/test/psi/tui/app_test.clj
 --
 -- Includes:
---   - 2-line base footer: location line + usage/model stats line
---   - Optional 3rd line for extension status texts
---   - Cumulative token/cache/cost display across whole session history
---   - Context usage display with unknown-after-compaction handling
---   - Model + thinking indicator on the right side
---   - Provider prefix when multiple providers are available
---   - Width-aware truncation and fallback layout rules
+--   - Query-driven footer snapshot (session + extension-ui attrs)
+--   - 2-line base footer: path line + usage/model stats line
+--   - Optional 3rd status line from extension statuses
+--   - Width-aware truncation/layout fallbacks
+--   - Context warning/error coloring thresholds
 --
 -- Excludes:
---   - Custom footer replacement via extension UI setFooter
---   - ANSI rendering internals and TUI diffing
---   - Git filesystem watch implementation details
+--   - Theme/style internals beyond severity levels
+--   - RPC event publication (see rpc-edn.allium)
+--   - Emacs projection formatting (see emacs-footer.allium)
 
 use "./session-management.allium" as session
 
@@ -26,12 +25,32 @@ use "./session-management.allium" as session
 -- Value Types
 ------------------------------------------------------------
 
-value FooterTotals {
-    input: Integer
-    output: Integer
-    cacheRead: Integer
-    cacheWrite: Integer
-    cost: Decimal
+value FooterStatus {
+    extensionId: String
+    text: String
+}
+
+value FooterInputs {
+    cwd: String
+    gitBranch: String?
+    sessionName: String?
+
+    usageInput: Integer
+    usageOutput: Integer
+    usageCacheRead: Integer
+    usageCacheWrite: Integer
+    usageCostTotal: Decimal
+
+    contextFraction: Decimal?
+    contextWindow: Integer?
+    autoCompactionEnabled: Boolean
+
+    modelProvider: String?
+    modelId: String?
+    modelReasoning: Boolean
+    thinkingLevel: String?
+
+    statuses: List<FooterStatus>
 }
 
 value FooterContextDisplay {
@@ -46,28 +65,16 @@ value FooterView {
 }
 
 ------------------------------------------------------------
--- Entities
+-- Entity
 ------------------------------------------------------------
-
-entity FooterStatus {
-    -- Status text contributed by an extension, keyed by extension id.
-    footer: DefaultFooter
-    key: String
-    text: String
-}
 
 entity DefaultFooter {
     session: session/AgentSession
 
-    -- Inputs supplied by footer data provider / interactive mode
-    gitBranch: String?                  -- null when not in git repo; detached literal allowed
-    availableProviderCount: Integer
-    autoCompactionEnabled: Boolean
+    -- Fallback cwd used when query attrs are unavailable.
+    cwdFallback: String
 
-    -- Extension statuses shown as an optional third line
-    statuses: FooterStatus for this footer
-
-    -- Last rendered footer content
+    -- Last rendered footer projection.
     view: FooterView?
 }
 
@@ -76,274 +83,284 @@ entity DefaultFooter {
 ------------------------------------------------------------
 
 config {
-    context_warning_threshold_pct: Decimal = 70
-    context_error_threshold_pct: Decimal = 90
     stats_min_padding: Integer = 2
+    context_warning_fraction: Decimal = 0.7
+    context_error_fraction: Decimal = 0.9
 }
 
 ------------------------------------------------------------
 -- Rules
 ------------------------------------------------------------
 
+rule FooterReadsCanonicalProjectionAttributes {
+    when: FooterRenderRequested(footer, _)
+
+    ensures: FooterQueryAttributes() = [
+        "psi.agent-session/cwd",
+        "psi.agent-session/git-branch",
+        "psi.agent-session/session-name",
+        "psi.agent-session/usage-input",
+        "psi.agent-session/usage-output",
+        "psi.agent-session/usage-cache-read",
+        "psi.agent-session/usage-cache-write",
+        "psi.agent-session/usage-cost-total",
+        "psi.agent-session/context-fraction",
+        "psi.agent-session/context-window",
+        "psi.agent-session/auto-compaction-enabled",
+        "psi.agent-session/model-provider",
+        "psi.agent-session/model-id",
+        "psi.agent-session/model-reasoning",
+        "psi.agent-session/thinking-level",
+        "psi.ui/statuses"
+    ]
+}
+
+rule FooterInputsUseSafeFallbacks {
+    -- Query failures are ignored; rendering proceeds with defaults.
+    when: FooterRenderRequested(footer, _)
+
+    ensures: FooterInputsFor(footer).cwd =
+        FirstNonNull(QueryValue("psi.agent-session/cwd"), footer.cwdFallback, "")
+
+    ensures: FooterInputsFor(footer).gitBranch = QueryValue("psi.agent-session/git-branch")
+    ensures: FooterInputsFor(footer).sessionName = QueryValue("psi.agent-session/session-name")
+
+    ensures: FooterInputsFor(footer).usageInput = QueryValueOrDefault("psi.agent-session/usage-input", 0)
+    ensures: FooterInputsFor(footer).usageOutput = QueryValueOrDefault("psi.agent-session/usage-output", 0)
+    ensures: FooterInputsFor(footer).usageCacheRead = QueryValueOrDefault("psi.agent-session/usage-cache-read", 0)
+    ensures: FooterInputsFor(footer).usageCacheWrite = QueryValueOrDefault("psi.agent-session/usage-cache-write", 0)
+    ensures: FooterInputsFor(footer).usageCostTotal = QueryValueOrDefault("psi.agent-session/usage-cost-total", 0.0)
+
+    ensures: FooterInputsFor(footer).contextFraction = QueryValue("psi.agent-session/context-fraction")
+    ensures: FooterInputsFor(footer).contextWindow = QueryValue("psi.agent-session/context-window")
+    ensures: FooterInputsFor(footer).autoCompactionEnabled =
+        Boolean(QueryValue("psi.agent-session/auto-compaction-enabled"))
+
+    ensures: FooterInputsFor(footer).modelProvider = QueryValue("psi.agent-session/model-provider")
+    ensures: FooterInputsFor(footer).modelId = QueryValue("psi.agent-session/model-id")
+    ensures: FooterInputsFor(footer).modelReasoning =
+        Boolean(QueryValue("psi.agent-session/model-reasoning"))
+    ensures: FooterInputsFor(footer).thinkingLevel = QueryValue("psi.agent-session/thinking-level")
+
+    ensures: FooterInputsFor(footer).statuses = QueryValueOrDefault("psi.ui/statuses", [])
+}
+
 rule FooterRendered {
-    -- Recompute all footer lines for the current terminal width.
     when: FooterRenderRequested(footer, width)
 
-    let totals = FooterTotalsForSession(footer.session)
-    let context = FooterContextFor(footer.session, footer.autoCompactionEnabled)
-    let pathLine = FooterPathLine(
-        cwd: CurrentWorkingDirectory(),
-        gitBranch: footer.gitBranch,
-        sessionName: footer.session.sessionName,
-        width: width
-    )
+    let inputs = FooterInputsFor(footer)
+    let context = FooterContextFor(inputs.contextFraction, inputs.contextWindow, inputs.autoCompactionEnabled)
+    let pathLine = FooterPathLine(inputs.cwd, inputs.gitBranch, inputs.sessionName, width)
 
-    let leftStats = LeftStatsLine(footer.session, totals, context)
-    let rightStats = RightStatsLine(
-        session: footer.session,
-        providerCount: footer.availableProviderCount,
-        left: leftStats,
-        width: width,
-        minPadding: config.stats_min_padding
-    )
+    let leftStats = LeftStatsLine(inputs, context)
+    let rightStats = RightStatsLine(inputs)
+    let statsLine = ComposeStatsLine(leftStats, rightStats, width, config.stats_min_padding)
 
-    let statsLine = ComposeStatsLine(
-        left: leftStats,
-        right: rightStats,
-        width: width,
-        minPadding: config.stats_min_padding
-    )
+    let statusLine = FooterStatusLine(inputs.statuses, width)
 
-    let statusLine =
-        if footer.statuses.count > 0:
-            FooterStatusLine(footer.statuses, width)
-        else:
+    ensures: footer.view.pathLine = pathLine
+    ensures: footer.view.statsLine = statsLine
+    ensures: footer.view.statusLine =
+        if statusLine = "":
             null
-
-    ensures: footer.view = {
-        pathLine: pathLine,
-        statsLine: statsLine,
-        statusLine: statusLine
-    }
+        else:
+            statusLine
 }
 
 rule PathLineComposition {
-    -- Path line format:
+    -- Format:
     --   <cwd-with-~-home> [(branch)] [• session-name]
-    -- then middle-truncated to terminal width.
-    when: FooterPathLineComputed(cwd, gitBranch, sessionName, width)
+    -- then middle-truncated to width.
+    when: FooterPathLineRequested(cwd, gitBranch, sessionName, width)
 
     let withHome = ReplaceHomePrefixWithTilde(cwd)
     let withBranch =
-        if gitBranch != null:
+        if gitBranch != null and gitBranch != "":
             withHome + " (" + gitBranch + ")"
         else:
             withHome
-
     let withSession =
-        if sessionName != null:
+        if sessionName != null and sessionName != "":
             withBranch + " • " + sessionName
         else:
             withBranch
 
-    ensures: FooterPathLine(cwd, gitBranch, sessionName, width) = MiddleTruncate(withSession, width)
+    ensures: FooterPathLine(cwd, gitBranch, sessionName, width) =
+        MiddleTruncate(withSession, max(1, width))
 }
 
-rule FooterTotalsAreCumulativeAcrossSessionHistory {
-    -- Totals are taken from assistant usage across all persisted session entries,
-    -- not only currently-expanded messages after compaction.
-    when: FooterTotalsRequested(agentSession)
+rule LeftStatsPartOrder {
+    -- Parts are shown in this order, skipping zero-valued usage counters:
+    --   ↑input ↓output Rcache-read Wcache-write $cost context
+    when: LeftStatsLineRequested(inputs, context)
 
-    let assistantMessages = AssistantMessagesFromAllEntries(agentSession)
-
-    ensures: FooterTotalsForSession(agentSession).input = Sum(assistantMessages.usage.input)
-    ensures: FooterTotalsForSession(agentSession).output = Sum(assistantMessages.usage.output)
-    ensures: FooterTotalsForSession(agentSession).cacheRead = Sum(assistantMessages.usage.cacheRead)
-    ensures: FooterTotalsForSession(agentSession).cacheWrite = Sum(assistantMessages.usage.cacheWrite)
-    ensures: FooterTotalsForSession(agentSession).cost = Sum(assistantMessages.usage.cost.total)
+    ensures: LeftStatsLine(inputs, context) = JoinWithSpaces([
+        OptionalPart(inputs.usageInput > 0, "↑" + FormatTokenCount(inputs.usageInput)),
+        OptionalPart(inputs.usageOutput > 0, "↓" + FormatTokenCount(inputs.usageOutput)),
+        OptionalPart(inputs.usageCacheRead > 0, "R" + FormatTokenCount(inputs.usageCacheRead)),
+        OptionalPart(inputs.usageCacheWrite > 0, "W" + FormatTokenCount(inputs.usageCacheWrite)),
+        OptionalPart(inputs.usageCostTotal > 0, "$" + RoundTo3Decimals(inputs.usageCostTotal)),
+        context.text
+    ])
 }
 
-rule LeftStatsParts {
-    -- Left side includes non-zero usage parts plus context usage (always shown).
-    -- Format examples:
-    --   ↑76k ↓3.6k R1.4M $0.434 17.6%/400k (auto)
-    --   ?/400k (auto)
-    when: LeftStatsRequested(agentSession, totals, context)
+rule ContextDisplayText {
+    when: FooterContextRequested(fraction, contextWindow, autoCompactionEnabled)
 
-    ensures:
-        LeftStatsLine(agentSession, totals, context) = JoinWithSpaces([
-            OptionalPart(totals.input > 0, "↑" + FormatTokenCount(totals.input)),
-            OptionalPart(totals.output > 0, "↓" + FormatTokenCount(totals.output)),
-            OptionalPart(totals.cacheRead > 0, "R" + FormatTokenCount(totals.cacheRead)),
-            OptionalPart(totals.cacheWrite > 0, "W" + FormatTokenCount(totals.cacheWrite)),
-            CostPart(agentSession, totals),
-            context.text
-        ])
-}
-
-rule CostPartIncludesSubscriptionMarker {
-    -- Cost is shown when any cost was incurred OR when provider billing is subscription-based.
-    when: CostPartRequested(agentSession, totals)
-
-    let usingSubscription = ModelUsesOAuthSubscription(agentSession.model)
-
-    ensures:
-        if totals.cost > 0 or usingSubscription:
-            CostPart(agentSession, totals) = "$" + RoundTo3Decimals(totals.cost) + (if usingSubscription: " (sub)" else: "")
-        else:
-            CostPart(agentSession, totals) = null
-}
-
-rule ContextDisplayKnownOrUnknown {
-    -- After compaction and before next assistant response, context tokens are unknown.
-    -- Display falls back to "?/contextWindow".
-    when: FooterContextRequested(agentSession, autoCompactionEnabled)
-
-    let usage = session/GetContextUsage(agentSession)
     let suffix = if autoCompactionEnabled: " (auto)" else: ""
+    let window = FormatTokenCount(if contextWindow != null: contextWindow else: 0)
 
     ensures:
-        if usage = null:
-            FooterContextFor(agentSession, autoCompactionEnabled).text = "?/0" + suffix
-        else if usage.percent = null:
-            FooterContextFor(agentSession, autoCompactionEnabled).text = "?/" + FormatTokenCount(usage.contextWindow) + suffix
+        if fraction = null:
+            FooterContextFor(fraction, contextWindow, autoCompactionEnabled).text = "?/" + window + suffix
         else:
-            FooterContextFor(agentSession, autoCompactionEnabled).text =
-                RoundTo1Decimal(usage.percent) + "%/" + FormatTokenCount(usage.contextWindow) + suffix
+            FooterContextFor(fraction, contextWindow, autoCompactionEnabled).text =
+                RoundTo1Decimal(fraction * 100) + "%/" + window + suffix
 }
 
-rule ContextSeverityThresholds {
-    when: FooterContextRequested(agentSession, autoCompactionEnabled)
-
-    let usage = session/GetContextUsage(agentSession)
+rule ContextDisplaySeverity {
+    when: FooterContextRequested(fraction, contextWindow, autoCompactionEnabled)
 
     ensures:
-        if usage = null or usage.percent = null:
-            FooterContextFor(agentSession, autoCompactionEnabled).severity = normal
-        else if usage.percent > config.context_error_threshold_pct:
-            FooterContextFor(agentSession, autoCompactionEnabled).severity = error
-        else if usage.percent > config.context_warning_threshold_pct:
-            FooterContextFor(agentSession, autoCompactionEnabled).severity = warning
+        if fraction = null:
+            FooterContextFor(fraction, contextWindow, autoCompactionEnabled).severity = normal
+        else if fraction > config.context_error_fraction:
+            FooterContextFor(fraction, contextWindow, autoCompactionEnabled).severity = error
+        else if fraction > config.context_warning_fraction:
+            FooterContextFor(fraction, contextWindow, autoCompactionEnabled).severity = warning
         else:
-            FooterContextFor(agentSession, autoCompactionEnabled).severity = normal
+            FooterContextFor(fraction, contextWindow, autoCompactionEnabled).severity = normal
 }
 
-rule RightSideModelAndThinking {
-    -- Right side base:
-    --   <model-id>
-    -- or for reasoning models:
-    --   <model-id> • thinking off
-    --   <model-id> • <thinking-level>
-    when: RightStatsRequested(agentSession)
-
-    let modelId = if agentSession.model != null: agentSession.model.id else: "no-model"
-
-    ensures:
-        if agentSession.model != null and agentSession.model.reasoning:
-            RightStatsBase(agentSession) =
-                if agentSession.thinkingLevel = off:
-                    modelId + " • thinking off"
-                else:
-                    modelId + " • " + agentSession.thinkingLevel
-        else:
-            RightStatsBase(agentSession) = modelId
-}
-
-rule ProviderPrefixShownWhenAmbiguousAndFits {
-    -- If multiple providers are available, prepend provider name when it fits:
+rule RightStatsAlwaysIncludesProvider {
+    -- Right side always starts with provider in parentheses.
+    -- Examples:
     --   (openai) gpt-5.3-codex • xhigh
-    when: RightStatsLineRequested(agentSession, providerCount, left, width, minPadding)
+    --   (anthropic) claude-3.7-sonnet
+    --   (no-provider) no-model
+    when: RightStatsLineRequested(inputs)
 
-    requires: providerCount > 1
-    requires: agentSession.model != null
+    let modelLabel = if inputs.modelId != null: inputs.modelId else: "no-model"
+    let providerLabel = if inputs.modelProvider != null: inputs.modelProvider else: "no-provider"
 
-    let withProvider = "(" + agentSession.model.provider + ") " + RightStatsBase(agentSession)
+    let normalizedThinking = NormalizeThinkingLevel(inputs.thinkingLevel)
+    let rightBase =
+        if inputs.modelReasoning:
+            if normalizedThinking = "off":
+                modelLabel + " • thinking off"
+            else:
+                modelLabel + " • " + normalizedThinking
+        else:
+            modelLabel
+
+    ensures: RightStatsLine(inputs) = "(" + providerLabel + ") " + rightBase
+}
+
+rule ThinkingLevelNormalization {
+    -- Query may surface thinking level as keyword or string.
+    -- Footer display always uses plain lowercase text.
+    when: ThinkingLevelNormalized(level)
 
     ensures:
-        if FitsWithPadding(left, withProvider, width, minPadding):
-            RightStatsLine(agentSession, providerCount, left, width, minPadding) = withProvider
+        if level = null:
+            NormalizeThinkingLevel(level) = "off"
         else:
-            RightStatsLine(agentSession, providerCount, left, width, minPadding) = RightStatsBase(agentSession)
+            NormalizeThinkingLevel(level) = Lowercase(KeywordNameOrString(level))
 }
 
-rule ProviderPrefixHiddenWhenSingleProvider {
-    when: RightStatsLineRequested(agentSession, providerCount, left, width, minPadding)
-    requires: providerCount <= 1 or agentSession.model = null
-    ensures: RightStatsLine(agentSession, providerCount, left, width, minPadding) = RightStatsBase(agentSession)
-}
-
-rule StatsLineWidthFallback {
+rule StatsLineLayoutFallback {
     -- Layout priority:
-    --   1) left + padding + right (right-aligned)
-    --   2) if too tight, truncate right
-    --   3) if still too tight, show only left
+    --   1) left + right with right-alignment and min padding
+    --   2) if too narrow, truncate right side
+    --   3) if still too narrow, left side only
     when: StatsLineRequested(left, right, width, minPadding)
 
-    ensures: StatsLineFitsWidth(ComposeStatsLine(left, right, width, minPadding), width)
-}
+    let safeLeft =
+        if VisibleWidth(left) > width:
+            TrimRightVisible(left, width)
+        else:
+            left
 
-rule StatusLineOrderingAndSanitization {
-    -- Status line is built from statuses sorted by key, displaying text only.
-    -- Sanitization: CR/LF/TAB -> space, collapse repeated spaces, trim.
-    when: FooterStatusLineRequested(statuses, width)
-
-    let sorted = SortBy(statuses, key)
-    let sanitized = sorted.map(s => SanitizeSingleLineText(s.text))
-    let joined = JoinWithSpaces(sanitized)
-
-    ensures: FooterStatusLine(statuses, width) = TruncateToWidth(joined, width)
-}
-
-rule ExtensionStatusSet {
-    when: FooterStatusSet(footer, key, text)
+    let leftWidth = VisibleWidth(safeLeft)
+    let rightWidth = VisibleWidth(right)
+    let availForRight = width - leftWidth - minPadding
+    let rightTruncated =
+        if availForRight > 3:
+            TrimRightVisible(right, availForRight)
+        else:
+            ""
 
     ensures:
-        let existing = FooterStatus{footer: footer, key: key}
-        if exists existing:
-            existing.text = text
+        if leftWidth + minPadding + rightWidth <= width:
+            ComposeStatsLine(left, right, width, minPadding) =
+                safeLeft + Spaces(width - leftWidth - rightWidth) + right
+        else if availForRight > 3:
+            ComposeStatsLine(left, right, width, minPadding) =
+                safeLeft
+                + Spaces(max(minPadding, width - leftWidth - VisibleWidth(rightTruncated)))
+                + rightTruncated
         else:
-            FooterStatus.created(footer: footer, key: key, text: text)
-    ensures: FooterRenderRequested(footer, CurrentTerminalWidth())
+            ComposeStatsLine(left, right, width, minPadding) = safeLeft
 }
 
-rule ExtensionStatusCleared {
-    when: FooterStatusCleared(footer, key)
+rule StatusLineOrderingSanitizationAndTruncation {
+    -- Statuses are sorted by extension id, sanitized to single-line text,
+    -- blank statuses dropped, then joined with spaces.
+    when: FooterStatusLineRequested(statuses, width)
 
-    let target = FooterStatus{footer: footer, key: key}
-    requires: exists target
+    let sorted = SortBy(statuses, extensionId)
+    let sanitized = sorted.map(s => SanitizeSingleLineText(s.text))
+    let nonBlank = sanitized.filter(t => t != "")
+    let joined = JoinWithSpaces(nonBlank)
 
-    ensures: not exists target
-    ensures: FooterRenderRequested(footer, CurrentTerminalWidth())
+    ensures:
+        if joined = "":
+            FooterStatusLine(statuses, width) = ""
+        else:
+            FooterStatusLine(statuses, width) = TruncateToWidth(joined, width)
 }
 
-rule FooterRenderOnBranchChange {
-    when: FooterGitBranchChanged(footer, branch)
-    ensures: footer.gitBranch = branch
-    ensures: FooterRenderRequested(footer, CurrentTerminalWidth())
-}
+rule StatusTextSanitization {
+    -- Sanitization:
+    --   CR/LF/TAB -> space
+    --   collapse repeated spaces
+    --   trim leading/trailing spaces
+    when: StatusTextSanitized(text)
 
-rule FooterRenderOnProviderCountChange {
-    when: FooterAvailableProviderCountSet(footer, count)
-    ensures: footer.availableProviderCount = count
-    ensures: FooterRenderRequested(footer, CurrentTerminalWidth())
+    ensures: SanitizeSingleLineText(text) =
+        Trim(CollapseSpaces(Replace(text, pattern: "[\\r\\n\\t]", replacement: " ")))
 }
 
 rule FooterTokenFormatting {
-    -- Token formatter used for input/output/cache/contextWindow displays.
+    -- Formatter for usage counters and context window display.
     when: FormatTokenCountCalled(count)
+
+    let safeCount = if count != null: count else: 0
 
     ensures:
         FormatTokenCount(count) =
-            if count < 1000:
-                count.to_string
-            else if count < 10000:
-                RoundTo1Decimal(count / 1000) + "k"
-            else if count < 1000000:
-                RoundToInteger(count / 1000) + "k"
-            else if count < 10000000:
-                RoundTo1Decimal(count / 1000000) + "M"
+            if safeCount < 1000:
+                safeCount.to_string
+            else if safeCount < 10000:
+                RoundTo1Decimal(safeCount / 1000) + "k"
+            else if safeCount < 1000000:
+                RoundToInteger(safeCount / 1000) + "k"
+            else if safeCount < 10000000:
+                RoundTo1Decimal(safeCount / 1000000) + "M"
             else:
-                RoundToInteger(count / 1000000) + "M"
+                RoundToInteger(safeCount / 1000000) + "M"
+}
+
+rule FooterRenderedLinesClearTrailingCharacters {
+    -- Each rendered footer row clears to end-of-line so shorter re-renders
+    -- do not leave stale trailing characters.
+    when: FooterRenderedForTerminal(footer, width)
+
+    ensures: FooterRowClearsToEnd(footer.view.pathLine)
+    ensures: FooterRowClearsToEnd(footer.view.statsLine)
+    ensures:
+        if footer.view.statusLine != null:
+            FooterRowClearsToEnd(footer.view.statusLine)
 }
 
 ------------------------------------------------------------
@@ -355,7 +372,7 @@ actor User {
 }
 
 ------------------------------------------------------------
--- Surfaces
+-- Surface
 ------------------------------------------------------------
 
 surface DefaultFooterView {
@@ -370,26 +387,24 @@ surface DefaultFooterView {
 
     provides:
         FooterRenderRequested(footer, width)
-        FooterStatusSet(footer, key, text)
-        FooterStatusCleared(footer, key)
-        FooterGitBranchChanged(footer, branch)
-        FooterAvailableProviderCountSet(footer, count)
+
+    guidance:
+        -- Built from EQL query attrs listed in FooterReadsCanonicalProjectionAttributes.
+        -- Path line is always present.
+        -- Stats line is always present.
+        -- Status line is optional (only when non-blank statuses exist).
 }
 
 ------------------------------------------------------------
 -- Deferred Specifications
 ------------------------------------------------------------
 
-deferred FooterRenderer.compose           -- ANSI styling and dim/warn/error coloring
-
-deferred FooterDataProvider.git_branch   -- git HEAD/worktree resolution and branch watch
-
-deferred FooterDataProvider.provider_count
-    -- Derived from currently-available model candidates.
+deferred FooterRenderer.ansi_styles        -- dim/warn/error styling choices
+deferred FooterQueryExecution.error_policy -- query-fn exception handling internals
 
 ------------------------------------------------------------
 -- Open Questions
 ------------------------------------------------------------
 
-open_question "Should context warning/error thresholds be user-configurable (settings) instead of fixed at 70/90?"
-open_question "Should the status line support multi-row wrapping instead of single-line truncation?"
+open_question "Should provider prefix remain always visible, or hide when only one provider is configured?"
+open_question "Should footer status line wrap to multiple rows instead of truncating at terminal width?"

--- a/spec/emacs-footer.allium
+++ b/spec/emacs-footer.allium
@@ -173,7 +173,11 @@ surface EmacsFooterProjectionContract {
 }
 
 ------------------------------------------------------------
--- Open Questions
+-- Notes
 ------------------------------------------------------------
 
-open_question "Should Emacs keep the single-line `Footer: ...` projection, or move to a dedicated 2-3 line footer area in parity mode?"
+-- Assumption/trade-off (story D4/D5):
+-- Emacs parity keeps the single-line `Footer: ...` projection contract for
+-- deterministic process-buffer rendering and compatibility with existing
+-- transcript anchoring behavior. A dedicated multi-line footer area is
+-- explicitly deferred to future runtime/frontend work.

--- a/spec/emacs-footer.allium
+++ b/spec/emacs-footer.allium
@@ -1,0 +1,179 @@
+-- emacs-footer.allium
+--
+-- Scope: Emacs parity handling for `footer/updated` events.
+--
+-- Source distillation:
+--   - components/emacs-ui/psi.el
+--   - components/emacs-ui/test/psi-test.el
+--
+-- Includes:
+--   - Canonical `footer/updated` payload mapping (path-line, stats-line, status-line)
+--   - Projection text composition for process-buffer rendering
+--   - Backward-compatible fallback to legacy single-text payloads
+--   - Deterministic projection-block rendering and anchor preservation
+--
+-- Excludes:
+--   - Footer line generation itself (see default-footer.allium)
+--   - RPC transport framing/subscription rules (see rpc-edn.allium)
+--   - Header-line status rendering (see emacs-frontend.allium)
+
+use "./default-footer.allium" as footer
+use "./rpc-edn.allium" as rpc
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value EmacsFooterProjection {
+    pathLine: String?
+    statsLine: String?
+    statusLine: String?
+    text: String?
+}
+
+------------------------------------------------------------
+-- Entity
+------------------------------------------------------------
+
+entity EmacsFooterState {
+    projection: EmacsFooterProjection
+}
+
+------------------------------------------------------------
+-- Config
+------------------------------------------------------------
+
+config {
+    projection_separator: String = " | "
+    projection_prefix: String = "Footer: "
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+rule CanonicalFooterPayloadMapsToDefaultFooterView {
+    -- Link contract: canonical RPC payload is the same 3-line shape
+    -- exposed by footer/DefaultFooterView.
+    when: FooterUpdatedReceived(state, payload: rpc/FooterUpdatedPayload)
+
+    let view = footer/FooterView{
+        pathLine: payload.pathLine,
+        statsLine: payload.statsLine,
+        statusLine: payload.statusLine
+    }
+
+    ensures: state.projection.pathLine = view.pathLine
+    ensures: state.projection.statsLine = view.statsLine
+    ensures: state.projection.statusLine = view.statusLine
+}
+
+rule CanonicalFooterProjectionTextFunction {
+    -- Pure projection helper used by parity frontends.
+    when: CanonicalFooterProjectionTextRequested(payload: rpc/FooterUpdatedPayload)
+
+    let lines = NonEmptyStrings([payload.pathLine, payload.statsLine, payload.statusLine])
+
+    ensures:
+        if lines.count > 0:
+            CanonicalFooterProjectionText(payload) = Join(lines, config.projection_separator)
+        else:
+            CanonicalFooterProjectionText(payload) = null
+}
+
+rule CanonicalFooterProjectionTextAppliedToState {
+    -- Emacs flattens canonical footer lines into one deterministic line:
+    --   <path-line> | <stats-line> | <status-line?>
+    -- with empty lines removed.
+    when: FooterUpdatedReceived(state, payload: rpc/FooterUpdatedPayload)
+
+    ensures: state.projection.text = CanonicalFooterProjectionText(payload)
+}
+
+rule LegacyFooterPayloadFallback {
+    -- Backward compatibility for older payloads that only provide a single
+    -- text-ish field. Used only when canonical lines are absent/blank.
+    when: LegacyFooterUpdatedReceived(state, payload)
+
+    let canonicalLines = NonEmptyStrings([
+        PayloadValue(payload, keys: ["path-line", "pathLine", "path_line"]),
+        PayloadValue(payload, keys: ["stats-line", "statsLine", "stats_line"]),
+        PayloadValue(payload, keys: ["status-line", "statusLine", "status_line"])
+    ])
+
+    let fallback = FirstPresent(payload, keys: ["text", "message", "footer", "content"])
+
+    ensures:
+        if canonicalLines.count > 0:
+            state.projection.text = Join(canonicalLines, config.projection_separator)
+        else:
+            state.projection.text = CoerceStringOrNull(fallback)
+}
+
+rule FooterLineRenderedInProjectionBlock {
+    when: ProjectionBlockRenderRequested(state)
+
+    requires: state.projection.text != null
+    requires: Trim(state.projection.text) != ""
+
+    ensures: ProjectionBlockContainsLine(config.projection_prefix + state.projection.text)
+}
+
+rule FooterLineOmittedWhenProjectionBlank {
+    when: ProjectionBlockRenderRequested(state)
+
+    requires: state.projection.text = null or Trim(state.projection.text) = ""
+
+    ensures: ProjectionBlockOmitsPrefix(config.projection_prefix)
+}
+
+rule FooterProjectionUpsertPreservesTranscriptAndAnchor {
+    -- Updating the projection block must not clobber transcript content,
+    -- and the draft anchor stays at end-of-buffer when it was already there.
+    when: FooterProjectionUpserted(state)
+
+    ensures: TranscriptContentPreserved()
+    ensures: DraftAnchorAtEndPreservedWhenFollowing()
+}
+
+------------------------------------------------------------
+-- Surface
+------------------------------------------------------------
+
+surface EmacsFooterProjectionContract {
+    for client: rpc/RpcClient
+
+    context state: EmacsFooterState
+
+    exposes:
+        state.projection.pathLine
+        state.projection.statsLine
+        state.projection.statusLine
+        state.projection.text
+
+    provides:
+        FooterUpdatedReceived(state, payload: rpc/FooterUpdatedPayload)
+        LegacyFooterUpdatedReceived(state, payload)
+        CanonicalFooterProjectionTextRequested(payload: rpc/FooterUpdatedPayload)
+        ProjectionBlockRenderRequested(state)
+
+    related:
+        footer/DefaultFooterView
+        rpc/RpcEventStream
+
+    guidance:
+        -- Canonical parity path:
+        --   footer/updated payload (path-line, stats-line, status-line?)
+        --   -> flatten non-empty lines with " | "
+        --   -> render as one deterministic projection line:
+        --        Footer: <flattened-text>
+        --
+        -- Legacy path remains accepted for compatibility when only
+        -- text/message/footer/content is present.
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open_question "Should Emacs keep the single-line `Footer: ...` projection, or move to a dedicated 2-3 line footer area in parity mode?"

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -863,12 +863,13 @@ rule ParityFooterUsesSharedProjectionContract {
     ensures: emacs_footer/EmacsFooterProjectionContract governs footer/updated projection behavior
 }
 
-rule FooterUpdatedEventsRefreshProjectionText {
+rule FooterUpdatedEventsRefreshProjectionViaEmacsFooterContract {
     when: RpcEventReceived(frontend.rpc, "footer/updated", payload: rpc/FooterUpdatedPayload)
 
     requires: frontend.phase = parity
     requires: frontend.footerParityEnabled
 
+    ensures: emacs_footer/EmacsFooterProjectionContract governs footer/updated payload interpretation
     ensures: frontend.footerProjection = emacs_footer/CanonicalFooterProjectionText(payload)
 }
 

--- a/spec/emacs-frontend.allium
+++ b/spec/emacs-frontend.allium
@@ -22,6 +22,7 @@
 --   Shared prompt autocomplete semantics (prompt-input-autocomplete.allium)
 --   Shared slash-command execution semantics (prompt-slash-commands.allium)
 --   TUI /resume selector behavior reference (tui-resume-selector.allium)
+--   Emacs footer parity projection contract (emacs-footer.allium)
 --
 -- Excludes:
 --   Canonical EDN frame envelopes and version negotiation (see rpc-edn.allium)
@@ -37,6 +38,7 @@ use "./tool-output-rendering.allium" as tool_render
 use "./prompt-input-autocomplete.allium" as prompt_autocomplete
 use "./prompt-slash-commands.allium" as slash_commands
 use "./tui-resume-selector.allium" as tui_resume
+use "./emacs-footer.allium" as emacs_footer
 
 ------------------------------------------------------------
 -- Value Types
@@ -129,6 +131,9 @@ entity EmacsFrontend {
 
     toolOutputView: collapsed | expanded
 
+    -- Flattened footer projection text rendered in parity mode.
+    footerProjection: String?
+
     runState: idle | streaming | reconnecting | error
     lastError: String?
 
@@ -200,6 +205,7 @@ rule MvpProfileIsDefault {
     ensures: frontend.buffer.transcriptEditable = true
     ensures: frontend.buffer.draftAnchor = end_of_buffer
     ensures: frontend.toolOutputView = config.default_tool_output_view
+    ensures: frontend.footerProjection = null
 
     ensures: frontend.runState = idle
     ensures: frontend.lastError = null
@@ -777,6 +783,7 @@ rule ReconnectStartsFreshSessionAndClearsBuffer {
     ensures: frontend.assistant.completedBlocks = []
     ensures: frontend.toolRows = []
     ensures: frontend.toolOutputView = config.default_tool_output_view
+    ensures: frontend.footerProjection = null
     ensures: frontend.lastError = null
     ensures: PersistentErrorLineCleared(frontend.buffer)
     ensures: StreamingWatchdogDisarmed(frontend)
@@ -847,6 +854,24 @@ rule ParityExtensionUiUsesSharedContract {
     ensures: ui/ExtensionUIQuery(frontend.session) governs extension UI state introspection
 }
 
+rule ParityFooterUsesSharedProjectionContract {
+    when: FrontendPhaseChanged(frontend, phase)
+
+    requires: phase = parity
+    requires: frontend.footerParityEnabled
+
+    ensures: emacs_footer/EmacsFooterProjectionContract governs footer/updated projection behavior
+}
+
+rule FooterUpdatedEventsRefreshProjectionText {
+    when: RpcEventReceived(frontend.rpc, "footer/updated", payload: rpc/FooterUpdatedPayload)
+
+    requires: frontend.phase = parity
+    requires: frontend.footerParityEnabled
+
+    ensures: frontend.footerProjection = emacs_footer/CanonicalFooterProjectionText(payload)
+}
+
 rule ParityPhaseEnablesSessionAndModelControls {
     when: FrontendPhaseChanged(frontend, phase)
 
@@ -882,6 +907,7 @@ surface EmacsSessionApi {
         frontend.session.isCompacting
         frontend.headerLine
         frontend.toolOutputView
+        frontend.footerProjection
         frontend.parity
 
     provides:
@@ -951,6 +977,7 @@ surface EmacsSessionApi {
         prompt_autocomplete/PromptAutocompleteContract
         slash_commands/PromptSlashCommandContract
         tui_resume/TuiResumeSelectorContract
+        emacs_footer/EmacsFooterProjectionContract
 
     guidance:
         -- MVP defaults:
@@ -1004,6 +1031,12 @@ surface EmacsSessionApi {
         --     - expanded: full tool body visible
         --   C-c C-t or M-x toggle_tool_output_view flips the global mode for
         --   both existing rows and future rows.
+        --
+        -- Footer parity rendering:
+        --   footer/updated payloads are interpreted via emacs-footer.allium.
+        --   Canonical path/stats/status lines are flattened to a deterministic
+        --   single projection line:
+        --     Footer: <path> | <stats> | <status?>
         --
         -- Error UX:
         --   RPC errors are surfaced in minibuffer and persisted in a single

--- a/spec/rpc-edn.allium
+++ b/spec/rpc-edn.allium
@@ -230,6 +230,19 @@ rule FooterUpdatedPayloadCanonicalAcrossFrontends {
     ensures: CanonicalFooterPayloadConsumer("emacs-footer") = FooterUpdatedPayload
 }
 
+rule FooterPayloadSpecConsistencyGuard {
+    -- Lightweight cross-spec guard so canonical footer payload fields stay aligned.
+    when: FooterSpecConsistencyCheckRequested()
+
+    ensures: FooterPayloadCanonicalFields() = ["pathLine", "statsLine", "statusLine?"]
+    ensures: EventTopicPayload("footer/updated") = FooterUpdatedPayload
+    ensures: EventPayloadRequiredKeysFor("footer/updated") = ["path-line", "stats-line"]
+
+    ensures: ContractFieldSet("default-footer", "FooterView") = FooterPayloadCanonicalFields()
+    ensures: ContractFieldSet("emacs-footer", "EmacsFooterProjection.canonical") = FooterPayloadCanonicalFields()
+    ensures: ContractUsesPayload("emacs-frontend", "footer/updated", FooterUpdatedPayload)
+}
+
 ------------------------------------------------------------
 -- Entity
 ------------------------------------------------------------

--- a/spec/rpc-edn.allium
+++ b/spec/rpc-edn.allium
@@ -199,9 +199,13 @@ value UiNotificationPayload {
 }
 
 value FooterUpdatedPayload {
-    -- Canonical footer projection shape shared across frontends.
-    -- These fields correspond to footer/FooterView in default-footer.allium
-    -- and are flattened by emacs-footer.allium for process-buffer rendering.
+    -- Canonical cross-frontend footer view payload.
+    -- Ownership: rpc-edn defines the transport shape; frontend specs consume it:
+    --   default-footer.allium -> footer/FooterView pathLine|statsLine|statusLine?
+    --   emacs-footer.allium   -> deterministic single-line projection flattening
+    --
+    -- Assumption (story D2): this 3-line shape is canonical for footer/updated.
+    -- Trade-off (story D5): protocol contract clarity now, runtime behavior changes deferred.
     pathLine: String
     statsLine: String
     statusLine: String?
@@ -212,6 +216,18 @@ value ErrorEventPayload {
     errorMessage: String
     id: String?
     op: String?
+}
+
+rule FooterUpdatedPayloadCanonicalAcrossFrontends {
+    -- Canonical relationship for footer parity specs.
+    when: EventSent(endpoint, frame: EdnFrame)
+
+    requires: frame.kind = event
+    requires: frame.event = "footer/updated"
+
+    ensures: EventPayloadType(frame.data) = FooterUpdatedPayload
+    ensures: CanonicalFooterPayloadConsumer("default-footer") = FooterUpdatedPayload
+    ensures: CanonicalFooterPayloadConsumer("emacs-footer") = FooterUpdatedPayload
 }
 
 ------------------------------------------------------------

--- a/spec/rpc-edn.allium
+++ b/spec/rpc-edn.allium
@@ -199,6 +199,9 @@ value UiNotificationPayload {
 }
 
 value FooterUpdatedPayload {
+    -- Canonical footer projection shape shared across frontends.
+    -- These fields correspond to footer/FooterView in default-footer.allium
+    -- and are flattened by emacs-footer.allium for process-buffer rendering.
     pathLine: String
     statsLine: String
     statusLine: String?


### PR DESCRIPTION
## Summary
Distill TUI footer behavior into explicit, shared Allium contracts and link Emacs footer parity to the canonical footer payload shape.

## Story
- #145: Distill TUI footer behavior into shared specs and link Emacs footer parity

## Description
This PR captures the current Clojure runtime footer semantics as explicit contracts, introduces an Emacs footer projection contract, links frontend parity handling to that contract, and clarifies canonical protocol ownership of `FooterUpdatedPayload`.

## Design notes
- Source-of-truth for distillation is current Clojure TUI/runtime behavior.
- Canonical cross-frontend payload shape remains:
  - `FooterUpdatedPayload { pathLine, statsLine, statusLine? }`
- Emacs parity uses canonical lines via a dedicated projection contract, with legacy single-text fallback retained.
- Scope is contract/spec alignment only (no runtime behavior changes).

## Commits in this PR
- 2608268 ⚒ Distill TUI footer spec and link emacs-footer parity contract
- c2159ec ⚒ Δ Distill default footer contract to runtime semantics
- 56ed592 ⚒ Δ Resolve emacs-footer projection ambiguity for parity contract
- 4bbe90a ⚒ Link emacs-frontend footer/updated parity rule to emacs-footer contract
- 5842fdd ⚒ λ Clarify canonical FooterUpdatedPayload ownership in rpc-edn spec
- eda6fa4 ⚒ Add footer payload cross-spec consistency guard rule

## Files/contracts touched
- `spec/default-footer.allium`
- `spec/emacs-footer.allium`
- `spec/emacs-frontend.allium`
- `spec/rpc-edn.allium`
