### PR TITLE
Add work-on base branch selection

### DIFF
--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_handlers.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_handlers.clj
@@ -61,10 +61,14 @@
            ;; request preparation and introspection can observe the split.
            selection (:prompt-component-selection sd)
            base    (if-let [build-opts (:system-prompt-build-opts sd)]
-                     (sys-prompt/build-system-prompt
-                      (assoc build-opts
-                             :prompt-mode (:prompt-mode sd :lambda)
-                             :prompt-contributions nil))
+                     (let [selected-tools (or (some->> (:tool-defs sd) seq (mapv :name))
+                                              (:selected-tools build-opts))]
+                       (sys-prompt/build-system-prompt
+                        (assoc build-opts
+                               :prompt-mode (:prompt-mode sd :lambda)
+                               :selected-tools selected-tools
+                               :skills (vec (or (:skills sd) []))
+                               :prompt-contributions nil)))
                      (or (:base-system-prompt sd) (:system-prompt sd) ""))
            prompt  (effective-prompt base contrib selection)]
        {:root-state-update (session/session-update session-id #(assoc %

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj
@@ -110,7 +110,8 @@
                                       :prefs {:prompt-mode validated}}
                             nil)]
        {:root-state-update (session/session-update session-id #(assoc % :prompt-mode validated))
-        :effects (cond-> [{:effect/type :runtime/refresh-system-prompt}]
+        :effects (cond-> [{:effect/type :runtime/refresh-system-prompt
+                           :session-id session-id}]
                    persist-effect (conj persist-effect))})))
 
   (register-core-handler!
@@ -204,20 +205,23 @@
                                                                       :tool-defs tool-defs))
         :effects [{:effect/type :runtime/agent-set-tools
                    :tool-maps tool-defs}
-                  {:effect/type :runtime/refresh-system-prompt}]})))
+                  {:effect/type :runtime/refresh-system-prompt
+                   :session-id session-id}]})))
 
   (register-core-handler!
    :session/set-skills
    (fn [_ctx {:keys [session-id skills]}]
      {:root-state-update (session/session-update session-id #(assoc % :skills (vec (or skills []))))
-      :effects [{:effect/type :runtime/refresh-system-prompt}]
+      :effects [{:effect/type :runtime/refresh-system-prompt
+                 :session-id session-id}]
       :return {:skills (vec (or skills []))}}))
 
   (register-core-handler!
    :session/set-prompt-component-selection
    (fn [_ctx {:keys [session-id selection]}]
      {:root-state-update (session/session-update session-id #(assoc % :prompt-component-selection selection))
-      :effects [{:effect/type :runtime/refresh-system-prompt}]
+      :effects [{:effect/type :runtime/refresh-system-prompt
+                 :session-id session-id}]
       :return {:prompt-component-selection selection}})))
 
 (defn- register-session-state-handlers! []
@@ -440,7 +444,9 @@
            next-count (if existing? (count skills) (inc (count skills)))]
        (cond-> {:return {:added? (not existing?) :count next-count}}
          (not existing?)
-         (assoc :root-state-update (session/session-update session-id #(update % :skills (fnil conj []) skill)))))))
+         (assoc :root-state-update (session/session-update session-id #(update % :skills (fnil conj []) skill))
+                :effects [{:effect/type :runtime/refresh-system-prompt
+                           :session-id session-id}])))))
 
   (register-core-handler!
    :session/request-interrupt

--- a/components/agent-session/test/psi/agent_session/config_compaction_test.clj
+++ b/components/agent-session/test/psi/agent_session/config_compaction_test.clj
@@ -3,6 +3,7 @@
   manual compaction, extension dispatch, and diagnostics."
   (:require
    [psi.agent-session.test-support :as test-support]
+   [clojure.string :as str]
    [clojure.test :refer [deftest testing is]]
    [psi.agent-session.core :as session]
    [psi.agent-session.dispatch :as dispatch]
@@ -119,9 +120,31 @@
         (is (= [:session/enqueue-steering-message
                 :session/enqueue-follow-up-message
                 :session/register-prompt-template
+                :session/refresh-system-prompt
                 :session/register-skill
                 :session/clear-queued-messages]
-               event-types))))))
+               event-types)))))
+
+  (testing "register-skill refreshes the system prompt so newly added skills appear"
+    (let [[ctx session-id] (create-session-context)
+          skill {:name "coding"
+                 :description "Use coding guidance"
+                 :file-path "/tmp/SKILL.md"
+                 :base-dir "/tmp"
+                 :source :project
+                 :disable-model-invocation false}]
+      (dispatch/dispatch! ctx :session/set-system-prompt-build-opts
+                          {:session-id session-id
+                           :opts {:cwd "/tmp"
+                                  :selected-tools ["read" "bash" "edit" "write" "psi-tool"]
+                                  :skills []}}
+                          {:origin :test})
+      (dispatch/dispatch! ctx :session/refresh-system-prompt {:session-id session-id} {:origin :test})
+      (let [before-prompt (:system-prompt (ss/get-session-data-in ctx session-id))]
+        (is (not (str/includes? (or before-prompt "") "coding → Use coding guidance @ /tmp/SKILL.md"))))
+      (dispatch/dispatch! ctx :session/register-skill {:session-id session-id :skill skill} {:origin :core})
+      (let [after-prompt (:system-prompt (ss/get-session-data-in ctx session-id))]
+        (is (str/includes? (or after-prompt "") "coding → Use coding guidance @ /tmp/SKILL.md"))))))
 
 ;; ── Auto-retry and compaction config ───────────────────────────────────────
 

--- a/components/history/src/psi/history/git.clj
+++ b/components/history/src/psi/history/git.clj
@@ -370,9 +370,14 @@
    - :create-branch (defaults to true)
 
    Compatibility:
+   - accepts both :base-ref and :base_ref
    - accepts both :create-branch and :create_branch"
   [ctx req]
