### PR TITLE
⊘ fix LSP diagnostics retry race in flaky test

### DIFF
--- a/extensions/lsp/src/extensions/lsp.clj
+++ b/extensions/lsp/src/extensions/lsp.clj
@@ -270,21 +270,23 @@
 
 (defn request-diagnostics!
   [api {:keys [workspace-root paths diagnostics-timeout-ms dispatch-id]}]
-  (let [timeout-ms (long (or diagnostics-timeout-ms 1000))
-        deadline   (+ (System/currentTimeMillis) timeout-ms)]
+  (let [timeout-ms         (long (or diagnostics-timeout-ms 1000))
+        deadline           (+ (System/currentTimeMillis) timeout-ms)
+        per-request-max-ms 200]
     (loop [diagnostics-by-path {}]
       (let [pending-paths (remove #(contains? diagnostics-by-path %) paths)
             requested     (reduce (fn [acc path]
                                     (let [remaining-ms (max 1 (- deadline (System/currentTimeMillis)))
-                                          response     (jsonrpc-request! api
-                                                                         (dispatch/assoc-dispatch-id
-                                                                          {:workspace-root workspace-root
-                                                                           :id (str "diagnostic-" (hash path))
-                                                                           :method "textDocument/diagnostic"
-                                                                           :params (document-diagnostics-request path)
-                                                                           :timeout-ms remaining-ms}
-                                                                          dispatch-id))
-                                          items        (diagnostics-response->items response)]
+                                          request-timeout-ms (min per-request-max-ms remaining-ms)
+                                          response           (jsonrpc-request! api
+                                                                               (dispatch/assoc-dispatch-id
+                                                                                {:workspace-root workspace-root
+                                                                                 :id (str "diagnostic-" (hash path))
+                                                                                 :method "textDocument/diagnostic"
+                                                                                 :params (document-diagnostics-request path)
+                                                                                 :timeout-ms request-timeout-ms}
+                                                                                dispatch-id))
+                                          items              (diagnostics-response->items response)]
                                       (cond-> acc
                                         (some? items) (assoc path items))))
                                   diagnostics-by-path

--- a/extensions/lsp/src/extensions/lsp.clj
+++ b/extensions/lsp/src/extensions/lsp.clj
@@ -272,30 +272,31 @@
   [api {:keys [workspace-root paths diagnostics-timeout-ms dispatch-id]}]
   (let [timeout-ms (long (or diagnostics-timeout-ms 1000))
         deadline   (+ (System/currentTimeMillis) timeout-ms)]
-    (loop [remaining          (seq paths)
-           diagnostics-by-path {}]
-      (if-let [path (first remaining)]
-        (let [response (jsonrpc-request! api
-                                         (dispatch/assoc-dispatch-id
-                                          {:workspace-root workspace-root
-                                           :id (str "diagnostic-" (hash path))
-                                           :method "textDocument/diagnostic"
-                                           :params (document-diagnostics-request path)
-                                           :timeout-ms timeout-ms}
-                                          dispatch-id))
-              items    (diagnostics-response->items response)]
-          (recur (next remaining)
-                 (cond-> diagnostics-by-path
-                   (some? items) (assoc path items))))
-        (loop [published diagnostics-by-path]
-          (let [merged (merge published
-                              (diagnostics-from-published-cache api workspace-root paths))]
-            (if (or (diagnostics-known? merged paths)
-                    (>= (System/currentTimeMillis) deadline))
-              merged
-              (do
-                (Thread/sleep 50)
-                (recur merged)))))))))
+    (loop [diagnostics-by-path {}]
+      (let [pending-paths (remove #(contains? diagnostics-by-path %) paths)
+            requested     (reduce (fn [acc path]
+                                    (let [remaining-ms (max 1 (- deadline (System/currentTimeMillis)))
+                                          response     (jsonrpc-request! api
+                                                                         (dispatch/assoc-dispatch-id
+                                                                          {:workspace-root workspace-root
+                                                                           :id (str "diagnostic-" (hash path))
+                                                                           :method "textDocument/diagnostic"
+                                                                           :params (document-diagnostics-request path)
+                                                                           :timeout-ms remaining-ms}
+                                                                          dispatch-id))
+                                          items        (diagnostics-response->items response)]
+                                      (cond-> acc
+                                        (some? items) (assoc path items))))
+                                  diagnostics-by-path
+                                  pending-paths)
+            merged        (merge requested
+                                 (diagnostics-from-published-cache api workspace-root paths))]
+        (if (or (diagnostics-known? merged paths)
+                (>= (System/currentTimeMillis) deadline))
+          merged
+          (do
+            (Thread/sleep 50)
+            (recur merged)))))))
 
 (defn- changed-paths
   [{:keys [tool-result]}]

--- a/extensions/lsp/src/extensions/lsp.clj
+++ b/extensions/lsp/src/extensions/lsp.clj
@@ -273,15 +273,17 @@
   (let [timeout-ms         (long (or diagnostics-timeout-ms 1000))
         deadline           (+ (System/currentTimeMillis) timeout-ms)
         per-request-max-ms 200]
-    (loop [diagnostics-by-path {}]
+    (loop [attempt 0
+           diagnostics-by-path {}]
       (let [pending-paths (remove #(contains? diagnostics-by-path %) paths)
             requested     (reduce (fn [acc path]
-                                    (let [remaining-ms (max 1 (- deadline (System/currentTimeMillis)))
+                                    (let [remaining-ms       (max 1 (- deadline (System/currentTimeMillis)))
                                           request-timeout-ms (min per-request-max-ms remaining-ms)
+                                          request-id         (str "diagnostic-" (hash path) "-" attempt "-" (System/nanoTime))
                                           response           (jsonrpc-request! api
                                                                                (dispatch/assoc-dispatch-id
                                                                                 {:workspace-root workspace-root
-                                                                                 :id (str "diagnostic-" (hash path))
+                                                                                 :id request-id
                                                                                  :method "textDocument/diagnostic"
                                                                                  :params (document-diagnostics-request path)
                                                                                  :timeout-ms request-timeout-ms}
@@ -298,7 +300,7 @@
           merged
           (do
             (Thread/sleep 50)
-            (recur merged)))))))
+            (recur (inc attempt) merged)))))))
 
 (defn- changed-paths
   [{:keys [tool-result]}]

--- a/extensions/lsp/test/extensions/lsp_post_tool_test.clj
+++ b/extensions/lsp/test/extensions/lsp_post_tool_test.clj
@@ -134,6 +134,31 @@
       (is (= "LSP diagnostics unavailable"
              (get-in contribution [:enrichments 0 :label]))))))
 
+(deftest request-diagnostics-retries-until-deadline-test
+  (testing "request-diagnostics! retries unresolved direct diagnostic requests until deadline"
+    (let [root (tmp-dir)
+          _    (mkdirs! (str root "/.git"))
+          path (spit! (str root "/src/foo/core.clj") "(ns foo.core)")
+          {:keys [api state]} (nullable/create-nullable-extension-api {:path "/test/lsp.clj"})
+          calls* (atom 0)
+          api' (assoc api
+                      :list-services (fn [] [])
+                      :service-request (fn [spec]
+                                         (swap! state update :service-requests conj spec)
+                                         (swap! calls* inc)
+                                         (if (= 1 @calls*)
+                                           {:psi.extension.service/response {"result" {}}}
+                                           {:psi.extension.service/response
+                                            {"result" {"items" [{"message" "Unused require"
+                                                                 "severity" 2}]}}})))
+          diagnostics (sut/request-diagnostics! api' {:workspace-root root
+                                                      :paths [path]
+                                                      :diagnostics-timeout-ms 500})]
+      (is (= [{"message" "Unused require"
+               "severity" 2}]
+             (get diagnostics path)))
+      (is (<= 2 @calls*)))))
+
 (deftest lsp-post-tool-handler-live-runtime-diagnostics-test
   (testing "post-tool handler can use the live runtime path and append real diagnostics"
     (reset! sut/state {:initialized-workspaces #{} :documents {}})


### PR DESCRIPTION
## Summary
- retry direct LSP document diagnostic requests until the overall deadline
- keep merging published-diagnostics cache while waiting
- add a regression test covering a first empty diagnostic response followed by a later successful retry

## Problem
GitHub Actions showed a flaky failure where the live LSP runtime path sometimes returned `nil` diagnostics for a changed file.

## Cause
`request-diagnostics!` sent only one direct `textDocument/diagnostic` request per path, then only polled the published-diagnostics cache. If that first request raced service readiness and no async publish arrived, diagnostics stayed missing until timeout.

## Validation
- `bb clojure:test:extensions`
- focused LSP runtime-path and post-tool tests
