### PR TITLE
⚒ add GitHub bug triage workflow and skill

### DIFF
--- a/.psi/prompts/gh-bug-triage.md
+++ b/.psi/prompts/gh-bug-triage.md
@@ -1,0 +1,38 @@
+---
+name: gh-bug-triage
+description: Example invocations for the gh-bug-triage workflow.
+lambda: Show how to invoke the gh-bug-triage workflow to process labeled GitHub bug-triage issues, attempt reproduction in an issue worktree, and either request more information or continue to a fix PR.
+---
+Use this prompt when you want to run the `gh-bug-triage` workflow against GitHub issues labeled for bug triage.
+
+Example invocations:
+
+- Process the next matching issue in the current repository:
+  - `Run workflow gh-bug-triage`
+  - `Use gh-bug-triage`
+
+- Narrow to a specific matching issue number:
+  - `Run workflow gh-bug-triage for issue 123`
+  - `Use gh-bug-triage on 123`
+
+- Repo-qualified issue reference:
+  - `Run workflow gh-bug-triage for hugoduncan/psi#123`
+
+- Full URL:
+  - `Run workflow gh-bug-triage for https://github.com/hugoduncan/psi/issues/123`
+
+Expected outcome:
+- the workflow finds an open issue with both `triage` and `bug` labels
+- creates an issue-specific worktree from `origin/master`
+- attempts reproduction using the `issue-bug-triage` skill
+- if reproduction fails:
+  - posts a concise reply requesting the most useful additional reproduction information
+  - removes the `triage` label
+  - adds the `waiting` label
+- if reproduction succeeds:
+  - creates a Munera task for the bug fix
+  - refines the design and fixes the bug
+  - pushes the branch and creates a PR mentioning the original issue number
+  - removes the `triage` label
+
+When invoked without an explicit issue reference, the workflow should discover and process the next matching issue automatically.

--- a/.psi/skills/issue-bug-triage/SKILL.md
+++ b/.psi/skills/issue-bug-triage/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: issue-bug-triage
+description: Triage a GitHub bug issue by attempting reproduction in an issue-specific worktree, then shape either a precise request for more information or a concrete reproduction handoff into bug-fix execution.
+---
+
+Use this skill for bug reports, especially GitHub issues labeled for triage where the next important question is whether the bug can be reproduced.
+
+A good bug triage will answer the following:
+
+What behavior is being reported?
+Capture the user-visible failure, error, regression, or incorrect behavior as described in the issue.
+
+What behavior was expected?
+If the issue makes the intended behavior clear, state it explicitly. If it does not, say that the expectation is only partially inferable rather than inventing certainty.
+
+How should reproduction be attempted?
+Distill the smallest concrete reproduction plan you can derive from the issue. Prefer the fewest steps that could realistically demonstrate the problem.
+
+Where should reproduction happen?
+Ensure reproduction happens in an issue-specific worktree before attempting investigation so the work is isolated from the current checkout. Treat that worktree as authoritative for reproduction commands, edits, and later implementation if the bug is confirmed.
+
+What was actually observed during reproduction?
+Record the concrete attempt, including the commands, actions, or test paths you used when they matter to understanding the result.
+
+Was the bug reproduced?
+Conclude with one explicit status:
+- `reproducible`
+- `not-yet-reproducible`
+
+If the bug was not reproduced, what information is missing?
+Ask only for the minimum additional information most likely to unblock reproduction, such as exact steps, environment details, sample input, expected output, actual output, logs, screenshots, or version/commit information.
+
+If the bug was reproduced, what evidence should carry forward?
+Leave a concise reproduction handoff that can seed a Munera bug-fix task. Include the reported behavior, expected behavior, concrete reproduction steps, and the observed failing result.
+
+Guidelines:
+- Stay grounded in the issue as written and in observed evidence from the reproduction attempt.
+- Do not pretend a bug is reproduced when it is not.
+- Do not jump into broad implementation planning inside the triage itself.
+- Keep the failed-reproduction reply collaborative and specific rather than generic.
+- Keep the successful-reproduction handoff concrete enough that a follow-on Munera task can start from facts rather than re-discovery.
+- Prefer narrow reproduction over speculative redesign.
+
+Suggested output surfaces:
+- reported behavior
+- expected behavior
+- reproduction plan
+- attempted reproduction
+- reproduction status
+- missing information needed next
+- reproduction evidence for implementation handoff