-  (let [{:keys [path branch base-ref] :as req*} req
+  (let [{:keys [path branch] :as req*} req
+        base-ref      (if (contains? req* :base-ref)
+                        (:base-ref req*)
+                        (when (contains? req* :base_ref)
+                          (:base_ref req*)))
         create-branch (if (contains? req* :create-branch)
                         (:create-branch req*)
                         (if (contains? req* :create_branch)

--- a/extensions/work-on/src/extensions/work_on.clj
+++ b/extensions/work-on/src/extensions/work_on.clj
@@ -336,6 +336,50 @@
          "` on branch `" (:branch-name result) "`")
     (:error result)))
 
+(def ^:private work-on-usage
+  "usage: /work-on <description>\n       /work-on --base <branch> <description>")
+
+(defn- work-on-usage-error
+  []
+  (work-on-error work-on-usage))
+
+(def ^:private work-on-base-usage-error
+  "usage error: --base requires a branch and description\n\nusage: /work-on <description>\n       /work-on --base <branch> <description>")
+
+(defn- parse-work-on-command-args
+  [args]
+  (let [args* (trim-arg args)]
+    (cond
+      (nil? args*)
+      {:ok? false
+       :error work-on-usage}
+
+      (str/starts-with? args* "--base")
+      (let [[_ branch description] (re-matches #"--base\s+(\S+)(?:\s+(.+))?" args*)]
+        (cond
+          (not (re-find #"^--base(?:\s|$)" args*))
+          {:ok? false :error work-on-usage}
+
+          (nil? branch)
+          (if (re-matches #"--base\s*" args*)
+            {:ok? false :error work-on-base-usage-error}
+            {:ok? false :error work-on-usage})
+
+          (nil? description)
+          {:ok? false :error work-on-base-usage-error}
+
+          (nil? (trim-arg description))
+          {:ok? false :error work-on-base-usage-error}
+
+          :else
+          {:ok? true
+           :request {:description description
+                     :base-branch branch}}))
+
+      :else
+      {:ok? true
+       :request {:description args*}})))
+
 (defn- work-on-tool-result
   [result]
   {:content  (work-on-result-message result)
@@ -351,34 +395,46 @@
                                           slug)}))
 
 (defn- add-worktree!
-  [worktree-path branch-name]
+  [worktree-path branch-name base-branch]
   (let [create-result (mutate! 'git.worktree/add!
                                {:input {:path worktree-path
                                         :branch branch-name
-                                        :base_ref nil
+                                        :base_ref base-branch
                                         :create-branch true}})]
     (if (= "branch already exists" (:error create-result))
-      (mutate! 'git.worktree/add!
-               {:input {:path worktree-path
-                        :branch branch-name
-                        :base_ref nil
-                        :create-branch false}})
-      create-result)))
+      (assoc (mutate! 'git.worktree/add!
+                      {:input {:path worktree-path
+                               :branch branch-name
+                               :base_ref nil
+                               :create-branch false}})
+             :reused-existing-branch? true)
+      (assoc create-result :reused-existing-branch? false))))
+
+(defn- maybe-assoc-base-branch-result
+  [result requested-base-branch applied?]
+  (if (some? requested-base-branch)
+    (assoc result
+           :requested-base-branch requested-base-branch
+           :base-branch-applied? applied?)
+    result))
 
 (defn- create-work-on-session-result
-  [session description worktree-path branch-name reused?]
+  [session description worktree-path branch-name reused? requested-base-branch base-branch-applied?]
   (let [origin-session-id (:psi.agent-session/session-id session)
         _                 (set-current-session-worktree-path! origin-session-id worktree-path)
         sd                (create-worktree-session! description worktree-path origin-session-id)]
-    (work-on-result true
-                    :reused? reused?
-                    :worktree-path worktree-path
-                    :branch-name branch-name
-                    :session-id (created-session-id sd)
-                    :session-name description)))
+    (maybe-assoc-base-branch-result
+     (work-on-result true
+                     :reused? reused?
+                     :worktree-path worktree-path
+                     :branch-name branch-name
+                     :session-id (created-session-id sd)
+                     :session-name description)
+     requested-base-branch
+     base-branch-applied?)))
 
 (defn- reuse-existing-worktree-result
-  [session description worktree-path branch-name]
+  [session description worktree-path branch-name requested-base-branch]
   (if-let [existing-wt (find-worktree-by-path worktree-path)]
     (let [origin-session-id (:psi.agent-session/session-id session)
           _                 (set-current-session-worktree-path! origin-session-id worktree-path)
@@ -387,22 +443,35 @@
       (if existing-session
         (do
           (switch-to-session! (:psi.session-info/id existing-session))
-          (work-on-result true
-                          :reused? true
-                          :worktree-path worktree-path
-                          :branch-name resolved-branch
-                          :session-id (:psi.session-info/id existing-session)
-                          :session-name (:psi.session-info/name existing-session)))
-        (create-work-on-session-result session description worktree-path resolved-branch true)))
+          (maybe-assoc-base-branch-result
+           (work-on-result true
+                           :reused? true
+                           :worktree-path worktree-path
+                           :branch-name resolved-branch
+                           :session-id (:psi.session-info/id existing-session)
+                           :session-name (:psi.session-info/name existing-session))
+           requested-base-branch
+           false))
+        (create-work-on-session-result session description worktree-path resolved-branch true requested-base-branch false)))
     (work-on-error
      (str "worktree path already exists but is not a registered git worktree: "
           worktree-path))))
 
 (defn- execute-work-on!
-  [description]
-  (let [description* (trim-arg description)]
-    (if (nil? description*)
-      (work-on-error "usage: /work-on <description>")
+  [request-or-description]
+  (let [{:keys [description base-branch]} (if (map? request-or-description)
+                                            request-or-description
+                                            {:description request-or-description})
+        description* (trim-arg description)
+        base-branch* (when (some? base-branch) (trim-arg base-branch))]
+    (cond
+      (nil? description*)
+      (work-on-usage-error)
+
+      (and (some? base-branch) (nil? base-branch*))
+      (work-on-error "base_branch must be a non-blank string")
+
+      :else
       (let [session    (current-session-query)
             current-wt (:git.worktree/current session)
             main-wt    (or (current-main-worktree) current-wt)]
@@ -415,13 +484,20 @@
 
           :else
           (let [{:keys [worktree-path branch-name]} (work-on-target description* current-wt main-wt)
-                add-result                          (add-worktree! worktree-path branch-name)]
+                add-result                          (add-worktree! worktree-path branch-name base-branch*)]
             (cond
               (:success add-result)
-              (create-work-on-session-result session description* worktree-path branch-name false)
+              (create-work-on-session-result session
+                                             description*
+                                             worktree-path
+                                             branch-name
+                                             (:reused-existing-branch? add-result)
+                                             base-branch*
+                                             (and (some? base-branch*)
+                                                  (not (:reused-existing-branch? add-result))))
 
               (= "worktree path already exists" (:error add-result))
-              (reuse-existing-worktree-result session description* worktree-path branch-name)
+              (reuse-existing-worktree-result session description* worktree-path branch-name base-branch*)
 
               :else
               (work-on-error
@@ -430,8 +506,8 @@
                         "missing git mutation payload"))))))))))
 
 (defn work-on!
-  [description]
-  (execute-work-on! description))
+  [description & [base-branch]]
+  (execute-work-on! {:description description :base-branch base-branch}))
 
 (defn work-done!
   []
@@ -516,7 +592,11 @@
 
 (defn- handle-work-on-command
   [args]
-  (append-assistant-message! (work-on-result-message (execute-work-on! args))))
+  (let [{:keys [ok? request error]} (parse-work-on-command-args args)]
+    (append-assistant-message!
+     (if ok?
+       (work-on-result-message (execute-work-on! request))
+       error))))
 
 (defn- handle-work-done-command
   [_args]
@@ -565,11 +645,17 @@
     :description "Create a layout-derived git worktree + branch and continue there"
     :parameters  {:type       "object"
                   :properties {"description" {:type "string"
-                                              :description "Description of the work to create a branch/worktree for"}}
+                                              :description "Description of the work to create a branch/worktree for"}
+                               "base_branch" {:type "string"
+                                              :description "Optional base branch to use when creating a new branch/worktree"}}
                   :required   ["description"]}
     :execute     (fn
-                   ([args] (work-on-tool-result (execute-work-on! (get args "description"))))
-                   ([args _opts] (work-on-tool-result (execute-work-on! (get args "description")))))})
+                   ([args] (work-on-tool-result
+                            (execute-work-on! {:description (get args "description")
+                                               :base-branch (get args "base_branch")})))
+                   ([args _opts] (work-on-tool-result
+                                  (execute-work-on! {:description (get args "description")
+                                                     :base-branch (get args "base_branch")}))))})
   ((:register-command api) "work-on"
                            {:description "Create a layout-derived git worktree + branch and continue there"
                             :handler handle-work-on-command})

--- a/extensions/work-on/test/extensions/work_on_test.clj
+++ b/extensions/work-on/test/extensions/work_on_test.clj
@@ -107,6 +107,9 @@
       (is (= "work-on" (get-in @state [:tools "work-on" :name])))
       (is (= "Work On" (get-in @state [:tools "work-on" :label])))
       (is (= ["description"] (get-in @state [:tools "work-on" :parameters :required])))
+      (is (= {:type "string"
+              :description "Optional base branch to use when creating a new branch/worktree"}
+             (get-in @state [:tools "work-on" :parameters :properties "base_branch"])))
       (is (fn? (get-in @state [:tools "work-on" :execute]))))))
 
 (deftest session-switch-handler-returns-nil-test
@@ -169,6 +172,7 @@
                  (get-in (second (first @mutate-calls)) [:input :path])))
           (is (= "fix-footer-not-displayed"
                  (get-in (second (first @mutate-calls)) [:input :branch])))
+          (is (nil? (get-in (second (first @mutate-calls)) [:input :base_ref])))
           (is (= ['git.worktree/add!
                   'psi.extension/set-worktree-path
                   'psi.extension/create-session
@@ -187,7 +191,46 @@
                   :content "Working in `/repo/fix-footer-not-displayed` on branch `fix-footer-not-displayed`"
                   :ext-path "/test/work_on.clj"}
                  (second (last @mutate-calls))))
