### PR TITLE
Reduce complexity of prompt lifecycle register!

### DIFF
--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_lifecycle.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_lifecycle.clj
@@ -62,6 +62,181 @@
                  :user-msg user-msg}
     :origin :core}])
 
+(defn- prepared-request-state-summary
+  [turn-id prepared-request]
+  {:turn-id             turn-id
+   :system-prompt-chars (count (or (:prepared-request/system-prompt prepared-request) ""))
+   :message-count       (count (:prepared-request/messages prepared-request))
+   :tool-count          (count (:prepared-request/tools prepared-request))
+   :cache-breakpoints   (get-in prepared-request [:prepared-request/session-snapshot :cache-breakpoints])
+   :input-expansion     (:prepared-request/input-expansion prepared-request)
+   :prepared-at         (now-inst)})
+
+(defn- prepared-request-query-text
+  [prepared-request]
+  (or (get-in prepared-request [:prepared-request/user-message :content 0 :text])
+      (some->> (:prepared-request/queued-steering-messages prepared-request)
+               first
+               :content
+               first
+               :text)))
+
+(defn- prompt-prepare-request-effects
+  [prepared-request progress-queue steering-consumed?]
+  (cond-> [{:effect/type :memory/recover-query
+            :query-text (prepared-request-query-text prepared-request)}
+           {:effect/type      :runtime/prompt-execute-and-record
+            :prepared-request prepared-request
+            :progress-queue   progress-queue}]
+    steering-consumed?
+    (conj {:effect/type :runtime/agent-clear-steering-queue})))
+
+(defn- prompt-prepare-request-handler
+  [ctx {:keys [session-id turn-id user-msg runtime-opts progress-queue]}]
+  (let [prepared-request   ((:build-prepared-request-fn ctx)
+                            ctx session-id {:turn-id turn-id
+                                            :user-message user-msg
+                                            :runtime-opts runtime-opts
+                                            :commands (ext/command-names-in (:extension-registry ctx))})
+        api-key            (get-in prepared-request [:prepared-request/ai-options :api-key])
+        steering-consumed? (seq (:prepared-request/queued-steering-messages prepared-request))]
+    {:root-state-update
+     (session/session-update
+      session-id
+      #(cond-> (assoc % :last-prepared-request-summary
+                      (prepared-request-state-summary turn-id prepared-request))
+         api-key            (assoc :runtime-api-key api-key)
+         steering-consumed? (assoc :steering-messages [])))
+     :effects (prompt-prepare-request-effects prepared-request progress-queue steering-consumed?)
+     :return-effect-result? true
+     :return {:prepared-request prepared-request}}))
+
+(defn- execution-usage-tokens
+  [execution-result]
+  (let [usage (:execution-result/usage execution-result)]
+    (when (map? usage)
+      (let [total (or (:total-tokens usage)
+                      (+ (or (:input-tokens usage) 0)
+                         (or (:output-tokens usage) 0)
+                         (or (:cache-read-tokens usage) 0)
+                         (or (:cache-write-tokens usage) 0)))]
+        (when (and (number? total) (pos? total))
+          total)))))
+
+(defn- prompt-record-next-payload
+  [session-id execution-result progress-queue next-event]
+  (cond-> {:session-id session-id
+           :execution-result execution-result
+           :progress-queue progress-queue}
+    (= next-event :session/prompt-finish)
+    (assoc :turn-id (:execution-result/turn-id execution-result)
+           :terminal-result execution-result)))
+
+(defn- prompt-record-next-event-effect
+  [next-event next-payload]
+  {:effect/type :runtime/dispatch-event
+   :event-type next-event
+   :event-data next-payload
+   :origin :core})
+
+(defn- prompt-record-context-usage-effect
+  [session-id tokens window]
+  {:effect/type :runtime/dispatch-event
+   :event-type :session/update-context-usage
+   :event-data {:session-id session-id
+                :tokens tokens
+                :window window}
+   :origin :core})
+
+(defn- prompt-record-response-handler
+  [ctx {:keys [session-id execution-result progress-queue]}]
+  (let [result       ((:build-record-response-fn ctx) session-id execution-result progress-queue)
+        next-event   (get-in result [:return :next-event])
+        next-payload (prompt-record-next-payload session-id execution-result progress-queue next-event)
+        tokens       (execution-usage-tokens execution-result)
+        sd           (when tokens (session/get-session-data-in ctx session-id))
+        window       (or (some-> execution-result :execution-result/model :context-window)
+                         (when sd (:context-window sd)))]
+    (cond-> result
+      next-event
+      (update :effects (fnil conj []) (prompt-record-next-event-effect next-event next-payload))
+      (and tokens (number? window) (pos? window))
+      (update :effects (fnil conj []) (prompt-record-context-usage-effect session-id tokens window)))))
+
+(defn- prompt-continue-handler
+  [_ctx {:keys [session-id execution-result progress-queue]}]
+  (let [turn-id (str (java.util.UUID/randomUUID))]
+    {:effects [{:effect/type :runtime/prompt-continue-chain
+                :execution-result execution-result
+                :progress-queue progress-queue}
+               {:effect/type :runtime/dispatch-event-with-effect-result
+                :event-type :session/prompt-prepare-request
+                :event-data {:session-id session-id
+                             :turn-id turn-id
+                             :user-msg nil
+                             :progress-queue progress-queue}
+                :origin :core}
+               {:effect/type :runtime/reconcile-and-emit-background-job-terminals}]
+     :return-effect-result? true
+     :return {:continued? true
+              :next-turn-id turn-id
+              :turn-outcome (:execution-result/turn-outcome execution-result)}}))
+
+(defn- prompt-finish-base-result
+  [session-id turn-id terminal-result next-turn-id follow-up-msg follow-up-batch]
+  {:effects [{:effect/type :runtime/dispatch-event
+              :event-type :on-agent-done
+              :event-data {:session-id session-id}
+              :origin :core}
+             {:effect/type :notify/extension-dispatch
+              :event-name "session_turn_finished"
+              :payload {:session-id session-id
+                        :turn-id turn-id}}
+             {:effect/type :runtime/reconcile-and-emit-background-job-terminals}
+             {:effect/type :statechart/send-event
+              :event :session/reset}]
+   :return {:finished? true
+            :turn-id turn-id
+            :next-turn-id next-turn-id
+            :turn-outcome (:execution-result/turn-outcome terminal-result)
+            :follow-up-triggered? (boolean follow-up-msg)
+            :follow-up-count (or (:consume-count follow-up-batch) 0)}})
+
+(defn- consume-follow-up-state-update
+  [session-id follow-up-batch]
+  (session/session-update
+   session-id
+   #(update % :follow-up-messages
+            (fn [xs]
+              (vec (drop (:consume-count follow-up-batch) (or xs [])))))))
+
+(defn- prompt-finish-follow-up-effects
+  [session-id follow-up-batch follow-up-msg]
+  [{:effect/type :runtime/agent-drain-follow-up-queue
+    :messages (:messages follow-up-batch)}
+   {:effect/type :runtime/dispatch-event-with-effect-result
+    :event-type :session/submit-synthetic-user-prompt
+    :event-data {:session-id session-id
+                 :user-msg follow-up-msg}
+    :origin :core}])
+
+(defn- prompt-finish-handler
+  [ctx {:keys [session-id turn-id terminal-result]}]
+  (let [follow-up-batch (queued-follow-up-batch ctx session-id)
+        follow-up-msg   (first (:messages follow-up-batch))
+        next-turn-id    (when follow-up-msg (str (java.util.UUID/randomUUID)))]
+    (cond-> (prompt-finish-base-result session-id turn-id terminal-result next-turn-id follow-up-msg follow-up-batch)
+      follow-up-batch
+      (assoc :root-state-update (consume-follow-up-state-update session-id follow-up-batch))
+      follow-up-msg
+      (update :effects into (prompt-finish-follow-up-effects session-id follow-up-batch follow-up-msg)))))
+
+(defn- prompt-execute-handler
+  [_ctx {:keys [user-msg]}]
+  {:effects [{:effect/type :runtime/agent-start-loop-with-messages
+              :messages [user-msg]}
+             {:effect/type :runtime/reconcile-and-emit-background-job-terminals}]})
+
 (defn register!
   "Register prompt lifecycle handlers. Called once during context creation."
   [_ctx]
@@ -91,142 +266,8 @@
       :return {:submitted? true
                :user-msg user-msg}}))
 