--- a/.psi/workflows/gh-bug-triage.md
+++ b/.psi/workflows/gh-bug-triage.md
@@ -1,0 +1,140 @@
+---
+name: gh-bug-triage
+description: Find labeled GitHub bug-triage issues, attempt reproduction in an issue worktree, request more information when not reproducible, or fix and PR when reproducible
+---
+{:tools ["read" "bash" "edit" "write" "work-on"]
+ :skills ["issue-bug-triage" "munera-task-design" "work-independently"]
+ :thinking-level :high}
+
+You are executing a focused GitHub bug-triage workflow in this repository.
+
+Goal:
+- Find open GitHub bug issues marked for triage.
+- Read the selected issue carefully.
+- Use the `issue-bug-triage` skill to attempt reproduction in an issue-specific worktree created from `origin/master`.
+- If reproduction fails, post a concise reply requesting the minimum information likely to unblock reproduction, remove the `triage` label, and add `waiting`.
+- If reproduction succeeds, create a Munera task in the issue worktree, refine the design with `munera-task-design`, fix the bug autonomously with `work-independently`, push the branch, create a PR mentioning the original issue number, and remove the `triage` label.
+
+Use the `issue-bug-triage` skill during reproduction and evidence gathering.
+Use the `munera-task-design` skill when shaping the Munera bug-fix task.
+Use the `work-independently` skill once the design is clean and implementation begins.
+
+Primary selection rule:
+- Look for open GitHub issues carrying both the `triage` label and the `bug` label.
+- If there are no matching issues, stop and report that there is nothing to process.
+- If multiple matching issues exist, process them in ascending issue-number order unless the input narrows the target.
+
+Input expectations:
+- `$INPUT` is optional.
+- If provided, treat it as an optional narrowing hint such as an issue number, repo-qualified issue reference, full issue URL, or a short instruction that identifies a specific matching issue.
+- If `$INPUT` is absent, discover candidate issues from labels.
+
+Required procedure:
+
+1. Discover and select the issue.
+   - Use `gh issue list` with JSON output to find open issues with both the `triage` and `bug` labels.
+   - Retrieve enough list information to identify candidates, including at least: number, title, labels, state, and URL.
+   - Treat the current repository as authoritative unless the input explicitly identifies another repository.
+   - If the request input narrows the target, use it to select exactly one matching issue.
+
+2. Read the selected issue.
+   - Use `gh issue view` with JSON output.
+   - Retrieve enough detail to understand and attempt reproduction, including at least: number, title, body, labels, author, assignees, state, and URL.
+   - If the issue cannot be read, stop and report the failure instead of fabricating details.
+
+3. Refresh the base branch.
+   - Run `git fetch origin master`.
+   - Treat `origin/master` as the authoritative base for the reproduction worktree.
+   - If the fetch fails, stop and report the failure rather than proceeding on a stale base.
+
+4. Create the issue worktree before reproduction.
+   - Use the `work-on` tool, not manual `git worktree` shell commands.
+   - Base the worktree on `origin/master`, using the explicit base-branch input supported by `work-on`.
+   - Use a short issue-derived description, such as the issue number plus a concise bug title fragment.
+   - After `work-on`, treat the resulting worktree path as authoritative for all repository edits, git commands, reproduction attempts, and later PR work.
+   - If the `work-on` tool is unavailable, stop and report that limitation instead of improvising another mechanism.
+
+5. Attempt reproduction.
+   - Use the `issue-bug-triage` skill.
+   - Distill the issue into these surfaces:
+     - reported behavior
+     - expected behavior if inferable
+     - reproduction plan
+     - attempted reproduction
+     - reproduction status
+     - missing information needed next
+     - reproduction evidence for implementation handoff
+   - Attempt the smallest concrete reproduction that the issue supports.
+   - Keep the analysis faithful to the issue and to observed runtime/test evidence.
+   - Conclude with exactly one explicit reproduction status: `reproducible` or `not-yet-reproducible`.
+   - Do not claim the bug is reproduced unless the evidence supports that conclusion.
+
+6. If reproduction failed.
+   - Write a concise GitHub reply that says the issue could not yet be reproduced.
+   - Ask only for the most useful additional information likely to unblock reproduction.
+   - Prefer concrete requests such as exact reproduction steps, environment details, logs, screenshots, sample inputs, expected output, actual output, or version/commit details, depending on the issue.
+   - Use `gh issue comment` to post the reply.
+   - If posting the comment fails, stop and report the failure.
+   - Remove the `triage` label from the issue.
+   - Add the `waiting` label to the issue.
+   - Stop after reporting the partial outcome.
+
+7. If reproduction succeeded, create the Munera task.
+   - Orient in Munera inside the issue worktree by reading `munera/plan.md` and inspecting `munera/open/` and `munera/closed/`.
+   - Allocate the next canonical `NNN-slug` task id.
+   - Create a new task directory under `munera/open/NNN-slug/`.
+   - Write at least:
+     - `design.md`
+     - `steps.md`
+     - `implementation.md`
+   - Include issue provenance in the task files, especially the issue number and URL.
+   - Seed the design from the concrete reproduction evidence rather than from speculation.
+
+8. Refine the task design.
+   - Use the `munera-task-design` skill.
+   - Refine until the design is complete and unambiguous enough to pass the Munera design gate.
+   - If the design cannot be made complete and unambiguous without external decisions or new information, stop implementation, preserve the design work, and report that blocked state clearly.
+
+9. If the design is blocked after successful reproduction.
+   - Commit the task-design work in the issue worktree.
+   - Push the branch.
+   - Create a PR that explains the blocked design state and mentions the original issue number.
+   - Remove the `triage` label from the issue.
+   - Do not add `waiting`; this workflow's requested label change on the reproducible path is only to remove `triage`.
+
+10. If the design is clean, fix the bug autonomously.
+   - Follow the `work-independently` skill.
+   - Add or refine `plan.md` only after the design is complete and unambiguous.
+   - Implement the bug fix in small, reviewable steps.
+   - Keep Munera task files synchronized with what was learned and done.
+   - Run relevant verification for the affected area.
+   - If the bug is fixed successfully, commit the work, push the branch, and create a PR.
+   - The PR must mention the original issue number, for example `Closes #<issue-number>` when appropriate.
+   - Remove the `triage` label from the issue.
+
+Execution constraints:
+- Prefer one issue per run unless the input explicitly asks for batch processing.
+- Use `work-on` rather than manual git worktree creation.
+- Reproduction must happen in the issue-specific worktree, not the caller's current checkout.
+- Do not create a Munera task when the issue is not yet reproducible.
+- Do not proceed to implementation on an ambiguous design.
+- Do not invent reproduction evidence, requirements, or bug causes.
+- Keep changes scoped to the selected issue.
+- Preserve Munera protocol distinctions among `design.md`, `plan.md`, `steps.md`, and `implementation.md`.
+
+Suggested GitHub and git command shapes:
+- `gh issue list --state open --label triage --label bug --json number,title,labels,state,url`
+- `gh issue view "$ISSUE" --json number,title,body,labels,author,assignees,state,url`
+- `git fetch origin master`
+- `gh issue comment "$ISSUE" --body-file <path-or-stdin>`
+- `gh issue edit "$ISSUE" --remove-label triage --add-label waiting`
+- `gh issue edit "$ISSUE" --remove-label triage`
+- `gh pr create ...`
+
+Final response requirements:
+- Report the selected issue.
+- State whether reproduction succeeded.
+- State whether a worktree was created and give its path when available.
+- If reproduction failed, summarize the information requested and state whether labels were updated from `triage` to `waiting`.
+- If reproduction succeeded, report the created Munera task id/path, whether the result was design-only or implementation-complete, the pushed branch name, and the PR URL if created.
+- If nothing matched, say so clearly.