-          (is (nil? @printed)))))))
+          (is (nil? @printed))))))
+
+  (testing "/work-on --base <branch> <description> threads the base branch into creation"
+    (let [mutate-calls (atom [])
+          {:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/work_on.clj"
+                                :query-fn (with-session-query
+                                            {:psi.agent-session/session-id "s-main"
+                                             :psi.agent-session/worktree-path "/repo/main"
+                                             :psi.agent-session/system-prompt "prompt"
+                                             :psi.agent-session/host-sessions [{:psi.session-info/id "s-main"
+                                                                                :psi.session-info/worktree-path "/repo/main"
+                                                                                :psi.session-info/name "main"}]
+                                             :git.worktree/current {:git.worktree/path "/repo/main"
+                                                                    :git.worktree/branch-name "main"}
+                                             :git.worktree/list [{:git.worktree/path "/repo/main"
+                                                                  :git.worktree/branch-name "main"
+                                                                  :git.worktree/current? true}]})
+                                :mutate-fn (fn [op params]
+                                             (swap! mutate-calls conj [op params])
+                                             (case op
+                                               git.branch/default {:branch "main" :source :fallback}
+                                               git.worktree/add! {:success true
+                                                                  :path "/repo/fix-footer-not-displayed"
+                                                                  :branch "fix-footer-not-displayed"
+                                                                  :head "abc123"}
+                                               psi.extension/set-worktree-path {:psi.agent-session/worktree-path (:worktree-path params)}
+                                               psi.extension/append-message {:psi.extension/message params}
+                                               psi.extension/create-session {:psi.agent-session/session-id "s-created"
+                                                                             :psi.agent-session/session-name (:session-name params)
+                                                                             :psi.agent-session/worktree-path (:worktree-path params)}
+                                               nil))})]
+      (sut/init api)
+      ((get-in @state [:commands "work-on" :handler]) "--base release/1.2 Fix footer not displayed")
+      (is (= "release/1.2"
+             (get-in (second (first @mutate-calls)) [:input :base_ref])))
+      (is (= {:role "assistant"
+              :content "Working in `/repo/fix-footer-not-displayed` on branch `fix-footer-not-displayed`"
+              :ext-path "/test/work_on.clj"}
+             (second (last @mutate-calls)))))))
 
 (deftest work-on-command-nested-linked-layout-test
   (testing "/work-on derives nested target placement when current worktree is directly under the main checkout"
@@ -280,6 +323,65 @@
                @create-calls))
         (is (nil? @printed)))))
 
+  (testing "existing-branch attach with explicit base branch records requested base branch but does not apply it"
+    (let [tool-results  (atom nil)
+          create-calls  (atom [])
+          {:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/work_on.clj"
+                                :query-fn (with-session-query
+                                            {:psi.agent-session/session-id "s-main"
+                                             :psi.agent-session/worktree-path "/repo/main"
+                                             :psi.agent-session/system-prompt "prompt"
+                                             :psi.agent-session/host-sessions [{:psi.session-info/id "s-main"
+                                                                                :psi.session-info/worktree-path "/repo/main"
+                                                                                :psi.session-info/name "main"}]
+                                             :git.worktree/current {:git.worktree/path "/repo/main"
+                                                                    :git.worktree/branch-name "main"}
+                                             :git.worktree/list [{:git.worktree/path "/repo/main"
+                                                                  :git.worktree/branch-name "main"
+                                                                  :git.worktree/current? true}]})
+                                :mutate-fn (fn [op params]
+                                             (case op
+                                               git.branch/default {:branch "main" :source :fallback}
+                                               git.worktree/add! (let [input (:input params)]
+                                                                   (swap! create-calls conj input)
+                                                                   (if (:create-branch input)
+                                                                     {:success false
+                                                                      :error "branch already exists"}
+                                                                     {:success true
+                                                                      :path (:path input)
+                                                                      :branch (:branch input)
+                                                                      :head "abc123"}))
+                                               psi.extension/create-session {:psi.agent-session/session-id "s-branch-existing"
+                                                                             :psi.agent-session/session-name (:session-name params)
+                                                                             :psi.agent-session/worktree-path (:worktree-path params)}
+                                               psi.extension/set-worktree-path {:psi.agent-session/worktree-path (:worktree-path params)}
+                                               nil))})]
+      (sut/init api)
+      (let [tool (get-in @state [:tools "work-on"])
+            result ((:execute tool) {"description" "fix repeated thinking output"
+                                     "base_branch" "release/1.2"})]
+        (reset! tool-results result)
+        (is (= [{:path "/repo/fix-repeated-thinking-output"
+                 :branch "fix-repeated-thinking-output"
+                 :base_ref "release/1.2"
+                 :create-branch true}
+                {:path "/repo/fix-repeated-thinking-output"
+                 :branch "fix-repeated-thinking-output"
+                 :base_ref nil
+                 :create-branch false}]
+               @create-calls))
+        (is (= {:ok? true
+                :action :work-on
+                :reused? true
+                :worktree-path "/repo/fix-repeated-thinking-output"
+                :branch-name "fix-repeated-thinking-output"
+                :session-id "s-branch-existing"
+                :session-name "fix repeated thinking output"
+                :requested-base-branch "release/1.2"
+                :base-branch-applied? false}
+               (:details @tool-results))))))
+
   (testing "/work-on reuses an existing worktree, updates worktree-path, switches session, and appends one AI-visible assistant summary"
     (let [printed      (atom nil)
           switched     (atom [])
@@ -333,6 +435,33 @@
                (second (last @mutate-calls))))
         (is (nil? @printed))))))
 