-  (register-core-handler!
-   :session/prompt-prepare-request
-   (fn [ctx {:keys [session-id turn-id user-msg runtime-opts progress-queue]}]
-     (let [prepared-request   ((:build-prepared-request-fn ctx)
-                               ctx session-id {:turn-id turn-id
-                                               :user-message user-msg
-                                               :runtime-opts runtime-opts
-                                               :commands (ext/command-names-in (:extension-registry ctx))})
-           api-key            (get-in prepared-request [:prepared-request/ai-options :api-key])
-           steering-consumed? (seq (:prepared-request/queued-steering-messages prepared-request))]
-       {:root-state-update
-        (session/session-update
-         session-id
-         #(cond-> (assoc % :last-prepared-request-summary
-                         {:turn-id             turn-id
-                          :system-prompt-chars (count (or (:prepared-request/system-prompt prepared-request) ""))
-                          :message-count       (count (:prepared-request/messages prepared-request))
-                          :tool-count          (count (:prepared-request/tools prepared-request))
-                          :cache-breakpoints   (get-in prepared-request [:prepared-request/session-snapshot :cache-breakpoints])
-                          :input-expansion     (:prepared-request/input-expansion prepared-request)
-                          :prepared-at         (now-inst)})
-            api-key            (assoc :runtime-api-key api-key)
-            steering-consumed? (assoc :steering-messages [])))
-        :effects (cond-> [{:effect/type :memory/recover-query
-                           :query-text (or (get-in prepared-request [:prepared-request/user-message :content 0 :text])
-                                           (some->> (:prepared-request/queued-steering-messages prepared-request)
-                                                    first
-                                                    :content
-                                                    first
-                                                    :text))}
-                          {:effect/type      :runtime/prompt-execute-and-record
-                           :prepared-request prepared-request
-                           :progress-queue   progress-queue}]
-                   steering-consumed?
-                   (conj {:effect/type :runtime/agent-clear-steering-queue}))
-        :return-effect-result? true
-        :return {:prepared-request prepared-request}})))
-
-  (register-core-handler!
-   :session/prompt-record-response
-   (fn [ctx {:keys [session-id execution-result progress-queue]}]
-     (let [result       ((:build-record-response-fn ctx) session-id execution-result progress-queue)
-           next-event   (get-in result [:return :next-event])
-           next-payload (cond-> {:session-id session-id
-                                 :execution-result execution-result
-                                 :progress-queue progress-queue}
-                          (= next-event :session/prompt-finish)
-                          (assoc :turn-id (:execution-result/turn-id execution-result)
-                                 :terminal-result execution-result))
-           usage        (:execution-result/usage execution-result)
-           tokens       (when (map? usage)
-                          (let [total (or (:total-tokens usage)
-                                          (+ (or (:input-tokens usage) 0)
-                                             (or (:output-tokens usage) 0)
-                                             (or (:cache-read-tokens usage) 0)
-                                             (or (:cache-write-tokens usage) 0)))]
-                            (when (and (number? total) (pos? total)) total)))
-           sd           (when tokens (session/get-session-data-in ctx session-id))
-           window       (or (some-> execution-result :execution-result/model :context-window)
-                            (when sd (:context-window sd)))]
-       (cond-> result
-         next-event
-         (update :effects (fnil conj []) {:effect/type :runtime/dispatch-event
-                                          :event-type next-event
-                                          :event-data next-payload
-                                          :origin :core})
-         (and tokens (number? window) (pos? window))
-         (update :effects (fnil conj []) {:effect/type :runtime/dispatch-event
-                                          :event-type :session/update-context-usage
-                                          :event-data {:session-id session-id
-                                                       :tokens tokens
-                                                       :window window}
-                                          :origin :core})))))
-
-  (register-core-handler!
-   :session/prompt-continue
-   (fn [_ctx {:keys [session-id execution-result progress-queue]}]
-     (let [turn-id (str (java.util.UUID/randomUUID))]
-       {:effects [{:effect/type :runtime/prompt-continue-chain
-                   :execution-result execution-result
-                   :progress-queue progress-queue}
-                  {:effect/type :runtime/dispatch-event-with-effect-result
-                   :event-type :session/prompt-prepare-request
-                   :event-data {:session-id session-id
-                                :turn-id turn-id
-                                :user-msg nil
-                                :progress-queue progress-queue}
-                   :origin :core}
-                  {:effect/type :runtime/reconcile-and-emit-background-job-terminals}]
-        :return-effect-result? true
-        :return {:continued? true
-                 :next-turn-id turn-id
-                 :turn-outcome (:execution-result/turn-outcome execution-result)}})))
-
-  (register-core-handler!
-   :session/prompt-finish
-   (fn [ctx {:keys [session-id turn-id terminal-result]}]
-     (let [follow-up-batch (queued-follow-up-batch ctx session-id)
-           follow-up-msg   (first (:messages follow-up-batch))
-           next-turn-id    (when follow-up-msg (str (java.util.UUID/randomUUID)))]
-       (cond-> {:effects [{:effect/type :runtime/dispatch-event
-                           :event-type :on-agent-done
-                           :event-data {:session-id session-id}
-                           :origin :core}
-                          {:effect/type :notify/extension-dispatch
-                           :event-name "session_turn_finished"
-                           :payload {:session-id session-id
-                                     :turn-id turn-id}}
-                          {:effect/type :runtime/reconcile-and-emit-background-job-terminals}
-                          {:effect/type :statechart/send-event
-                           :event :session/reset}]
-                :return {:finished? true
-                         :turn-id turn-id
-                         :next-turn-id next-turn-id
-                         :turn-outcome (:execution-result/turn-outcome terminal-result)
-                         :follow-up-triggered? (boolean follow-up-msg)
-                         :follow-up-count (or (:consume-count follow-up-batch) 0)}}
-         follow-up-batch
-         (assoc :root-state-update
-                (session/session-update
-                 session-id
-                 #(update % :follow-up-messages
-                          (fn [xs]
-                            (vec (drop (:consume-count follow-up-batch) (or xs [])))))))
-         follow-up-msg
-         (update :effects into [{:effect/type :runtime/agent-drain-follow-up-queue
-                                 :messages (:messages follow-up-batch)}
-                                {:effect/type :runtime/dispatch-event-with-effect-result
-                                 :event-type :session/submit-synthetic-user-prompt
-                                 :event-data {:session-id session-id
-                                              :user-msg follow-up-msg}
-                                 :origin :core}])))))
-
-  (register-core-handler!
-   :session/prompt-execute
-   (fn [_ctx {:keys [user-msg]}]
-     {:effects [{:effect/type :runtime/agent-start-loop-with-messages
-                 :messages [user-msg]}
-                {:effect/type :runtime/reconcile-and-emit-background-job-terminals}]})))
+  (register-core-handler! :session/prompt-prepare-request prompt-prepare-request-handler)
+  (register-core-handler! :session/prompt-record-response prompt-record-response-handler)
+  (register-core-handler! :session/prompt-continue prompt-continue-handler)
+  (register-core-handler! :session/prompt-finish prompt-finish-handler)
+  (register-core-handler! :session/prompt-execute prompt-execute-handler))