--- a/munera/open/047-gh-issue-bug-triage-workflow/design.md
+++ b/munera/open/047-gh-issue-bug-triage-workflow/design.md
@@ -1,0 +1,123 @@
+Goal: add a GitHub bug-triage workflow and companion bug-triage skill that can find labeled bug issues, attempt reproduction in an issue-specific worktree, and either request more information or continue through fix-and-PR completion.
+
+Issue provenance:
+- branch/worktree intent: `gh-bug-triage`
+
+Intent:
+- automate first-response handling for GitHub bug reports that are ready for triage
+- make reproduction attempts happen in an isolated issue-specific worktree rather than the current checkout
+- distinguish clearly between bugs that are reproducible now and bugs that still need reporter information
+- reuse existing Munera-task design and autonomous implementation skills when reproduction succeeds
+
+Context:
+- the repository already has:
+  - `gh-issue-ingest` workflow for enhancement/feature triage
+  - `gh-issue-implement` workflow for implementation-labeled issues
+  - `issue-feature-triage` skill for concise issue analysis
+  - `munera-task-design` and `work-independently` skills for design and autonomous execution
+  - `work-on` command/tool for creating issue-specific worktrees, including explicit base-branch support
+- there is not yet a workflow dedicated to bug issues labeled for triage and reproduction
+- there is not yet a skill dedicated to bug reproduction triage and evidence gathering
+
+Problem:
+- bug reports need a different triage path than enhancement requests
+- feature-triage analysis is not sufficient for bug reports because the key first branch is whether the issue can be reproduced
+- without a dedicated bug workflow, the reproduction step, label transitions, issue reply content, and handoff into fix implementation remain inconsistent and manual
+
+Desired outcome:
+- a new workflow can find open GitHub issues carrying both `triage` and `bug` labels
+- the workflow uses a new `issue-bug-triage` skill to:
+  - read the selected issue carefully
+  - create an issue-specific worktree using `work-on` from `origin/master`
+  - attempt to reproduce the reported bug in that worktree
+  - capture a concise, concrete reproduction assessment
+- when reproduction fails:
+  - the workflow posts a GitHub reply that clearly says reproduction did not succeed
+  - the reply asks for the minimum additional information most likely to make reproduction possible
+  - the workflow removes `triage` and adds `waiting`
+  - the workflow stops without creating a Munera task or PR
+- when reproduction succeeds:
+  - the workflow creates a new Munera task in the issue worktree
+  - the workflow uses `munera-task-design` to refine the task design until it is complete and unambiguous
+  - the workflow then fixes the bug in that worktree
+  - the workflow commits, pushes the branch, and creates a PR that mentions the original issue number
+  - the workflow removes the `triage` label from the original issue
+  - adding `waiting` on the success path is out of scope and not required
+
+Scope:
+In scope:
+- add a new skill at `.psi/skills/issue-bug-triage/SKILL.md`
+- add a new workflow at `.psi/workflows/gh-bug-triage.md`
+- add a prompt/example invocation doc for the workflow
+- make the workflow select issues by `triage` + `bug` labels
+- make the workflow instruct use of `issue-bug-triage`, `munera-task-design`, and `work-independently`
+- make the workflow explicitly use an issue-specific worktree created via `work-on` from `origin/master`
+- define the two outcome branches:
+  - reproduction failed -> comment + relabel to `waiting`
+  - reproduction succeeded -> create Munera task -> fix bug -> push -> PR -> remove `triage`
+
+Out of scope:
+- adding new runtime support for GitHub or worktree operations
+- changing `work-on` semantics
+- changing Munera task protocol
+- implementing a general bug-classification schema beyond what the new skill needs
+- forcing every successful reproduction to add more labels than requested
+- changing existing enhancement-ingest or implementation workflow behavior
+
+Canonical workflow behavior:
+1. discover open GitHub issues with both `triage` and `bug` labels
+2. select one issue, preferring ascending issue-number order unless input narrows the target
+3. read the issue in detail
+4. use `issue-bug-triage`
+5. inside that skill-driven reproduction phase:
+   - fetch `origin/master`
+   - create an issue-specific worktree with `work-on` using `base_branch origin/master`
+   - treat the returned worktree path as authoritative
+   - attempt reproduction in that isolated worktree
+   - produce one of two explicit outcomes:
+     - reproducible
+     - not reproducible with current information
+6. if not reproducible:
+   - post a concise request-for-information comment tailored to reproduction needs
+   - remove `triage`
+   - add `waiting`
+   - stop
+7. if reproducible:
+   - create a new Munera task in the issue worktree using the next canonical task id
+   - record issue provenance in task files
+   - refine the task design with `munera-task-design`
+   - when design is clean, implement the fix autonomously with `work-independently`
+   - run relevant verification
+   - commit and push the branch
+   - create a PR mentioning the original issue number, ideally with `Closes #<n>` when appropriate
+   - remove `triage` from the issue
+
+Skill contract for `issue-bug-triage`:
+- the skill is for bug reports, not feature requests
+- it should stay grounded in the issue as written and in observed reproduction evidence
+- it should create/use an issue-specific worktree before attempting reproduction
+- it should extract and structure:
+  - reported behavior
+  - expected behavior if inferable from the issue
+  - attempted reproduction steps
+  - observed reproduction result
+  - reproduction status: reproducible | not-yet-reproducible
+  - missing information most likely to unblock reproduction
+- on failed reproduction, it should help shape a concise GitHub reply requesting only the most useful missing information
+- on successful reproduction, it should provide enough concrete reproduction evidence to seed a Munera bug-fix task design
+
+Acceptance:
+- `.psi/skills/issue-bug-triage/SKILL.md` exists and clearly describes bug reproduction triage in an issue-specific worktree
+- `.psi/workflows/gh-bug-triage.md` exists and targets GitHub issues labeled `triage` and `bug`
+- the workflow explicitly uses the new skill for reproduction
+- the workflow explicitly branches on reproduction failure vs success
+- the failure branch posts a GitHub comment requesting reproduction-helping information, removes `triage`, and adds `waiting`
+- the success branch creates a Munera task, uses `munera-task-design`, fixes the bug, pushes a branch, creates a PR mentioning the original issue number, and removes `triage`
+- the workflow uses the issue-specific worktree path returned from `work-on` as the authoritative location for edits and git commands
+- the enhancement-ingest workflow and existing issue-feature-triage skill remain unchanged
+
+Why this design is complete and unambiguous:
+- it defines one issue-selection rule, one reproduction gate, and two explicit outcome branches
+- it names the exact labels involved on each branch
+- it reuses existing repository capabilities instead of requiring new runtime behavior
+- it separates bug reproduction triage from later fix implementation while still connecting them on the reproducible path

