### PR TITLE
Document custom LLM provider setup for #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ For prompt lifecycle introspection summaries and normalized prompt-turn attrs, s
 ## Configuration
 
 Config file locations, precedence (session > project-local > project-shared > user > system), settings
-reference, and runtime scoped setters:
+reference, runtime scoped setters, and custom provider setup:
 - [`doc/configuration.md`](doc/configuration.md)
+- [`doc/custom-providers.md`](doc/custom-providers.md)
 
 ## ψ Psi project config
 

--- a/components/agent-session/src/psi/agent_session/commands.clj
+++ b/components/agent-session/src/psi/agent_session/commands.clj
@@ -131,7 +131,7 @@
          "  /thinking [level] — show current thinking level or set level\n"
          "  /remember [text] — capture a memory note for future ψ\n"
          "  /worktree — show git worktree context\n"
-         "  /reload-models — reload custom model definitions from disk\n"
+         "  /reload-models — reload custom model definitions from ~/.psi/agent/models.edn and .psi/models.edn\n"
          "  /reload-extension-installs — reload/apply extension installs from extensions.edn\n"
          "  /jobs [status ...] — list background jobs (default: running,pending-cancel)\n"
          "  /job <job-id> — inspect a background job\n"

--- a/components/agent-session/test/psi/agent_session/commands_test.clj
+++ b/components/agent-session/test/psi/agent_session/commands_test.clj
@@ -532,7 +532,9 @@
                  "/reload-models"
                  "/jobs" "/job" "/cancel-job"
                  "/help" "/prompts" "/skills"]]