--- a/extensions/lsp/test/extensions/lsp_runtime_path_test.clj
+++ b/extensions/lsp/test/extensions/lsp_runtime_path_test.clj
@@ -55,21 +55,17 @@
     (session/register-mutations-in! qctx mutations/all-mutations true)
     (ext/create-extension-api (:extension-registry ctx) "/ext/lsp.clj" runtime-fns)))
 
-(defn- await-diagnostic
-  [api worktree file-path timeout-ms]
+(defn- await-diagnostic-finding
+  [api workspace-root file-path timeout-ms]
   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
     (loop []
-      (let [result (sut/sync-tool-result! api
-                                          {:worktree-path worktree
-                                           :tool-result {:effects [{:path file-path}]}
-                                           :config {:command lsp-fixture-command
-                                                    :startup-timeout-ms 2000
-                                                    :diagnostics-timeout-ms timeout-ms
-                                                    :sync-timeout-ms 2000}})
-            finding (get (:diagnostics-by-path result) file-path)]
-        (if (or finding
+      (let [diagnostics-by-path (sut/request-diagnostics! api {:workspace-root workspace-root
+                                                               :paths [file-path]
+                                                               :diagnostics-timeout-ms 500})
+            finding (get diagnostics-by-path file-path)]
+        (if (or (seq finding)
                 (>= (System/currentTimeMillis) deadline))
-          [result finding]
+          finding
           (do
             (Thread/sleep 100)
             (recur)))))))
@@ -321,8 +317,14 @@
                                                         :startup-timeout-ms 2000
                                                         :diagnostics-timeout-ms 5000}})
           _ (write-file! file-path "(ns demo) ;; warn\n")