--- a/munera/open/047-gh-issue-bug-triage-workflow/implementation.md
+++ b/munera/open/047-gh-issue-bug-triage-workflow/implementation.md
@@ -1,0 +1,11 @@
+2026-04-23
+
+- Created task `047-gh-issue-bug-triage-workflow` to add a bug-specific GitHub workflow parallel to the existing enhancement-ingest workflow.
+- Chose to implement this as workflow/skill/prompt/task-definition content only, reusing existing `work-on`, `munera-task-design`, and `work-independently` capabilities.
+- Intended new surfaces:
+  - `.psi/skills/issue-bug-triage/SKILL.md`
+  - `.psi/workflows/gh-bug-triage.md`
+  - `.psi/prompts/gh-bug-triage.md`
+- Key behavioral split captured in design:
+  - if reproduction fails, comment on the issue asking for reproduction-helping information and relabel from `triage` to `waiting`
+  - if reproduction succeeds, create a Munera task, fix the bug in the issue worktree, push, create a PR mentioning the issue, and remove `triage`

--- a/munera/open/047-gh-issue-bug-triage-workflow/plan.md
+++ b/munera/open/047-gh-issue-bug-triage-workflow/plan.md
@@ -1,0 +1,29 @@
+Approach:
+- Keep the change documentation-only and workflow-definition-only unless a real loader/runtime gap is discovered.
+- Reuse the established pattern from `gh-issue-ingest` and `gh-issue-implement` rather than inventing a new workflow shape.
+- Add one new bug-focused skill, one new workflow, and one prompt/example file.
+- Record the task in `munera/plan.md` so the new work is part of active orchestration.
+
+Decisions:
+- Workflow name: `gh-bug-triage`.
+- Skill name: `issue-bug-triage`.
+- The workflow should declare tools `read`, `bash`, `edit`, `write`, and `work-on` because it needs GitHub CLI, task-file creation, and issue-specific worktree creation.
+- The workflow should declare skills `issue-bug-triage`, `munera-task-design`, and `work-independently`.
+- The reproduction phase should explicitly create the issue worktree from `origin/master` via `work-on` with `base_branch`/`--base` support.
+- The workflow should process one issue per run unless narrowed input specifies a particular issue.
+
+Implementation steps:
+1. Add the Munera task and update `munera/plan.md`.
+2. Add `.psi/skills/issue-bug-triage/SKILL.md`.
+3. Add `.psi/workflows/gh-bug-triage.md`, mirroring the clarity and structure of the existing GitHub workflows.
+4. Add `.psi/prompts/gh-bug-triage.md` with example invocations and expected outcome.
+5. Re-read the new files for coherence with existing `gh-issue-ingest` and `gh-issue-implement` behavior.
+
+Verification:
+- Read the new workflow/skill/prompt files for consistency and completeness.
+- Ensure label names and branch behavior exactly match the requested contract.
+- Ensure the workflow refers to the correct existing skills and tools and does not require nonexistent mechanisms.
+
+Risks:
+- The exact GitHub reply wording on the failure branch should stay helpful but not over-prescriptive.
+- The workflow should not imply that reproduction is guaranteed; it must allow a clean not-yet-reproducible outcome.