-      (is (str/includes? s cmd) (str "help should mention " cmd)))))
+      (is (str/includes? s cmd) (str "help should mention " cmd)))
+    (is (str/includes? s "~/.psi/agent/models.edn"))
+    (is (str/includes? s ".psi/models.edn"))))
 
 (deftest format-prompts-none-test
   (let [[ctx session-id] (make-test-ctx)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -22,6 +22,9 @@ are not written to disk unless you specify a scope when setting them.
 
 ## Config files
 
+For custom provider/model definitions loaded from `models.edn` rather than the
+session settings files documented below, see [`doc/custom-providers.md`](custom-providers.md).
+
 All config files use the same EDN shape:
 
 ```edn

--- a/doc/custom-providers.md
+++ b/doc/custom-providers.md
@@ -1,0 +1,169 @@
+# Custom providers
+
+Psi supports custom LLM providers through `models.edn` files.
+
+This lets you add providers such as MiniMax, Ollama, LM Studio, vLLM, llama.cpp,
+or any other service that exposes an OpenAI-compatible or Anthropic-compatible API.
+
+## File locations
+
+You can define custom providers in either or both of these files:
+
+- user-global: `~/.psi/agent/models.edn`
+- project-local: `<worktree>/.psi/models.edn`
+
+If the same custom provider/model pair appears in both places, the project-local
+entry wins.
+
+Built-in models remain available alongside custom ones.
+
+## What a provider definition contains
+
+Each provider entry defines:
+
+- a provider id, such as `"minimax"` or `"ollama"`
+- `:base-url` — the API root for that provider
+- `:api` — which wire protocol psi should use
+- optional `:auth` settings
+- one or more `:models`
+
+Supported custom-provider API protocols are:
+
+- `:openai-completions`
+- `:anthropic-messages`
+- `:openai-codex-responses`
+
+In practice, most custom hosted providers fit the first two.
+
+## OpenAI-compatible example: MiniMax
+
+Illustrative example: confirm the provider's current base URL and model ids in
+its own docs, then place a definition like this in `~/.psi/agent/models.edn` or
+`.psi/models.edn`:
+
+```clojure
+{:version 1
+ :providers
+ {"minimax"
+  {:base-url "https://api.minimax.chat/v1"
+   :api      :openai-completions
+   :auth     {:api-key "env:MINIMAX_API_KEY"}
+   :models   [{:id                 "MiniMax-M1"
+               :name               "MiniMax M1"
+               :supports-reasoning true
+               :supports-text      true
+               :context-window     128000
+               :max-tokens         16384
+               :latency-tier       :medium
+               :cost-tier          :medium}]}}}
+```
+
+Then export your key:
+
+```bash
+export MINIMAX_API_KEY=...
+```
+
+Notes:
+- the provider id here is `minimax`
+- psi will route requests through its OpenAI-compatible transport because `:api`
+  is `:openai-completions`
+- you can define multiple models under the same provider
+
+## Anthropic-compatible example
+
+If a provider exposes an Anthropic Messages-compatible API, configure it the
+same way but set `:api` to `:anthropic-messages`.
+
+```clojure
+{:version 1
+ :providers
+ {"my-anthropic-proxy"
+  {:base-url "https://example.com/anthropic"
+   :api      :anthropic-messages
+   :auth     {:api-key "env:MY_PROXY_API_KEY"}
+   :models   [{:id                 "proxy-sonnet"
+               :name               "Proxy Sonnet"
+               :supports-reasoning true
+               :supports-text      true
+               :context-window     200000
+               :max-tokens         8192}]}}}
+```
+
+For Anthropic-compatible providers, psi uses the Anthropic transport and will
+send the configured key through the compatible auth path.
+
+## Local servers and custom headers
+
+The `:auth` map supports more than just an API key:
+
+```clojure
+{:auth {:api-key "env:LOCAL_LLM_KEY"
+        :auth-header? false
+        :headers {"X-Client" "psi"}}}
+```
+
+Use cases:
+- `:api-key` — literal key or `"env:VAR_NAME"`
+- `:auth-header? false` — omit the normal auth header for servers that reject it
+- `:headers` — add custom request headers
+
+A common use for `:auth-header? false` is an OpenAI-compatible local server that
+accepts requests without a bearer token and rejects unexpected auth headers.
+
+## Reload after editing
+
+If psi is already running, reload the definitions after editing either models
+file:
+
+```text
+/reload-models
+```
+
+That reloads:
+- `~/.psi/agent/models.edn`
+- `<worktree>/.psi/models.edn`
+
+## Switch to the configured model
+
+After reloading, use the normal model-selection surface.
+
+In-session:
+
+```text
+/model minimax MiniMax-M1
+```
+
+or, for the Anthropic-compatible example:
+
+```text
+/model my-anthropic-proxy proxy-sonnet
+```
+
+Once selected, the custom model behaves like any other model in psi.
+
+## Multiple providers
+
+You can define multiple providers in the same file, for example:
+
+- `minimax`
+- `ollama`
+- `staging-openai`
+- `company-anthropic-proxy`
+
+This already satisfies the issue's requested workflow of configuring multiple
+providers in a config file and switching between them at runtime.
+
+## Troubleshooting
+
+- If psi does not see a newly added provider, run `/reload-models`.
+- If a models file is malformed, psi logs a warning and keeps built-in models available.
+- If a custom provider uses the same `(provider, model-id)` as a built-in model,
+  the custom definition is skipped to avoid shadowing built-ins.
+- If a project-local and user-global definition use the same `(provider, model-id)`,
+  the project-local definition wins.
+
+## Related docs
+
+- [`doc/configuration.md`](configuration.md)
+- [`spec/custom-providers.allium`](../spec/custom-providers.allium)

--- a/munera/open/046-custom-llm-providers/design.md
+++ b/munera/open/046-custom-llm-providers/design.md
@@ -1,0 +1,91 @@
+Goal: close issue #25 by making psi's existing custom LLM provider support discoverable, documented, and easy to configure for real users.
+
+Issue provenance:
+- GitHub issue: #25
+- URL: https://github.com/hugoduncan/psi/issues/25
+
+Context:
+- The issue asks for support for custom providers such as MiniMax that expose OpenAI-compatible or Anthropic-compatible APIs.
+- The issue also describes, as a nice-to-have, configuring new providers in a config file with type, URL, and key so users can define multiple providers and switch between them at runtime.
+- The current codebase already implements this capability through `.psi/models.edn` and `~/.psi/agent/models.edn`:
+  - custom providers can be declared with a provider id, API protocol, base URL, auth config, and models
+  - custom providers dispatch through the built-in OpenAI-compatible or Anthropic-compatible transports according to the declared API
+  - custom provider auth and custom headers are already supported
+  - project-local and user-global model definition files are already loaded and can be reloaded
+  - users can switch models at runtime through the existing model-selection surfaces
+- What is missing is clear operator-facing guidance that tells a user this capability exists, how to configure it, which file to edit, how to reload it, and how to switch to the configured provider/model.
+
+Problem:
+- A user reading the current top-level docs would not reliably discover that psi already supports custom providers through `models.edn`.
+- The repository has implementation, tests, and an internal spec for custom providers, but not a clear user-facing setup guide.
+- As a result, the issue remains effectively unresolved from the user's point of view even though the runtime capability already exists.
+
+Desired outcome:
+- A user who wants to configure MiniMax or another OpenAI-compatible or Anthropic-compatible provider can do so by following repository documentation alone.
+- The docs make the canonical configuration surface explicit:
+  - `~/.psi/agent/models.edn` for user-global custom providers
+  - `<worktree>/.psi/models.edn` for project-local custom providers
+- The docs explain the required provider fields in practical terms:
+  - provider id
+  - API protocol type
+  - base URL
+  - auth configuration
+  - models
+- The docs explain how to reload definitions and how to select the configured model at runtime.
+- The docs include at least one concrete example that maps closely to the issue request, such as MiniMax.
+
+Scope:
+In scope:
+- add a dedicated user-facing guide at `doc/custom-providers.md`
+- document the canonical `models.edn` file locations and precedence
+- document the practical setup flow for OpenAI-compatible and Anthropic-compatible custom providers
+- document auth options that materially affect setup, especially API keys and optional auth-header suppression
+- document runtime usage after configuration, including reload and model switching
+- add concise discoverability links from existing high-traffic docs such as `README.md` and `doc/configuration.md`
+- tighten the `/reload-models` help text so it explicitly points users at the custom-model definition files
+
+Out of scope:
+- redesigning the custom provider data model
+- adding a new configuration mechanism beyond `models.edn`
+- changing model registry precedence or merge semantics
+- adding new transport implementations
+- changing provider execution semantics
+- adding new commands for custom provider management
+- changing the existing runtime model selection behavior
+
+Canonical user flow to document:
+1. Choose the config scope:
+   - user-global: `~/.psi/agent/models.edn`
+   - project-local: `.psi/models.edn`
+2. Define a custom provider entry with:
+   - a provider key
+   - `:base-url`
+   - `:api` set to the compatible wire protocol
+   - optional `:auth`
+   - one or more `:models`
+3. Reload model definitions with `/reload-models` if psi is already running.
+4. Select the configured model through the normal model-selection surface.
+5. Use the model like any other provider/model in psi.
+
+Design decisions:
+- Treat the issue as a discoverability and operator-guidance gap, not as a missing runtime capability.
+- Keep the implementation scoped to user-facing documentation and light discoverability improvements.
+- Preserve the existing `models.edn` configuration shape as the canonical answer to the issue's requested config-file setup.
+- Use examples that demonstrate both the required fields and the runtime workflow after editing the file.
+
+Acceptance:
+- repository documentation clearly states that psi supports custom LLM providers through `models.edn`
+- repository documentation explains both supported custom-provider protocol families:
+  - OpenAI-compatible
+  - Anthropic-compatible
+- repository documentation states where to put custom provider definitions for user-global and project-local scope
+- repository documentation includes a concrete example for a custom provider similar to the issue request
+- repository documentation explains how to reload the definitions and switch to the configured model at runtime
+- discoverability is improved from existing entry-point docs so a user can find this capability without reading source or tests
+- any in-session help text change remains aligned with the documented canonical behavior
+
+Why this design is complete and unambiguous:
+- the runtime capability already exists, so the remaining work is specifically to expose and explain that capability
+- the canonical file surfaces, runtime commands, and supported protocol families already exist in code and tests
+- the task does not depend on unresolved product decisions or new runtime semantics
+- the scope is intentionally narrow: make the existing feature legible and usable from the docs and light UX copy

--- a/munera/open/046-custom-llm-providers/implementation.md
+++ b/munera/open/046-custom-llm-providers/implementation.md
@@ -1,0 +1,20 @@
+Issue provenance:
+- GitHub issue: #25
+- URL: https://github.com/hugoduncan/psi/issues/25
+
+2026-04-22
+- Reviewed the existing implementation and confirmed the runtime already supports the issue's requested capability through `models.edn` files.
+- Chose a documentation-and-discoverability slice rather than inventing a second configuration mechanism, because the requested behavior is already present in code, tests, and spec.
+- Added `doc/custom-providers.md` as the dedicated user-facing guide for custom providers.
+- Documented:
+  - user-global and project-local `models.edn` locations
+  - supported compatible protocol families
+  - provider definition shape
+  - MiniMax-style OpenAI-compatible configuration
+  - Anthropic-compatible configuration
+  - auth options including `env:` keys, optional auth-header suppression, and custom headers
+  - `/reload-models` and `/model` usage after editing config
+  - multiple-provider configuration and precedence behavior
+- Added discoverability links from `README.md` and `doc/configuration.md`.
+- Tightened `/help` text for `/reload-models` so the relevant config files are named directly in-session.
+- Added a focused command-help assertion proving the in-session help now mentions both `~/.psi/agent/models.edn` and `.psi/models.edn`.

--- a/munera/open/046-custom-llm-providers/plan.md
+++ b/munera/open/046-custom-llm-providers/plan.md
@@ -1,0 +1,20 @@
+Approach:
+- Treat issue #25 as a documentation/discoverability task because the runtime already supports custom providers through `models.edn`.
+- Add one dedicated operator-facing guide instead of scattering the full explanation across multiple docs.
+- Improve discoverability from existing entry points (`README.md`, configuration docs, and in-session help text).
+- Keep code changes minimal and scoped to help-text discoverability plus a focused assertion proving the new help copy.
+
+Decisions:
+- Canonical setup guide lives in `doc/custom-providers.md`.
+- The guide should document both user-global and project-local `models.edn` locations.
+- The guide should cover both OpenAI-compatible and Anthropic-compatible providers.
+- MiniMax should appear as the concrete example closest to the reported need.
+- Examples are illustrative; docs should avoid claiming unverifiable provider-specific details beyond the config shape psi expects.
+
+Risks:
+- Provider-specific external details may drift over time, so examples should be framed as patterns users can adapt.
+- Discoverability improvements should not imply a new config surface; they must stay consistent with the existing `models.edn` implementation.
+
+Verification plan:
+- Re-read changed docs and help text for consistency with the existing implementation.
+- Run focused command/help tests for the changed in-session help copy.

--- a/munera/open/046-custom-llm-providers/steps.md
+++ b/munera/open/046-custom-llm-providers/steps.md
@@ -1,0 +1,8 @@
+- [x] Inspect the existing custom-provider implementation and current docs to identify the smallest user-facing gap that keeps issue #25 effectively unresolved
+- [x] Write a dedicated user-facing custom-provider setup guide covering file locations, schema shape, reload workflow, and runtime model selection
+- [x] Add a concrete OpenAI-compatible example close to the issue request, such as MiniMax
+- [x] Document the Anthropic-compatible variant as also supported by the same config surface
+- [x] Add or update discoverability links from `README.md` and other relevant operator-facing docs
+- [x] Review `/help` and nearby command-surface text for a small discoverability improvement if needed
+- [x] Verify the changed docs and any help-text update for coherence with the current implementation
+- [x] Update `implementation.md` with what changed and why

--- a/munera/plan.md
+++ b/munera/plan.md
@@ -13,6 +13,7 @@ Backlog:
 `munera/open/006-agent-tool-skill-prelude-follow-on/`
 `munera/open/040-work-on-execute-function-code-shaping/`
 `munera/open/045-work-on-base-branch-selection/`
+`munera/open/046-custom-llm-providers/`
 
 Notes:
 - `munera/plan.md` is the active project-wide orchestration surface.


### PR DESCRIPTION
## Summary
- add a dedicated custom-provider setup guide covering models.edn locations, protocol types, auth options, reload flow, and runtime model switching
- improve discoverability from the README, configuration docs, and in-session /reload-models help text
- add a focused help-text assertion proving the custom model definition file paths are surfaced in-session

## Outcome
Implementation-complete for the issue as scoped in this branch: the runtime capability already existed, and this PR makes that capability discoverable and usable from the user-facing docs.

## Remaining ambiguities or follow-on work
- provider-specific external details such as exact third-party model ids or endpoint URLs may evolve over time and should be confirmed against provider docs
- no runtime transport or config-shape changes were needed in this slice

Closes #25