+(deftest parse-work-on-command-args-test
+  (testing "parses plain description"
+    (is (= {:ok? true
+            :request {:description "Fix footer not displayed"}}
+           (#'sut/parse-work-on-command-args "Fix footer not displayed"))))
+
+  (testing "parses leading --base branch description form"
+    (is (= {:ok? true
+            :request {:description "Fix footer not displayed"
+                      :base-branch "release/1.2"}}
+           (#'sut/parse-work-on-command-args "--base release/1.2 Fix footer not displayed"))))
+
+  (testing "reports specific error when --base is missing a branch and description"
+    (is (= {:ok? false
+            :error "usage error: --base requires a branch and description\n\nusage: /work-on <description>\n       /work-on --base <branch> <description>"}
+           (#'sut/parse-work-on-command-args "--base"))))
+
+  (testing "reports specific error when --base has a branch but no description"
+    (is (= {:ok? false
+            :error "usage error: --base requires a branch and description\n\nusage: /work-on <description>\n       /work-on --base <branch> <description>"}
+           (#'sut/parse-work-on-command-args "--base release/1.2"))))
+
+  (testing "reports usage when description is missing"
+    (is (= {:ok? false
+            :error "usage: /work-on <description>\n       /work-on --base <branch> <description>"}
+           (#'sut/parse-work-on-command-args "   ")))))
+
 (deftest work-on-command-usage-error-test
   (testing "/work-on without description appends usage once into AI-visible conversation"
     (let [mutate-calls (atom [])
@@ -350,9 +479,43 @@
         (is (nil? @printed))
         (is (= [['psi.extension/append-message
                  {:role "assistant"
-                  :content "usage: /work-on <description>"
+                  :content "usage: /work-on <description>\n       /work-on --base <branch> <description>"
                   :ext-path "/test/work_on.clj"}]]
-               @mutate-calls))))))
+               @mutate-calls))))
+
+    (testing "/work-on with malformed --base usage appends a specific parse error once"
+      (let [mutate-calls (atom [])
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/work_on.clj"
+                                  :mutate-fn (fn [op params]
+                                               (swap! mutate-calls conj [op params])
+                                               (case op
+                                                 psi.extension/append-message {:psi.extension/message params}
+                                                 nil))})]
+        (sut/init api)
+        ((get-in @state [:commands "work-on" :handler]) "--base")
+        (is (= [['psi.extension/append-message
+                 {:role "assistant"
+                  :content "usage error: --base requires a branch and description\n\nusage: /work-on <description>\n       /work-on --base <branch> <description>"
+                  :ext-path "/test/work_on.clj"}]]
+               @mutate-calls)))))
+
+  (testing "/work-on --base <branch> without description appends the same specific parse error once"
+    (let [mutate-calls (atom [])
+          {:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/work_on.clj"
+                                :mutate-fn (fn [op params]
+                                             (swap! mutate-calls conj [op params])
+                                             (case op
+                                               psi.extension/append-message {:psi.extension/message params}
+                                               nil))})]
+      (sut/init api)
+      ((get-in @state [:commands "work-on" :handler]) "--base release/1.2")
+      (is (= [['psi.extension/append-message
+               {:role "assistant"
+                :content "usage error: --base requires a branch and description\n\nusage: /work-on <description>\n       /work-on --base <branch> <description>"
+                :ext-path "/test/work_on.clj"}]]
+             @mutate-calls)))))
 
 (deftest work-on-tool-happy-path-test
   (testing "work-on tool shares the operational path, returns tool shape, and does not append transcript messages"
@@ -392,6 +555,8 @@
                 'psi.extension/set-worktree-path
                 'psi.extension/create-session]
                (mapv first @mutate-calls)))
+        (is (= nil
+               (get-in (second (first @mutate-calls)) [:input :base_ref])))
         (is (= "Working in `/repo/fix-footer-not-displayed` on branch `fix-footer-not-displayed`"
                (:content result)))
         (is (false? (:is-error result)))
@@ -403,7 +568,53 @@
                 :session-id "s-created"
                 :session-name "Fix footer not displayed"}
                (:details result)))
-        (is (not-any? #(= 'psi.extension/append-message (first %)) @mutate-calls))))))
+        (is (not-any? #(= 'psi.extension/append-message (first %)) @mutate-calls)))))
+
+  (testing "work-on tool threads an explicit base_branch into new worktree creation"
+    (let [mutate-calls (atom [])
+          {:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/work_on.clj"
+                                :query-fn (with-session-query
+                                            {:psi.agent-session/session-id "s-main"
+                                             :psi.agent-session/worktree-path "/repo/main"
+                                             :psi.agent-session/system-prompt "prompt"
+                                             :psi.agent-session/host-sessions [{:psi.session-info/id "s-main"
+                                                                                :psi.session-info/worktree-path "/repo/main"
+                                                                                :psi.session-info/name "main"}]
+                                             :git.worktree/current {:git.worktree/path "/repo/main"
+                                                                    :git.worktree/branch-name "main"}
+                                             :git.worktree/list [{:git.worktree/path "/repo/main"
+                                                                  :git.worktree/branch-name "main"
+                                                                  :git.worktree/current? true}]})
+                                :mutate-fn (fn [op params]
+                                             (swap! mutate-calls conj [op params])
+                                             (case op
+                                               git.branch/default {:branch "main" :source :fallback}
+                                               git.worktree/add! {:success true
+                                                                  :path "/repo/fix-footer-not-displayed"
+                                                                  :branch "fix-footer-not-displayed"
+                                                                  :head "abc123"}
+                                               psi.extension/set-worktree-path {:psi.agent-session/worktree-path (:worktree-path params)}
+                                               psi.extension/create-session {:psi.agent-session/session-id "s-created"
+                                                                             :psi.agent-session/session-name (:session-name params)
+                                                                             :psi.agent-session/worktree-path (:worktree-path params)}
+                                               nil))})]
+      (sut/init api)
+      (let [tool   (get-in @state [:tools "work-on"])
+            result ((:execute tool) {"description" "Fix footer not displayed"
+                                     "base_branch" "release/1.2"})]
+        (is (= "release/1.2"
+               (get-in (second (first @mutate-calls)) [:input :base_ref])))
+        (is (= {:ok? true
+                :action :work-on
+                :reused? false
+                :worktree-path "/repo/fix-footer-not-displayed"
+                :branch-name "fix-footer-not-displayed"
+                :session-id "s-created"
+                :session-name "Fix footer not displayed"
+                :requested-base-branch "release/1.2"
+                :base-branch-applied? true}
+               (:details result)))))))
 
 (deftest work-on-tool-usage-error-test
   (testing "work-on tool returns canonical error shape and does not append transcript messages"
@@ -418,11 +629,30 @@
       (sut/init api)
       (let [tool   (get-in @state [:tools "work-on"])
             result ((:execute tool) {"description" "   "})]
-        (is (= "usage: /work-on <description>" (:content result)))
+        (is (= "usage: /work-on <description>\n       /work-on --base <branch> <description>" (:content result)))
         (is (true? (:is-error result)))
         (is (= {:ok? false
                 :action :work-on
-                :error "usage: /work-on <description>"}
+                :error "usage: /work-on <description>\n       /work-on --base <branch> <description>"}
+               (:details result)))
+        (is (empty? @mutate-calls)))))
+
+  (testing "blank tool base_branch is invalid"
+    (let [mutate-calls (atom [])
+          {:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/work_on.clj"
+                                :mutate-fn (fn [op params]
+                                             (swap! mutate-calls conj [op params])
+                                             nil)})]
+      (sut/init api)
+      (let [tool   (get-in @state [:tools "work-on"])
+            result ((:execute tool) {"description" "Fix footer not displayed"
+                                     "base_branch" "   "})]
+        (is (= "base_branch must be a non-blank string" (:content result)))
+        (is (true? (:is-error result)))
+        (is (= {:ok? false
+                :action :work-on
+                :error "base_branch must be a non-blank string"}
                (:details result)))
         (is (empty? @mutate-calls))))))
 
@@ -476,7 +706,57 @@
                 :session-id "s-existing"
                 :session-name "Fix repeated thinking output in emacs"}
                (:details result)))
-        (is (not-any? #(= 'psi.extension/append-message (first %)) @mutate-calls))))))
+        (is (not-any? #(= 'psi.extension/append-message (first %)) @mutate-calls)))))
+
+  (testing "requested base branch is recorded but not applied when reusing an existing worktree/session"
+    (let [switched     (atom [])
+          mutate-calls (atom [])
+          {:keys [api state]} (nullable/create-nullable-extension-api
+                               {:path "/test/work_on.clj"
+                                :query-fn (with-session-query
+                                            {:psi.agent-session/session-id "s-main"
+                                             :psi.agent-session/worktree-path "/repo/main"
+                                             :psi.agent-session/system-prompt "prompt"
+                                             :psi.agent-session/host-sessions [{:psi.session-info/id "s-main"
+                                                                                :psi.session-info/worktree-path "/repo/main"
+                                                                                :psi.session-info/name "main"}
+                                                                               {:psi.session-info/id "s-existing"
+                                                                                :psi.session-info/worktree-path "/repo/fix-repeated-thinking-output"
+                                                                                :psi.session-info/name "Fix repeated thinking output in emacs"}]
+                                             :git.worktree/current {:git.worktree/path "/repo/main"
+                                                                    :git.worktree/branch-name "main"}
+                                             :git.worktree/list [{:git.worktree/path "/repo/main"
+                                                                  :git.worktree/branch-name "main"
+                                                                  :git.worktree/current? true}
+                                                                 {:git.worktree/path "/repo/fix-repeated-thinking-output"
+                                                                  :git.worktree/branch-name "fix-repeated-thinking-output"}]})
+                                :mutate-fn (fn [op params]
+                                             (swap! mutate-calls conj [op params])
+                                             (case op
+                                               git.branch/default {:branch "main" :source :fallback}
+                                               git.worktree/add! {:success false
+                                                                  :error "worktree path already exists"}
+                                               psi.extension/set-worktree-path {:psi.agent-session/worktree-path (:worktree-path params)}
+                                               psi.extension/switch-session (do (swap! switched conj "s-existing")
+                                                                                {:psi.agent-session/session-id "s-existing"})
+                                               nil))})]
+      (sut/init api)
+      (let [tool   (get-in @state [:tools "work-on"])
+            result ((:execute tool) {"description" "fix repeated thinking output in emacs"
+                                     "base_branch" "release/1.2"})]
+        (is (= ["s-existing"] @switched))
+        (is (= "release/1.2"
+               (get-in (second (first @mutate-calls)) [:input :base_ref])))
+        (is (= {:ok? true
+                :action :work-on
+                :reused? true
+                :worktree-path "/repo/fix-repeated-thinking-output"
+                :branch-name "fix-repeated-thinking-output"
+                :session-id "s-existing"
+                :session-name "Fix repeated thinking output in emacs"
+                :requested-base-branch "release/1.2"
+                :base-branch-applied? false}
+               (:details result)))))))
 
 (defn- make-runtime-work-on-api
   [ctx load-session-id active-session-id ext-path mutate-calls]

--- a/extensions/work-on/test/extensions/work_on_test.clj
+++ b/extensions/work-on/test/extensions/work_on_test.clj
@@ -1,5 +1,6 @@
 (ns extensions.work-on-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [extensions.work-on :as sut]
    [psi.agent-session.commands :as commands]
@@ -58,6 +59,23 @@
         s1  (session/new-session-in! ctx nil {:session-name "one"})
         s2  (session/new-session-in! ctx (:session-id s1) {:session-name "two"})]
     [ctx (:session-id s1) (:session-id s2)]))
+
+(defn- run-git!
+  [repo-dir & args]
+  (let [pb   (ProcessBuilder. ^java.util.List (vec (cons "git" args)))
+        _    (.directory pb (java.io.File. ^String repo-dir))
+        _    (doto (.environment pb)
+               (.put "GIT_AUTHOR_NAME" "Test Author")
+               (.put "GIT_AUTHOR_EMAIL" "test@example.com")
+               (.put "GIT_COMMITTER_NAME" "Test Author")
+               (.put "GIT_COMMITTER_EMAIL" "test@example.com"))
+        proc (.start pb)
+        out  (slurp (.getInputStream proc))
+        err  (slurp (.getErrorStream proc))
+        exit (.waitFor proc)]
+    (when (pos? exit)
+      (throw (ex-info "git helper failed" {:args args :err err :exit exit})))
+    out))
 
 (deftest mechanical-slug-test
   (testing "slug is mechanical and limited to four significant words"
@@ -854,6 +872,76 @@
         (is (= 'psi.extension/set-worktree-path (first set-worktree-call)))
         (is (= s2 (get-in set-worktree-call [1 :session-id]))
             "work-on tool must update the active session worktree-path after /new")))))
+
+(deftest work-on-command-with-remote-base-ref-integration-test
+  (testing "/work-on --base origin/master should create the new branch from the remote-tracking ref, not current HEAD"
+    (let [base-dir     (str (java.nio.file.Files/createTempDirectory "psi-work-on-remote-base-"
+                                                                     (make-array java.nio.file.attribute.FileAttribute 0)))
+          remote-dir   (str (java.io.File. base-dir "remote.git"))
+          seed-dir     (str (java.io.File. base-dir "seed"))
+          clone-dir    (str (java.io.File. base-dir "clone"))
+          repo-dir     (str (java.io.File. clone-dir))
+          mutate-calls (atom [])]
+      (.mkdirs (java.io.File. seed-dir))
+      (run-git! base-dir "init" "--bare" remote-dir)
+      (run-git! base-dir "clone" remote-dir seed-dir)
+      (spit (str seed-dir "/README.md") "# seeded\n")
+      (run-git! seed-dir "add" "README.md")
+      (run-git! seed-dir "commit" "-m" "seed main")
+      (run-git! seed-dir "push" "origin" "HEAD:master")
+      (run-git! base-dir "clone" remote-dir clone-dir)
+      (run-git! clone-dir "checkout" "-b" "main" "origin/master")
+      (run-git! clone-dir "branch" "--set-upstream-to=origin/master" "main")
+      ;; Advance local HEAD without updating origin/master so the test can distinguish
+      ;; whether work-on actually uses the requested base ref or silently falls back to HEAD.
+      (spit (str clone-dir "/LOCAL_ONLY.md") "local only\n")
+      (run-git! clone-dir "add" "LOCAL_ONLY.md")
+      (run-git! clone-dir "commit" "-m" "advance local main only")
+      (let [origin-master-sha (str/trim (run-git! clone-dir "rev-parse" "origin/master"))
+            local-head-sha    (str/trim (run-git! clone-dir "rev-parse" "HEAD"))
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/work_on.clj"
+                                  :query-fn (with-session-query
+                                              {:psi.agent-session/session-id "s-main"
+                                               :psi.agent-session/worktree-path repo-dir
+                                               :psi.agent-session/system-prompt "prompt"
+                                               :psi.agent-session/host-sessions [{:psi.session-info/id "s-main"
+                                                                                  :psi.session-info/worktree-path repo-dir
+                                                                                  :psi.session-info/name "main"}]
+                                               :git.worktree/current {:git.worktree/path repo-dir
+                                                                      :git.worktree/branch-name "main"
+                                                                      :git.worktree/current? true}
+                                               :git.worktree/list [{:git.worktree/path repo-dir
+                                                                    :git.worktree/branch-name "main"
+                                                                    :git.worktree/current? true}]})
+                                  :mutate-fn (fn [op params]
+                                               (swap! mutate-calls conj [op params])
+                                               (case op
+                                                 git.branch/default {:branch "main" :source :fallback}
+                                                 git.worktree/add! (git/worktree-add (git/create-context repo-dir)
+                                                                                     (:input params))
+                                                 psi.extension/set-worktree-path {:psi.agent-session/worktree-path (:worktree-path params)}
+                                                 psi.extension/append-message {:psi.extension/message params}
+                                                 psi.extension/create-session {:psi.agent-session/session-id "s-created"
+                                                                               :psi.agent-session/session-name (:session-name params)
+                                                                               :psi.agent-session/worktree-path (:worktree-path params)}
+                                                 nil))})]
+        (is (not= origin-master-sha local-head-sha)
+            "test setup must diverge local HEAD from origin/master")
+        (sut/init api)
+        ((get-in @state [:commands "work-on" :handler]) "--base origin/master fix flakey test")
+        (let [worktree-add-call (first @mutate-calls)
+              worktree-path     (get-in worktree-add-call [1 :input :path])
+              created-ctx       (git/create-context worktree-path)
+              head-sha          (git/current-commit created-ctx)
+              branch-name       (git/current-branch created-ctx)]
+          (is (= 'git.worktree/add! (first worktree-add-call)))
+          (is (= "origin/master" (get-in worktree-add-call [1 :input :base_ref])))
+          (is (= "fix-flakey-test" branch-name))
+          (is (= origin-master-sha head-sha)
+              "fresh worktree branch should start at origin/master, not the current local HEAD")
+          (is (not= local-head-sha head-sha)
+              "if this equals local HEAD then the requested base ref was ignored"))))))
 
 (deftest work-done-and-rebase-commands-test
   (testing "/work-done fast-forwards onto the cached default branch, switches sessions, and /work-rebase emits notifications"

--- a/munera/open/003-prompt-lifecycle-architectural-convergence/implementation.md
+++ b/munera/open/003-prompt-lifecycle-architectural-convergence/implementation.md
@@ -22,3 +22,15 @@ Initialized from the prior active planning tracker on 2026-04-17.
   - `psi.app-runtime-test`
   - `psi.rpc-prompt-test`
 
+2026-04-22 — system-prompt refresh correctness for incrementally registered skills
+
+- Reproduced that incrementally registering a skill could leave the rebuilt system prompt stale even after refresh, so newly added skills were absent from the prompt-visible skills section.
+- Added a focused regression proof in `components/agent-session/test/psi/agent_session/config_compaction_test.clj` covering `:session/register-skill` followed by prompt refresh.
+- Fixed `components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj` so prompt-refresh effects emitted from prompt-mode/tool/skill/prompt-component mutations always carry explicit `:session-id`, and `:session/register-skill` now triggers prompt refresh.
+- Fixed `components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_handlers.clj` so refresh rebuild overlays canonical live session `:skills` and selected tools onto stored `:system-prompt-build-opts` instead of trusting stale build opts alone.
+- Focused verification is green:
+  - `psi.agent-session.config-compaction-test`
+  - `psi.agent-session.system-prompt-test`
+  - `psi.agent-session.child-session-mutation-test`
+  - `psi.agent-session.prompt-lifecycle-test`
+

--- a/munera/open/045-work-on-base-branch-selection/design.md
+++ b/munera/open/045-work-on-base-branch-selection/design.md
@@ -1,0 +1,150 @@
+Goal: allow callers to specify the base branch for `work-on` from both the slash-command surface and the extension tool surface, while preserving current behavior when no base branch is specified.
+
+Intent:
+- make branch ancestry for `work-on` explicit when needed
+- preserve one canonical operational path shared by command and tool
+- keep the change small, extension-local, and behavior-preserving by default
+
+Context:
+- `extensions.work-on` already provides two entrypoints over one canonical operation path:
+  - `/work-on`
+  - tool `work-on`
+- today `execute-work-on!` creates new worktrees through `git.worktree/add!` with `:base_ref nil`
+- branch naming and worktree placement are already shared between command and tool surfaces
+- reuse is already part of current `work-on` behavior:
+  - if the target branch already exists, `work-on` can create a worktree for that branch
+  - if the target worktree already exists and is a registered git worktree, `work-on` reuses it
+  - if a session already exists for that reused worktree, `work-on` switches to it
+- the extension already has default-branch discovery/caching used by `work-done!` and `work-rebase!`, but `work-on` itself does not currently let callers choose an explicit base branch
+
+Problem:
+- `work-on` currently chooses branch ancestry implicitly rather than from explicit caller intent
+- implicit ancestry is acceptable for simple default-branch work, but becomes inadequate for workflows such as:
+  - starting work from a release branch
+  - creating follow-on work from a long-lived integration branch
+  - making workflow-driven execution deterministic when a known base branch is required
+- if only one surface gains explicit base-branch support, command/tool parity would drift
+- if this task tries to redesign branch validation, command parsing, and reuse semantics all at once, it will become larger than needed
+
+Scope:
+- extend the canonical `work-on` operation to accept an optional base branch
+- extend `/work-on` command parsing to collect that optional base branch
+- extend the `work-on` tool schema and execution wrapper to accept the same concept
+- thread the selected base branch into git worktree creation
+- preserve shared command/tool operational semantics, side effects, and result shaping
+- add focused tests for command parsing, tool schema/execution, and operational parity
+
+Non-goals:
+- changing branch-name slug generation
+- changing worktree layout derivation
+- changing `work-done!` or `work-rebase!`
+- redesigning extension argument parsing generally
+- broadening this into general revision syntax or multi-ref selection
+- changing default behavior for callers that do not specify a base branch
+- enforcing ancestry constraints on reused branches/worktrees in this slice
+- adding separate pre-validation logic for base-branch existence before attempting git worktree creation
+
+Minimum concepts:
+- work description
+- optional base branch
+- canonical `work-on` request map or equivalent internal representation
+- shared command/tool execution path
+- explicit-vs-default base branch selection
+- reuse vs new creation
+
+Preferred surface shape:
+- tool surface:
+  - keep required `description` string
+  - add optional `base_branch` string
+- command surface:
+  - support an explicit base-branch flag rather than ambiguous freeform parsing
+  - supported forms in this slice are:
+    - `/work-on <description>`
+    - `/work-on --base <branch> <description>`
+  - trailing or mixed `--base` placements are out of scope and need not be accepted
+- internal shape:
+  - canonical execution takes both `description` and optional base branch, either as separate args or a small request map
+  - wrappers own parsing only; execution owns semantics
+  - tool input key `base_branch` maps to internal key `:base-branch`
+
+Reason for the preferred command shape:
+- branch names and descriptions are both freeform strings and can contain overlapping tokens
+- a flag-based command form keeps parsing deterministic and avoids heuristics
+- it aligns naturally with the tool surface, where `base_branch` is already explicit structured input
+- restricting support to a leading `--base` form keeps the parser small and predictable
+
+Canonical behavior expectations:
+- when no base branch is provided:
+  - `work-on` preserves current behavior
+  - preserving current behavior specifically means continuing to call `git.worktree/add!` with `:base_ref nil`
+- when a base branch is provided and a new branch/worktree is created:
+  - `git.worktree/add!` is called with `:base_ref` set to the requested branch
+  - the canonical result records that the requested base branch was applied
+  - in this task, “applied” means the requested base branch was used as the `:base_ref` input on a successful new-creation path
+  - “applied” does not imply separate ancestry verification beyond successful git creation
+- when a base branch is provided but the target is reused:
+  - current reuse behavior is preserved
+  - the requested base branch is not re-applied or reinterpreted
+  - this task does not attempt to prove or enforce that the reused branch descends from the requested base branch
+  - the canonical result records that a base branch was requested but was not applied because an existing target was reused
+- if the target branch already exists and this invocation creates a new worktree for that existing branch:
+  - that still counts as reuse for the purposes of base-branch reporting
+  - the requested base branch is recorded but not considered applied
+- existing session targeting, worktree-path updates, session create/switch behavior, and reuse semantics remain unchanged
+
+Reuse semantics:
+- reuse remains a valid and supported `work-on` outcome in this task
+- explicit base-branch selection affects only new creation
+- explicit base-branch selection does not constrain or invalidate reuse in this slice
+- if stricter ancestry enforcement for reused targets is desired later, that should be handled by a separate task with explicit semantics
+
+Canonical result shaping:
+- continue to return one canonical success/error result contract for both command and tool presenters
+- when a base branch is requested, the canonical result should include it under `:requested-base-branch`
+- the canonical result should also record whether the requested base branch was actually applied under `:base-branch-applied?`, so callers can distinguish creation from reuse
+- any effective/derived base-branch field beyond the explicit request is optional and should not require broad extra resolution work in this slice
+- tool `:details` mirrors the canonical result
+- command/tool presentation text may mention the base branch when it was explicitly requested and applied; if reuse prevented application, presentation may stay brief while the canonical result carries the detail
+
+Error behavior:
+- usage errors for the command should clearly describe the supported forms, including `--base`
+- malformed `--base` usage should be handled by command parsing rather than by ad hoc deeper failures
+- a missing value after `--base` should be treated as a specific command-parse error rather than silently falling through
+- missing description should still produce clear usage guidance
+- tool validation remains schema-driven plus runtime validation for blank strings
+- blank `base_branch` on the tool surface is invalid and should not be silently treated as absent
+- invalid or nonexistent base branch errors should surface from the canonical execution path, not from duplicated wrapper logic
+- this slice does not add separate pre-validation of base-branch existence; git mutation remains the source of truth for creation failure
+
+Architecture alignment:
+- keep the solution inside `extensions.work-on`
+- preserve the shared extension-local execution boundary established by task `039`
+- prefer a small parsing helper for the command surface over broad command-framework changes
+- do not introduce a second semantic implementation path
+- if needed, a small request-map refactor is acceptable when it improves parity and local clarity without changing behavior
+
+Acceptance:
+- `/work-on` supports:
+  - `/work-on <description>`
+  - `/work-on --base <branch> <description>`
+- tool `work-on` supports optional `base_branch`
+- command and tool still share one canonical execution path
+- explicit base branch is threaded to git worktree creation for new creation paths
+- default behavior remains unchanged when no base branch is provided
+- reuse behavior remains unchanged when the target already exists, including:
+  - existing-branch paths where a new worktree is created for that branch
+  - existing-worktree paths where the worktree is reused directly
+  - existing-session paths where the session for a reused worktree is switched to
+- canonical result records `:requested-base-branch` and `:base-branch-applied?` when a base branch is supplied
+- focused tests prove:
+  - tool registration/schema includes optional `base_branch`
+  - command parsing for plain description and `--base <branch> <description>`
+  - error behavior for missing `--base` values and missing descriptions
+  - blank tool `base_branch` is invalid
+  - happy-path explicit-base invocation on both command and tool surfaces
+  - default-path behavior remains unchanged when base branch is omitted
+  - reuse-path behavior remains unchanged and reports non-application of the requested base branch when appropriate
+
+Notes:
+- this task is a follow-on to `039-work-on-tool-surface` and preserves its core architectural decision: one canonical extension-local operational path with command/tool-specific presentation only
+- the main design choice in this task is to add explicit base-branch selection without broadening into ancestry enforcement or generalized revision parsing

--- a/munera/open/045-work-on-base-branch-selection/implementation.md
+++ b/munera/open/045-work-on-base-branch-selection/implementation.md
@@ -32,7 +32,7 @@ Tests added/updated:
 
 Focused verification:
 - ran `clojure -M:test --focus extensions.work-on-test`
-- result: `18 tests, 96 assertions, 0 failures`
+- result: `20 tests, 111 assertions, 0 failures`
 
 Review follow-up summary:
 - review found that existing-branch attach success was not distinguished from fresh creation, so `:base-branch-applied?` could be overstated

--- a/munera/open/045-work-on-base-branch-selection/implementation.md
+++ b/munera/open/045-work-on-base-branch-selection/implementation.md
@@ -1,0 +1,40 @@
+Implemented explicit optional base-branch support for `extensions.work-on` while preserving the single canonical execution path shared by `/work-on` and the `work-on` tool.
+
+Key decisions and outcomes:
+- Added a local command parser supporting only:
+  - `/work-on <description>`
+  - `/work-on --base <branch> <description>`
+- Kept parsing local to `extensions.work-on`; no command-framework changes.
+- Extended canonical execution to accept `{:description ... :base-branch ...}`.
+- Preserved default behavior when `base-branch` is omitted by continuing to call `git.worktree/add!` with `:base_ref nil`.
+- Threaded explicit base branch to `git.worktree/add!` as `:base_ref` on initial new-creation attempts.
+- Preserved reuse semantics:
+  - existing-branch attach remains reuse for reporting purposes
+  - existing-worktree/session reuse remains unchanged
+- Added canonical result fields when a base branch is supplied:
+  - `:requested-base-branch`
+  - `:base-branch-applied?`
+- `:base-branch-applied?` is true only for successful new-creation paths and false for reuse paths.
+- Tool schema now includes optional `base_branch` and blank values are rejected with a canonical runtime error.
+
+Notable behavior details:
+- On branch-already-exists fallback, the second `git.worktree/add!` call still uses `:create-branch false` and `:base_ref nil`; requested base branch is recorded but not applied.
+- Command parse errors surface usage/help before execution; git/base-branch validity remains enforced by the canonical git mutation path rather than prevalidation.
+
+Tests added/updated:
+- tool registration/schema coverage for optional `base_branch`
+- parser coverage for plain description and `--base <branch> <description>`
+- command parse error coverage for missing `--base` value and missing description
+- tool validation coverage for blank `base_branch`
+- command/tool happy-path coverage for explicit base-branch threading
+- default-path assertions proving omitted base branch keeps `:base_ref nil`
+- reuse-path coverage proving requested base branch is recorded but not applied
+
+Focused verification:
+- ran `clojure -M:test --focus extensions.work-on-test`
+- result: `18 tests, 96 assertions, 0 failures`
+
+Review follow-up summary:
+- review found that existing-branch attach success was not distinguished from fresh creation, so `:base-branch-applied?` could be overstated
+- review also found that `/work-on --base <branch>` without a description fell back to generic usage instead of the specific malformed-flag error
+- follow-up changes fixed both issues and the focused `extensions.work-on` namespace remained green

--- a/munera/open/045-work-on-base-branch-selection/plan.md
+++ b/munera/open/045-work-on-base-branch-selection/plan.md
@@ -1,0 +1,91 @@
+Approach:
+- keep the change small and extension-local within `extensions.work-on`
+- preserve the existing shared command/tool execution boundary
+- add explicit base-branch input at the wrappers, then thread it into the canonical operation path
+- use deterministic command parsing with a leading `--base` flag rather than heuristic freeform parsing
+- preserve current reuse behavior and treat explicit base-branch selection as applying only to new creation paths
+
+Implementation shape:
+1. Inspect current `work-on` execution and wrapper boundaries
+- confirm the smallest change to `execute-work-on!` that can accept optional base-branch input
+- prefer a small canonical request shape such as `{:description ... :base-branch ...}` if it makes parity and result shaping clearer
+- keep one canonical operational path for both command and tool
+
+2. Add command parsing for explicit base-branch selection
+- introduce a small private parser for `/work-on` args
+- support only:
+  - `/work-on <description>`
+  - `/work-on --base <branch> <description>`
+- do not accept trailing or mixed `--base` placements in this slice
+- return clear parse/usage errors for malformed flag usage, including:
+  - missing branch after `--base`
+  - missing description
+- keep parsing logic local to `extensions.work-on`
+
+3. Extend the canonical execution path
+- thread optional base-branch input into the `work-on` operation
+- update worktree creation so `git.worktree/add!` receives `:base_ref` when a base branch is specified
+- preserve current behavior when it is absent by continuing to call `git.worktree/add!` with `:base_ref nil`
+- keep success/error result shaping canonical and shared
+- add stable canonical result fields when a base branch is supplied:
+  - `:requested-base-branch`
+  - `:base-branch-applied?`
+- define `:base-branch-applied?` narrowly:
+  - true when the requested base branch was used as `:base_ref` on a successful new-creation path
+  - false for reuse paths, including when a branch already existed and only a new worktree was attached to it
+
+4. Preserve reuse semantics
+- keep current reuse behavior unchanged for:
+  - existing-branch paths where a new worktree is created for an existing branch
+  - existing-worktree paths where a registered worktree is reused
+  - existing-session paths where the session for a reused worktree is switched to
+- when a base branch was requested during a reuse path, record it in `:requested-base-branch` but leave `:base-branch-applied?` false
+- do not add ancestry verification or reuse constraints in this slice
+
+5. Extend the tool surface
+- update the registered tool schema to include optional `base_branch`
+- keep `description` required
+- map tool input key `base_branch` to internal `:base-branch`
+- make blank `base_branch` invalid rather than silently treating it as absent
+- make the tool wrapper pass both fields into the shared execution path
+- preserve the existing tool return contract `{:content ... :is-error ... :details ...}`
+
+6. Preserve command presentation behavior
+- keep `/work-on` as a presenter over the canonical result
+- use parse errors for malformed `--base` syntax and canonical execution errors for git/runtime failures
+- only adjust success wording if necessary to mention an explicitly applied base branch; keep wording otherwise stable
+- do not introduce separate command-side operational semantics
+
+7. Add focused tests
+- extend init registration coverage for the new optional tool parameter
+- add parser-focused command tests for:
+  - plain description
+  - `--base <branch> <description>`
+  - missing branch after `--base`
+  - missing description
+  - unsupported trailing/mixed `--base` forms if parser behavior needs proof
+- add focused tool validation tests for blank `base_branch`
+- add happy-path command/tool tests proving explicit base branch is threaded to `git.worktree/add!`
+- add or extend tests proving omitted base branch preserves current `:base_ref nil` behavior
+- add reuse-path tests proving explicit requested base branch is recorded but not considered applied when the target already exists
+- keep assertions focused on shared operational behavior and canonical payloads, not incidental implementation details
+
+8. Verify and record findings
+- run focused `extensions.work-on` tests
+- fix any regressions
+- record syntax decisions, result-field decisions, and reuse semantics in `implementation.md`
+
+Key decisions to preserve:
+- one canonical operational path for command and tool
+- deterministic command syntax via leading `--base`
+- no change to behavior when base branch is omitted
+- explicit base branch affects only new creation, not reuse semantics
+- no pre-validation of base-branch existence before git worktree creation
+- no broader command-framework or extension-architecture redesign in this slice
+
+Risks / watchpoints:
+- avoid ambiguous command parsing that could confuse branch names with descriptions
+- avoid changing existing `/work-on <description>` behavior
+- avoid treating existing-branch attach as an applied base-branch path
+- avoid silently collapsing blank tool `base_branch` to nil
+- keep the result contract stable and explicit for tests and future tool callers

--- a/munera/open/045-work-on-base-branch-selection/steps.md
+++ b/munera/open/045-work-on-base-branch-selection/steps.md
@@ -1,0 +1,22 @@
+- [ ] Inspect `extensions.work-on` and choose the smallest clean internal shape for optional base-branch input, preferring a canonical request map if it improves clarity
+- [ ] Add a private `/work-on` arg parser supporting only `<description>` and `--base <branch> <description>`
+- [ ] Define and implement clear command-parse errors for malformed `--base` input, including missing branch value and missing description
+- [ ] Extend the canonical `work-on` execution path to accept optional `:base-branch`
+- [ ] Preserve default behavior by continuing to call `git.worktree/add!` with `:base_ref nil` when no base branch is specified
+- [ ] Thread explicit base-branch input into `git.worktree/add!` as `:base_ref` on successful new-creation paths
+- [ ] Add canonical result fields `:requested-base-branch` and `:base-branch-applied?` when a base branch is supplied
+- [ ] Ensure `:base-branch-applied?` is true only when the requested base branch is used as `:base_ref` on a successful new-creation path
+- [ ] Ensure existing-branch attach paths are reported as reuse for base-branch purposes, with `:base-branch-applied? false`
+- [ ] Preserve existing worktree/session reuse behavior unchanged while recording requested-but-not-applied base-branch metadata where appropriate
+- [ ] Update the `work-on` tool registration schema to include optional `base_branch`
+- [ ] Treat blank tool `base_branch` as invalid rather than silently absent
+- [ ] Update the tool execute wrapper to pass both `description` and `base_branch` through the shared execution path
+- [ ] Keep command presentation derived from the canonical result and parse/runtime errors rather than adding separate semantics
+- [ ] Add focused command parser tests for plain description and `--base <branch> <description>`
+- [ ] Add focused error tests for missing `--base` value, missing description, and any intentionally unsupported flag placements that need proof
+- [ ] Add focused tool validation tests for blank `base_branch`
+- [ ] Add focused happy-path tests proving explicit base branch reaches `git.worktree/add!` on both command and tool paths
+- [ ] Retain or extend default-path tests proving omitted base branch preserves current `:base_ref nil` behavior
+- [ ] Add focused reuse-path tests proving requested base branch is recorded but not considered applied when the target already exists
+- [ ] Run focused `extensions.work-on` tests and fix any regressions
+- [ ] Record implementation notes, syntax decisions, and result-field/reuse semantics in `implementation.md`

--- a/munera/open/045-work-on-base-branch-selection/steps.md
+++ b/munera/open/045-work-on-base-branch-selection/steps.md
@@ -1,22 +1,28 @@
-- [ ] Inspect `extensions.work-on` and choose the smallest clean internal shape for optional base-branch input, preferring a canonical request map if it improves clarity
-- [ ] Add a private `/work-on` arg parser supporting only `<description>` and `--base <branch> <description>`
-- [ ] Define and implement clear command-parse errors for malformed `--base` input, including missing branch value and missing description
-- [ ] Extend the canonical `work-on` execution path to accept optional `:base-branch`
-- [ ] Preserve default behavior by continuing to call `git.worktree/add!` with `:base_ref nil` when no base branch is specified
-- [ ] Thread explicit base-branch input into `git.worktree/add!` as `:base_ref` on successful new-creation paths
-- [ ] Add canonical result fields `:requested-base-branch` and `:base-branch-applied?` when a base branch is supplied
-- [ ] Ensure `:base-branch-applied?` is true only when the requested base branch is used as `:base_ref` on a successful new-creation path
-- [ ] Ensure existing-branch attach paths are reported as reuse for base-branch purposes, with `:base-branch-applied? false`
-- [ ] Preserve existing worktree/session reuse behavior unchanged while recording requested-but-not-applied base-branch metadata where appropriate
-- [ ] Update the `work-on` tool registration schema to include optional `base_branch`
-- [ ] Treat blank tool `base_branch` as invalid rather than silently absent
-- [ ] Update the tool execute wrapper to pass both `description` and `base_branch` through the shared execution path
-- [ ] Keep command presentation derived from the canonical result and parse/runtime errors rather than adding separate semantics
-- [ ] Add focused command parser tests for plain description and `--base <branch> <description>`
-- [ ] Add focused error tests for missing `--base` value, missing description, and any intentionally unsupported flag placements that need proof
-- [ ] Add focused tool validation tests for blank `base_branch`
-- [ ] Add focused happy-path tests proving explicit base branch reaches `git.worktree/add!` on both command and tool paths
-- [ ] Retain or extend default-path tests proving omitted base branch preserves current `:base_ref nil` behavior
-- [ ] Add focused reuse-path tests proving requested base branch is recorded but not considered applied when the target already exists
-- [ ] Run focused `extensions.work-on` tests and fix any regressions
-- [ ] Record implementation notes, syntax decisions, and result-field/reuse semantics in `implementation.md`
+- [x] Inspect `extensions.work-on` and choose the smallest clean internal shape for optional base-branch input, preferring a canonical request map if it improves clarity
+- [x] Add a private `/work-on` arg parser supporting only `<description>` and `--base <branch> <description>`
+- [x] Define and implement clear command-parse errors for malformed `--base` input, including missing branch value and missing description
+- [x] Extend the canonical `work-on` execution path to accept optional `:base-branch`
+- [x] Preserve default behavior by continuing to call `git.worktree/add!` with `:base_ref nil` when no base branch is specified
+- [x] Thread explicit base-branch input into `git.worktree/add!` as `:base_ref` on successful new-creation paths
+- [x] Add canonical result fields `:requested-base-branch` and `:base-branch-applied?` when a base branch is supplied
+- [x] Ensure `:base-branch-applied?` is true only when the requested base branch is used as `:base_ref` on a successful new-creation path
+- [x] Ensure existing-branch attach paths are reported as reuse for base-branch purposes, with `:base-branch-applied? false`
+- [x] Preserve existing worktree/session reuse behavior unchanged while recording requested-but-not-applied base-branch metadata where appropriate
+- [x] Update the `work-on` tool registration schema to include optional `base_branch`
+- [x] Treat blank tool `base_branch` as invalid rather than silently absent
+- [x] Update the tool execute wrapper to pass both `description` and `base_branch` through the shared execution path
+- [x] Keep command presentation derived from the canonical result and parse/runtime errors rather than adding separate semantics
+- [x] Add focused command parser tests for plain description and `--base <branch> <description>`
+- [x] Add focused error tests for missing `--base` value, missing description, and any intentionally unsupported flag placements that need proof
+- [x] Add focused tool validation tests for blank `base_branch`
+- [x] Add focused happy-path tests proving explicit base branch reaches `git.worktree/add!` on both command and tool paths
+- [x] Retain or extend default-path tests proving omitted base branch preserves current `:base_ref nil` behavior
+- [x] Add focused reuse-path tests proving requested base branch is recorded but not considered applied when the target already exists
+- [x] Run focused `extensions.work-on` tests and fix any regressions
+- [x] Record implementation notes, syntax decisions, and result-field/reuse semantics in `implementation.md`
+- [x] Distinguish fresh branch creation from existing-branch attach in `add-worktree!`/canonical execution result shaping
+- [x] Ensure existing-branch attach success reports reuse semantics for base-branch purposes, including `:base-branch-applied? false`
+- [x] Add focused command/tool tests covering explicit `base_branch` on existing-branch attach success
+- [x] Make `/work-on --base <branch>` without description return the specific malformed-flag parse error
+- [x] Add focused parser/command tests for `/work-on --base <branch>` with missing description
+- [x] Re-run focused `extensions.work-on` tests after review follow-up fixes

--- a/munera/plan.md
+++ b/munera/plan.md
@@ -12,6 +12,7 @@ Backlog:
 `munera/open/005-canonical-dispatch-pipeline-trace-observability/`
 `munera/open/006-agent-tool-skill-prelude-follow-on/`
 `munera/open/040-work-on-execute-function-code-shaping/`
+`munera/open/045-work-on-base-branch-selection/`
 
 Notes:
 - `munera/plan.md` is the active project-wide orchestration surface.


### PR DESCRIPTION
## Summary
- add optional base branch support to `/work-on` and the `work-on` tool
- preserve reuse semantics while reporting whether a requested base branch was applied
- fix git worktree base-ref handling so remote refs like `origin/master` are respected

## Testing
- clojure -M:test --focus extensions.work-on-test
- clojure -M:test --focus psi.history.git-test --focus extensions.work-on-test