--- a/munera/open/047-gh-issue-bug-triage-workflow/steps.md
+++ b/munera/open/047-gh-issue-bug-triage-workflow/steps.md
@@ -1,0 +1,8 @@
+- [x] Create Munera task `047-gh-issue-bug-triage-workflow`
+- [x] Capture a complete design for bug-triage workflow behavior and outcome branches
+- [x] Write the new `issue-bug-triage` skill
+- [x] Write the new `gh-bug-triage` workflow
+- [x] Add a prompt/example file for `gh-bug-triage`
+- [x] Add the task to `munera/plan.md`
+- [x] Re-read changed files for coherence and adjust wording if needed
+- [x] Summarize the resulting workflow/skill contract for handoff

--- a/munera/plan.md
+++ b/munera/plan.md
@@ -15,6 +15,7 @@ Backlog:
 `munera/open/045-work-on-base-branch-selection/`
 `munera/open/046-custom-llm-providers/`
 `munera/open/046-tui-tmux-end-to-end-integration-test/`
+`munera/open/047-gh-issue-bug-triage-workflow/`
 
 Notes:
 - `munera/plan.md` is the active project-wide orchestration surface.


### PR DESCRIPTION
## Summary
- add a new `gh-bug-triage` workflow for GitHub issues labeled `triage` + `bug`
- add a new `issue-bug-triage` skill focused on reproduction-oriented bug triage in an issue-specific worktree
- add prompt examples and a Munera task documenting the workflow design and execution contract

## Outcome
- bug-triage can now branch cleanly between:
  - not-yet-reproducible: comment requesting the most useful missing information, remove `triage`, add `waiting`
  - reproducible: create a Munera task, refine design, fix autonomously, push, create a PR, remove `triage`

## Notes
- modeled closely on the existing `gh-issue-ingest` and `gh-issue-implement` workflows
- explicitly uses `work-on` with `origin/master` as the authoritative base for the issue-specific worktree
- keeps success-path label handling limited to removing `triage`