-          [second-result finding] (await-diagnostic api worktree file-path 5000)
+          second-result (sut/sync-tool-result! api
+                                               {:worktree-path worktree
+                                                :tool-result {:effects [{:path file-path}]}
+                                                :config {:command lsp-fixture-command
+                                                         :startup-timeout-ms 2000
+                                                         :diagnostics-timeout-ms 5000}})
           root (:workspace-root second-result)
+          finding (await-diagnostic-finding api root file-path 5000)
           svc (services/service-in ctx (sut/workspace-key root))
           debug @(:debug-atom svc)]
       (try
@@ -365,7 +367,14 @@
           cleared-document-state (sut/document-state file-path)
           cleared-initialized? (sut/workspace-initialized? root)
           _ (write-file! file-path "(ns demo) ;; warn again\n")
-          [second-result finding] (await-diagnostic api worktree file-path 5000)
+          second-result (sut/sync-tool-result! api
+                                               {:worktree-path worktree
+                                                :tool-result {:effects [{:path file-path}]}
+                                                :config {:command lsp-fixture-command
+                                                         :startup-timeout-ms 2000
+                                                         :diagnostics-timeout-ms 5000
+                                                         :sync-timeout-ms 2000}})
+          finding (await-diagnostic-finding api root file-path 5000)
           svc-after (services/service-in ctx (sut/workspace-key root))
           entries (dispatch/dispatch-trace-entries)]
       (try

--- a/extensions/lsp/test/extensions/lsp_runtime_path_test.clj
+++ b/extensions/lsp/test/extensions/lsp_runtime_path_test.clj
@@ -342,7 +342,7 @@
                                                :tool-result {:effects [{:path file-path}]}
                                                :config {:command lsp-fixture-command
                                                         :startup-timeout-ms 2000
-                                                        :diagnostics-timeout-ms 2000}})
+                                                        :diagnostics-timeout-ms 5000}})
           root worktree
           svc-before (services/service-in ctx (sut/workspace-key root))
           restarted-root (sut/restart-workspace! api {:worktree-path worktree

--- a/extensions/lsp/test/extensions/lsp_runtime_path_test.clj
+++ b/extensions/lsp/test/extensions/lsp_runtime_path_test.clj
@@ -55,6 +55,25 @@
     (session/register-mutations-in! qctx mutations/all-mutations true)
     (ext/create-extension-api (:extension-registry ctx) "/ext/lsp.clj" runtime-fns)))
 
+(defn- await-diagnostic
+  [api worktree file-path timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [result (sut/sync-tool-result! api
+                                          {:worktree-path worktree
+                                           :tool-result {:effects [{:path file-path}]}
+                                           :config {:command lsp-fixture-command
+                                                    :startup-timeout-ms 2000
+                                                    :diagnostics-timeout-ms timeout-ms
+                                                    :sync-timeout-ms 2000}})
+            finding (get (:diagnostics-by-path result) file-path)]
+        (if (or finding
+                (>= (System/currentTimeMillis) deadline))
+          [result finding]
+          (do
+            (Thread/sleep 100)
+            (recur)))))))
+
 (deftest service-spec-roundtrips-through-real-runtime-test
   (testing "extension service spec can be ensured through mutation path and gets live runtime fns"
     (let [[ctx session-id] (create-runtime-session (create-temp-worktree))
@@ -302,12 +321,7 @@
                                                         :startup-timeout-ms 2000
                                                         :diagnostics-timeout-ms 5000}})
           _ (write-file! file-path "(ns demo) ;; warn\n")
-          second-result (sut/sync-tool-result! api
-                                               {:worktree-path worktree
-                                                :tool-result {:effects [{:path file-path}]}
-                                                :config {:command lsp-fixture-command
-                                                         :startup-timeout-ms 2000
-                                                         :diagnostics-timeout-ms 5000}})
+          [second-result finding] (await-diagnostic api worktree file-path 5000)
           root (:workspace-root second-result)
           svc (services/service-in ctx (sut/workspace-key root))
           debug @(:debug-atom svc)]
@@ -321,7 +335,7 @@
         (is (some #(get-in % [:payload "params" "contentChanges" 0 "range"]) debug))
         (is (= [{"message" (str "fixture diagnostic for " file-path)
                  "severity" 2}]
-               (get (:diagnostics-by-path second-result) file-path)))
+               finding))
         (finally
           (when-let [close-fn (:close-fn svc)]
             (future (close-fn)))
@@ -351,13 +365,7 @@
           cleared-document-state (sut/document-state file-path)
           cleared-initialized? (sut/workspace-initialized? root)
           _ (write-file! file-path "(ns demo) ;; warn again\n")
-          second-result (sut/sync-tool-result! api
-                                               {:worktree-path worktree
-                                                :tool-result {:effects [{:path file-path}]}
-                                                :config {:command lsp-fixture-command
-                                                         :startup-timeout-ms 2000
-                                                         :diagnostics-timeout-ms 5000
-                                                         :sync-timeout-ms 2000}})
+          [second-result finding] (await-diagnostic api worktree file-path 5000)
           svc-after (services/service-in ctx (sut/workspace-key root))
           entries (dispatch/dispatch-trace-entries)]
       (try
@@ -369,7 +377,7 @@
                (:document-syncs second-result)))
         (is (= [{"message" (str "fixture diagnostic for " file-path)
                  "severity" 2}]
-               (get (:diagnostics-by-path second-result) file-path)))
+               finding))
         (is (nil? cleared-document-state))
         (is (false? cleared-initialized?))
         (is (= :running (:status svc-after)))


### PR DESCRIPTION
## Summary
- reduce cyclomatic complexity in `psi.agent-session.dispatch-handlers.prompt-lifecycle/register!`
- extract focused helper handlers for prepare, record, continue, finish, and execute branches
- preserve prompt lifecycle behavior while making registration a thin mapping layer

## Verification
- `bb fmt:check`
- `clojure -M:test --focus psi.agent-session.prompt-lifecycle-test --focus psi.agent-session.scheduler-handlers-test`
- `bb lint`
- `bb commit-check:dispatch-architecture`
- `bb gordian complexity --source-only --min cc=20 --top 20 --sort cc-risk --edn`

## Complexity
- target before: `register!` CC 27
- target after: `register!` CC 1
- main approach: move branch-specific logic into small private helpers and keep `register!` as registration-only wiring