### PR TITLE
Add Opus 4.7 and GPT-5.5 model support

### DIFF
--- a/components/agent-session/src/psi/agent_session/tool_defs.clj
+++ b/components/agent-session/src/psi/agent_session/tool_defs.clj
@@ -4,6 +4,7 @@
    Canonical shape is owned by agent-session and keeps `:parameters` as data.
    Boundary projections adapt that shape for agent-core and provider use."
   (:require
+   [cheshire.core :as json]
    [clojure.edn :as edn]))
 
 (defn- empty-object-schema []
@@ -16,13 +17,19 @@
     (merge (empty-object-schema) parameters)
 
     (string? parameters)
-    (try
-      (let [v (edn/read-string parameters)]
-        (if (map? v)
-          (merge (empty-object-schema) v)
-          (empty-object-schema)))
-      (catch Exception _
-        (empty-object-schema)))
+    (or (try
+          (let [v (json/parse-string parameters true)]
+            (when (map? v)
+              (merge (empty-object-schema) v)))
+          (catch Exception _
+            nil))
+        (try
+          (let [v (edn/read-string parameters)]
+            (when (map? v)
+              (merge (empty-object-schema) v)))
+          (catch Exception _
+            nil))
+        (empty-object-schema))
 
     (nil? parameters) (empty-object-schema)
     :else (empty-object-schema)))
@@ -72,9 +79,11 @@
   "Project a canonical or richer tool map into provider-facing conversation shape."
   [tool]
   (when-let [name (some-> (:name tool) str not-empty)]
-    {:name        name
-     :description (or (some-> (:description tool) str) "")
-     :parameters  (parse-parameters (:parameters tool))}))
+    (cond-> {:name        name
+             :description (or (some-> (:description tool) str) "")
+             :parameters  (parse-parameters (:parameters tool))}
+      (:cache-control tool)
+      (assoc :cache-control (:cache-control tool)))))
 
 (defn provider-tools
   [tools]

--- a/components/agent-session/test/psi/agent_session/tool_defs_test.clj
+++ b/components/agent-session/test/psi/agent_session/tool_defs_test.clj
@@ -21,13 +21,24 @@
           normalized (tool-defs/normalize-tool-def {:name "x" :execute exec-fn})]
       (is (identical? exec-fn (:execute normalized)))))
 
-  (testing "string parameters are parsed into canonical data when possible"
+  (testing "EDN string parameters are parsed into canonical data when possible"
     (let [tool {:name "x"
                 :label "X"
                 :description "desc"
                 :parameters "{:type \"object\" :required [\"p\"]}"}
           normalized (tool-defs/normalize-tool-def tool)]
       (is (= {:type "object" :properties {} :required ["p"]}
+             (:parameters normalized)))))
+
+  (testing "JSON string parameters are parsed into canonical data when possible"
+    (let [tool {:name "x"
+                :label "X"
+                :description "desc"
+                :parameters "{\"type\":\"object\",\"properties\":{\"p\":{\"type\":\"string\"}},\"required\":[\"p\"]}"}
+          normalized (tool-defs/normalize-tool-def tool)]
+      (is (= {:type "object"
+              :properties {:p {:type "string"}}
+              :required ["p"]}
              (:parameters normalized)))))
 
   (testing "invalid parameter strings degrade to empty object schema"

--- a/components/ai/src/psi/ai/conversation.clj
+++ b/components/ai/src/psi/ai/conversation.clj
@@ -1,6 +1,7 @@
 (ns psi.ai.conversation
   "Conversation entity and lifecycle management"
-  (:require [psi.ai.schemas :as schemas])
+  (:require [psi.ai.schemas :as schemas]
+            [psi.agent-session.tool-defs :as tool-defs])
   (:import [java.time Instant]
            [java.util UUID]))
 
@@ -135,7 +136,7 @@
   "Add tool to conversation"
   [conversation tool]
   (update-conversation conversation (fn [conversation]
-                                      (update conversation :tools conj tool))))
+                                      (update conversation :tools conj (tool-defs/provider-tool tool)))))
 
 ;; Derived data
 

--- a/components/ai/src/psi/ai/models.clj
+++ b/components/ai/src/psi/ai/models.clj
@@ -146,7 +146,23 @@
     :input-cost 1.0
     :output-cost 5.0
     :cache-read-cost 0.1
-    :cache-write-cost 1.25}})
+    :cache-write-cost 1.25}
+
+   :opus-4.7
+   {:id "claude-opus-4-7"
+    :name "Claude Opus 4.7"
+    :provider :anthropic
+    :api :anthropic-messages
+    :base-url "https://api.anthropic.com"
+    :supports-reasoning true
+    :supports-images true
+    :supports-text true
+    :context-window 1000000
+    :max-tokens 131072
+    :input-cost 5.0
+    :output-cost 25.0
+    :cache-read-cost 0.5
+    :cache-write-cost 6.25}})
 
 (def openai-models
   {:gpt-4o
@@ -483,6 +499,39 @@
     :input-cost 2.5
     :output-cost 15.0
     :cache-read-cost 0.25
+    :cache-write-cost 0.0}
+
+   :gpt-5.4-mini
+   {:id "gpt-5.4-mini"
+    :name "GPT-5.4 Mini"
+    :provider :openai
+    :api :openai-completions
+    :base-url "https://api.openai.com/v1"
+    :supports-reasoning true
+    :supports-images true
+    :supports-text true
+    :context-window 400000
+    :max-tokens 128000
+    :input-cost 0.75
+    :output-cost 4.5
+    :cache-read-cost 0.0
+    :cache-write-cost 0.0}
+
+   :gpt-5.5
+   {:id "gpt-5.5"
+    :name "GPT-5.5"
+    :provider :openai
+    :api :openai-completions
+    :base-url "https://api.openai.com/v1"
+    :supports-reasoning true
+    :supports-images true
+    :supports-text true
+    :context-window 1000000
+    :max-tokens 128000
+    :input-cost 5.0
+    :output-cost 30.0
+    ;; cache-read cost not published by OpenAI at time of writing
+    :cache-read-cost 0.0
     :cache-write-cost 0.0}})
 
 (def ^:private provider-defaults

--- a/components/ai/src/psi/ai/models.clj
+++ b/components/ai/src/psi/ai/models.clj
@@ -533,8 +533,7 @@
     :max-tokens 128000
     :input-cost 5.0
     :output-cost 30.0
-    ;; cache-read cost not published by OpenAI at time of writing
-    :cache-read-cost 0.0
+    :cache-read-cost 0.5
     :cache-write-cost 0.0}})
 
 (def ^:private provider-defaults

--- a/components/ai/src/psi/ai/models.clj
+++ b/components/ai/src/psi/ai/models.clj
@@ -161,7 +161,7 @@
     :supports-images true
     :supports-text true
     :context-window 1000000
-    :max-tokens 131072
+    :max-tokens 128000
     :input-cost 5.0
     :output-cost 25.0
     :cache-read-cost 0.5

--- a/components/ai/src/psi/ai/models.clj
+++ b/components/ai/src/psi/ai/models.clj
@@ -155,6 +155,9 @@
     :api :anthropic-messages
     :base-url "https://api.anthropic.com"
     :supports-reasoning true
+    ;; Opus 4.7 uses adaptive thinking — a different API protocol from
+    ;; extended thinking (budget_tokens). See providers/anthropic.clj.
+    :adaptive-thinking true
     :supports-images true
     :supports-text true
     :context-window 1000000

--- a/components/ai/src/psi/ai/providers/anthropic.clj
+++ b/components/ai/src/psi/ai/providers/anthropic.clj
@@ -204,10 +204,13 @@
 ;; Extended thinking: budget_tokens per level. Adaptive thinking (Opus 4.7+): effort string.
 (def ^:private thinking-level->budget
   {:off nil :minimal 1024 :low 2048 :medium 8000 :high 16000 :xhigh 32000})
+
 (def ^:private thinking-level->effort
   {:off nil :minimal "low" :low "low" :medium "medium" :high "high" :xhigh "high"})
 
-(defn- adaptive-thinking? [model] (boolean (:adaptive-thinking model)))
+(defn- adaptive-thinking?
+  [model]
+  (boolean (:adaptive-thinking model)))
 
 (defn- thinking-param
   "Extended thinking → {:type \"enabled\" :budget_tokens N}.

--- a/components/ai/src/psi/ai/providers/anthropic.clj
+++ b/components/ai/src/psi/ai/providers/anthropic.clj
@@ -202,6 +202,8 @@
             (:messages conversation))))
 
 (def ^:private thinking-level->budget
+  "Extended thinking budget_tokens map — used for all reasoning models
+   except those with :adaptive-thinking true (e.g. Opus 4.7)."
   {:off     nil
    :minimal 1024
    :low     2048
@@ -209,12 +211,37 @@
    :high    16000
    :xhigh   32000})
 
+(def ^:private thinking-level->effort
+  "Adaptive thinking effort map — used for models with :adaptive-thinking true."
+  {:off     nil
+   :minimal "low"
+   :low     "low"
+   :medium  "medium"
+   :high    "high"
+   :xhigh   "high"})
+
+(defn- adaptive-thinking?
+  "True when the model uses Anthropic adaptive thinking (e.g. Opus 4.7).
+   Adaptive thinking uses output_config.effort rather than budget_tokens,
+   and must not send the interleaved-thinking beta header."
+  [model]
+  (boolean (:adaptive-thinking model)))
+
 (defn- thinking-param
+  "Return the :thinking body param for the request, or nil when thinking is off.
+
+   Extended thinking models: {:type \"enabled\" :budget_tokens N}
+   Adaptive thinking models:  {:type \"adaptive\" :display \"summarized\"}"
   [model options]
   (when (:supports-reasoning model)
-    (when-let [budget (get thinking-level->budget (:thinking-level options))]
-      {:type          "enabled"
-       :budget_tokens budget})))
+    (let [level (:thinking-level options)]
+      (if (adaptive-thinking? model)
+        (when (get thinking-level->effort level)
+          {:type    "adaptive"
+           :display "summarized"})
+        (when-let [budget (get thinking-level->budget level)]
+          {:type          "enabled"
+           :budget_tokens budget})))))
 
 (defn- tool-definitions
   [conversation]
@@ -251,28 +278,34 @@
       (cache-control-present? (:messages conversation))))
 
 (defn- beta-header
-  [oauth? thinking prompt-caching?]
-  (let [betas (cond-> []
-                oauth?          (into [claude-code-beta
-                                       oauth-beta
-                                       context-management-beta
-                                       prompt-caching-scope-beta])
-                thinking        (conj interleaved-thinking-beta)
-                prompt-caching? (conj prompt-caching-beta))]
+  "Build the anthropic-beta header value.
+
+   Extended thinking adds interleaved-thinking-beta.
+   Adaptive thinking (Opus 4.7+) must NOT add interleaved-thinking-beta —
+   it uses a different protocol and the header causes a 400 error."
+  [oauth? thinking adaptive? prompt-caching?]
+  (let [extended-thinking? (and thinking (not adaptive?))
+        betas (cond-> []
+                oauth?               (into [claude-code-beta
+                                            oauth-beta
+                                            context-management-beta
+                                            prompt-caching-scope-beta])
+                extended-thinking?   (conj interleaved-thinking-beta)
+                prompt-caching?      (conj prompt-caching-beta))]
     (when (seq betas)
       (->> betas
            distinct
            (str/join ",")))))
 
 (defn- request-headers
-  [api-key thinking prompt-caching?]
+  [api-key thinking adaptive? prompt-caching?]
   (let [oauth?       (oauth-api-key? api-key)
         base-headers {"Content-Type"      "application/json"
                       "anthropic-version" anthropic-version}
         headers      (if oauth?
                        (assoc base-headers "Authorization" (str "Bearer " api-key))
                        (assoc base-headers "x-api-key" api-key))
-        beta         (beta-header oauth? thinking prompt-caching?)]
+        beta         (beta-header oauth? thinking adaptive? prompt-caching?)]
     (cond-> headers
       beta (assoc "anthropic-beta" beta))))
 
@@ -321,10 +354,25 @@
                        :provider :anthropic})))
     api-key))
 
+(defn- adaptive-effort
+  "Return the output_config effort string for an adaptive thinking request, or nil."
+  [model options]
+  (when (adaptive-thinking? model)
+    (get thinking-level->effort (:thinking-level options))))
+
 (defn build-request
-  "Build Anthropic API request map."
+  "Build Anthropic API request map.
+
+   Extended thinking models (e.g. Opus 4.6): thinking={type:enabled,budget_tokens:N}
+     + interleaved-thinking beta header + no temperature.
+   Adaptive thinking models (e.g. Opus 4.7): thinking={type:adaptive,display:summarized}
+     + output_config={effort:\"...\"}  + no interleaved-thinking beta + no temperature.
+   Non-reasoning models: temperature set, no thinking param."
   [conversation model options]
   (let [thinking        (thinking-param model options)
+        adaptive?       (adaptive-thinking? model)
+        effort          (when (and thinking adaptive?)
+                          (adaptive-effort model options))
         api-key         (resolve-api-key options)
         tool-defs       (tool-definitions conversation)
         system-body     (system-prompt-body conversation)
@@ -334,16 +382,20 @@
                                  :messages   (transform-messages conversation)
                                  :stream     true}
                           (some? system-body) (assoc :system system-body)
-                          ;; temperature is incompatible with extended thinking
-                          (not thinking)      (assoc :temperature (or (:temperature options) 0.7))
+                          ;; temperature is incompatible with extended thinking, and is a 400
+                          ;; error on adaptive-thinking models (Opus 4.7+) even when thinking=off
+                          (and (not thinking)
+                               (not adaptive?)) (assoc :temperature (or (:temperature options) 0.7))
                           thinking            (assoc :thinking thinking)
+                          ;; adaptive thinking uses output_config.effort instead of budget_tokens
+                          effort              (assoc :output_config {:effort effort})
                           (seq tool-defs)     (assoc :tools tool-defs))
         body*           (request-schema/validate-request-body! body)
         base-hdrs       (if (:no-auth-header options)
                           ;; Strip auth headers when explicitly disabled
-                          (dissoc (request-headers api-key thinking prompt-caching?)
+                          (dissoc (request-headers api-key thinking adaptive? prompt-caching?)
                                   "Authorization" "x-api-key")
-                          (request-headers api-key thinking prompt-caching?))
+                          (request-headers api-key thinking adaptive? prompt-caching?))
         headers         (if-let [custom (:headers options)]
                           (merge base-hdrs custom)
                           base-hdrs)]

--- a/components/ai/src/psi/ai/providers/anthropic.clj
+++ b/components/ai/src/psi/ai/providers/anthropic.clj
@@ -201,47 +201,25 @@
             []
             (:messages conversation))))
 
+;; Extended thinking: budget_tokens per level. Adaptive thinking (Opus 4.7+): effort string.
 (def ^:private thinking-level->budget
-  "Extended thinking budget_tokens map — used for all reasoning models
-   except those with :adaptive-thinking true (e.g. Opus 4.7)."
-  {:off     nil
-   :minimal 1024
-   :low     2048
-   :medium  8000
-   :high    16000
-   :xhigh   32000})
-
+  {:off nil :minimal 1024 :low 2048 :medium 8000 :high 16000 :xhigh 32000})
 (def ^:private thinking-level->effort
-  "Adaptive thinking effort map — used for models with :adaptive-thinking true."
-  {:off     nil
-   :minimal "low"
-   :low     "low"
-   :medium  "medium"
-   :high    "high"
-   :xhigh   "high"})
+  {:off nil :minimal "low" :low "low" :medium "medium" :high "high" :xhigh "high"})
 
-(defn- adaptive-thinking?
-  "True when the model uses Anthropic adaptive thinking (e.g. Opus 4.7).
-   Adaptive thinking uses output_config.effort rather than budget_tokens,
-   and must not send the interleaved-thinking beta header."
-  [model]
-  (boolean (:adaptive-thinking model)))
+(defn- adaptive-thinking? [model] (boolean (:adaptive-thinking model)))
 
 (defn- thinking-param
-  "Return the :thinking body param for the request, or nil when thinking is off.
-
-   Extended thinking models: {:type \"enabled\" :budget_tokens N}
-   Adaptive thinking models:  {:type \"adaptive\" :display \"summarized\"}"
+  "Extended thinking → {:type \"enabled\" :budget_tokens N}.
+   Adaptive thinking (Opus 4.7+) → {:type \"adaptive\" :display \"summarized\"}."
   [model options]
   (when (:supports-reasoning model)
     (let [level (:thinking-level options)]
       (if (adaptive-thinking? model)
         (when (get thinking-level->effort level)
-          {:type    "adaptive"
-           :display "summarized"})
+          {:type "adaptive" :display "summarized"})
         (when-let [budget (get thinking-level->budget level)]
-          {:type          "enabled"
-           :budget_tokens budget})))))
+          {:type "enabled" :budget_tokens budget})))))
 
 (defn- tool-definitions
   [conversation]
@@ -278,11 +256,7 @@
       (cache-control-present? (:messages conversation))))
 
 (defn- beta-header
-  "Build the anthropic-beta header value.
-
-   Extended thinking adds interleaved-thinking-beta.
-   Adaptive thinking (Opus 4.7+) must NOT add interleaved-thinking-beta —
-   it uses a different protocol and the header causes a 400 error."
+  ;; Adaptive thinking (Opus 4.7+) must NOT include interleaved-thinking-beta.
   [oauth? thinking adaptive? prompt-caching?]
   (let [extended-thinking? (and thinking (not adaptive?))
         betas (cond-> []
@@ -354,25 +328,13 @@
                        :provider :anthropic})))
     api-key))
 
-(defn- adaptive-effort
-  "Return the output_config effort string for an adaptive thinking request, or nil."
-  [model options]
-  (when (adaptive-thinking? model)
-    (get thinking-level->effort (:thinking-level options))))
-
 (defn build-request
-  "Build Anthropic API request map.
-
-   Extended thinking models (e.g. Opus 4.6): thinking={type:enabled,budget_tokens:N}
-     + interleaved-thinking beta header + no temperature.
-   Adaptive thinking models (e.g. Opus 4.7): thinking={type:adaptive,display:summarized}
-     + output_config={effort:\"...\"}  + no interleaved-thinking beta + no temperature.
-   Non-reasoning models: temperature set, no thinking param."
+  "Build Anthropic API request map."
   [conversation model options]
   (let [thinking        (thinking-param model options)
         adaptive?       (adaptive-thinking? model)
         effort          (when (and thinking adaptive?)
-                          (adaptive-effort model options))
+                          (get thinking-level->effort (:thinking-level options)))
         api-key         (resolve-api-key options)
         tool-defs       (tool-definitions conversation)
         system-body     (system-prompt-body conversation)

--- a/components/ai/src/psi/ai/providers/anthropic/request_schema.clj
+++ b/components/ai/src/psi/ai/providers/anthropic/request_schema.clj
@@ -72,10 +72,30 @@
    [:text :string]
    [:cache_control {:optional true} anthropic-cache-control-schema]])
 
-(def ^:private anthropic-thinking-schema
+(def ^:private anthropic-extended-thinking-schema
+  "Extended thinking — used by Opus 4.6 and earlier reasoning models."
   [:map {:closed true}
    [:type [:= "enabled"]]
    [:budget_tokens pos-int?]])
+
+(def ^:private anthropic-adaptive-thinking-schema
+  "Adaptive thinking — used by Opus 4.7+. No budget_tokens; effort is in output_config."
+  [:map {:closed true}
+   [:type [:= "adaptive"]]
+   [:display {:optional true} [:enum "summarized" "omitted"]]])
+
+(def ^:private anthropic-thinking-schema
+  [:or
+   anthropic-extended-thinking-schema
+   anthropic-adaptive-thinking-schema])
+
+(def ^:private anthropic-output-config-schema
+  "output_config — used with adaptive thinking to specify effort level."
+  [:map {:closed true}
+   [:effort [:enum "low" "medium" "high"]]
+   [:task_budget {:optional true} [:map
+                                   [:type [:= "tokens"]]
+                                   [:total pos-int?]]]])
 
 (def ^:private anthropic-request-body-schema
   [:map {:closed true}
@@ -86,6 +106,7 @@
    [:system {:optional true} [:or :string [:sequential anthropic-system-block-schema]]]
    [:temperature {:optional true} number?]
    [:thinking {:optional true} anthropic-thinking-schema]
+   [:output_config {:optional true} anthropic-output-config-schema]
    [:tools {:optional true} [:sequential anthropic-tool-schema]]])
 
 (defn- request-shape-error-message

--- a/components/ai/src/psi/ai/providers/anthropic/request_support.clj
+++ b/components/ai/src/psi/ai/providers/anthropic/request_support.clj
@@ -120,7 +120,8 @@
       (-> request
           (update-request-headers #(remove-beta-values %
                                                        #{interleaved-thinking-beta}))
-          (update-request-body #(dissoc % :thinking))))
+          ;; Strip both extended-thinking and adaptive-thinking params
+          (update-request-body #(dissoc % :thinking :output_config))))
 
     :without-all-betas
     #(update-request-headers % clear-beta-header)
@@ -139,6 +140,9 @@
   (beta-present? (:headers request) prompt-caching-beta))
 
 (defn thinking-request?
+  "True when the request has any form of thinking enabled:
+   - extended thinking: interleaved-thinking beta header or :thinking body key
+   - adaptive thinking: :thinking body key with type=adaptive (no beta header)"
   [request interleaved-thinking-beta]
   (or (beta-present? (:headers request) interleaved-thinking-beta)
       (contains? (or (request-body-map request) {}) :thinking)))

--- a/components/ai/src/psi/ai/schemas.clj
+++ b/components/ai/src/psi/ai/schemas.clj
@@ -139,6 +139,7 @@
    [:api Api]
    [:base-url string?]
    [:supports-reasoning boolean?]
+   [:adaptive-thinking {:optional true} boolean?]
    [:supports-images boolean?]
    [:supports-text boolean?]
    [:context-window pos-int?]

--- a/components/ai/test/psi/ai/core_test.clj
+++ b/components/ai/test/psi/ai/core_test.clj
@@ -42,6 +42,13 @@
       (is (= :openai (:provider model)))
       (is (= :openai-completions (:api model)))))
 
+  (testing "Adaptive thinking Anthropic model validation"
+    (let [model (models/get-model :opus-4.7)]
+      (is (schemas/valid? schemas/Model model))
+      (is (= :anthropic (:provider model)))
+      (is (= :anthropic-messages (:api model)))
+      (is (= true (:adaptive-thinking model)))))
+
   (testing "GPT-5 Codex family models are registered"
     (doseq [k [:gpt-5.2-codex :gpt-5.3-codex :gpt-5.3-codex-spark :gpt-5.4]]
       (let [model (models/get-model k)]

--- a/components/ai/test/psi/ai/model_registry_test.clj
+++ b/components/ai/test/psi/ai/model_registry_test.clj
@@ -48,8 +48,11 @@
   (testing "catalog includes built-in models"
     (let [models (registry/all-models)]
       (is (pos? (count models)))
-      ;; Check a known built-in exists
-      (is (some? (registry/find-model :anthropic "claude-sonnet-4-6")))))
+      ;; Check known built-ins exist
+      (is (some? (registry/find-model :anthropic "claude-sonnet-4-6")))
+      (is (some? (registry/find-model :anthropic "claude-opus-4-7")))
+      (is (some? (registry/find-model :openai "gpt-5.5")))
+      (is (some? (registry/find-model :openai "gpt-5.4-mini")))))
 
   (testing "no auth for built-in providers"
     (is (nil? (registry/get-auth :anthropic)))

--- a/components/ai/test/psi/ai/providers/anthropic_test.clj
+++ b/components/ai/test/psi/ai/providers/anthropic_test.clj
@@ -97,6 +97,53 @@
       (is (some? (re-find #"interleaved-thinking" (get headers "anthropic-beta")))
           "oauth requests with thinking must include interleaved-thinking beta"))))
 
+;; ── Adaptive thinking (Opus 4.7+) ───────────────────────────────────────────
+
+(deftest build-request-adaptive-thinking-test
+  (testing "adaptive thinking model emits type=adaptive + output_config, no budget_tokens"
+    (let [model   (models/get-model :opus-4.7)
+          convo   (conv/create "sys")
+          req     (#'anthropic/build-request convo model {:thinking-level :high
+                                                          :api-key "test-key"})
+          body    (json/parse-string (:body req) true)
+          headers (:headers req)]
+      (is (= "adaptive" (get-in body [:thinking :type])))
+      (is (= "summarized" (get-in body [:thinking :display])))
+      (is (nil? (get-in body [:thinking :budget_tokens]))
+          "budget_tokens must be absent for adaptive thinking")
+      (is (= "high" (get-in body [:output_config :effort])))
+      (is (nil? (:temperature body))
+          "temperature must be absent for adaptive thinking models")
+      (is (nil? (re-find #"interleaved-thinking" (or (get headers "anthropic-beta") "")))
+          "interleaved-thinking beta must NOT be sent for adaptive thinking")))
+
+  (testing "adaptive thinking off — no thinking param, no output_config, no temperature"
+    (let [model   (models/get-model :opus-4.7)
+          convo   (conv/create "sys")
+          req     (#'anthropic/build-request convo model {:thinking-level :off
+                                                          :api-key "test-key"})
+          body    (json/parse-string (:body req) true)]
+      (is (nil? (:thinking body)))
+      (is (nil? (:output_config body)))
+      (is (nil? (:temperature body))
+          "temperature must be absent even with thinking off on adaptive models")))
+
+  (testing "xhigh effort maps to high for adaptive thinking"
+    (let [model   (models/get-model :opus-4.7)
+          convo   (conv/create "sys")
+          req     (#'anthropic/build-request convo model {:thinking-level :xhigh
+                                                          :api-key "test-key"})
+          body    (json/parse-string (:body req) true)]
+      (is (= "high" (get-in body [:output_config :effort])))))
+
+  (testing "medium effort level passes through"
+    (let [model   (models/get-model :opus-4.7)
+          convo   (conv/create "sys")
+          req     (#'anthropic/build-request convo model {:thinking-level :medium
+                                                          :api-key "test-key"})
+          body    (json/parse-string (:body req) true)]
+      (is (= "medium" (get-in body [:output_config :effort]))))))
+
 (deftest build-request-with-cache-breakpoints-test
   (testing "system prompt blocks and tools emit Anthropic cache_control when marked ephemeral"
     (let [model   (models/get-model :sonnet-4.6)

--- a/components/ai/test/psi/ai/providers/anthropic_test.clj
+++ b/components/ai/test/psi/ai/providers/anthropic_test.clj
@@ -144,6 +144,24 @@
           body    (json/parse-string (:body req) true)]
       (is (= "medium" (get-in body [:output_config :effort]))))))
 
+(deftest build-request-normalizes-legacy-string-tool-parameters-test
+  (testing "legacy string tool parameters are normalized before Anthropic input_schema validation"
+    (let [model        (models/get-model :opus-4.7)
+          convo        (-> (conv/create "sys")
+                           (conv/add-tool {:name "read"
+                                           :description "Read a file"
+                                           :parameters "{:type \"object\" :properties {\"path\" {:type \"string\"}} :required [\"path\"]}"}))
+          req          (#'anthropic/build-request convo model {:thinking-level :high
+                                                               :api-key "test-key"})
+          body         (json/parse-string (:body req) true)
+          input-schema (get-in body [:tools 0 :input_schema])]
+      (is (map? input-schema))
+      (is (= "object" (:type input-schema)))
+      (is (= ["path"] (:required input-schema)))
+      (is (= "string"
+             (or (get-in input-schema [:properties "path" :type])
+                 (get-in input-schema [:properties :path :type])))))))
+
 (deftest build-request-with-cache-breakpoints-test
   (testing "system prompt blocks and tools emit Anthropic cache_control when marked ephemeral"
     (let [model   (models/get-model :sonnet-4.6)

--- a/components/ai/test/psi/ai/providers/anthropic_test.clj
+++ b/components/ai/test/psi/ai/providers/anthropic_test.clj
@@ -142,7 +142,15 @@
           req     (#'anthropic/build-request convo model {:thinking-level :medium
                                                           :api-key "test-key"})
           body    (json/parse-string (:body req) true)]
-      (is (= "medium" (get-in body [:output_config :effort]))))))
+      (is (= "medium" (get-in body [:output_config :effort])))))
+
+  (testing "Opus 4.7 defaults max_tokens to Anthropic's 128000 cap"
+    (let [model   (models/get-model :opus-4.7)
+          convo   (conv/create "sys")
+          req     (#'anthropic/build-request convo model {:thinking-level :off
+                                                          :api-key "test-key"})
+          body    (json/parse-string (:body req) true)]
+      (is (= 128000 (:max_tokens body))))))
 
 (deftest build-request-normalizes-legacy-string-tool-parameters-test
   (testing "legacy string tool parameters are normalized before Anthropic input_schema validation"

--- a/munera/open/067-add-anthropic-4-7-and-openai-5-5-models/design.md
+++ b/munera/open/067-add-anthropic-4-7-and-openai-5-5-models/design.md
@@ -1,0 +1,103 @@
+Goal: Add Claude Opus 4.7 (Anthropic) and GPT-5.5 (OpenAI) to psi's built-in model catalog, and update any model-capability checks that need to cover the new generations.
+
+## Intent
+
+Keep psi's built-in model list current so users can select and use the latest Anthropic and OpenAI models without needing a custom `models.edn` workaround. The task is purely additive: new entries in `psi.ai.models` plus targeted updates to any capability predicates that gate on model generation.
+
+## Problem statement
+
+`psi.ai.models` currently tops out at:
+- Anthropic: `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5`
+- OpenAI: `gpt-5.4` (and family: mini, nano, pro)
+
+Both providers have released newer generations. The confirmed specs are:
+
+### Anthropic (from platform.claude.com/docs/en/about-claude/models/overview and anthropic.com/pricing)
+
+| Model | API ID | Context | Max output | Input $/MTok | Output $/MTok | Cache write | Cache read | Reasoning |
+|---|---|---|---|---|---|---|---|---|
+| Claude Opus 4.7 | `claude-opus-4-7` | 1M | 128k | $5 | $25 | $6.25 | $0.50 | adaptive (xhigh) |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | 1M | 64k | $3 | $15 | $3.75 | $0.30 | extended thinking |
+| Claude Haiku 4.5 | `claude-haiku-4-5` | 200k | 64k | $1 | $5 | $1.25 | $0.10 | extended thinking |
+
+Note: Sonnet 4.6 and Haiku 4.5 are already in `psi.ai.models`. **Only Opus 4.7 is new.**
+
+Opus 4.7 characteristics:
+- Adaptive thinking (not extended thinking) — `supports-reasoning true`
+- No dated snapshot ID in the public API alias; `claude-opus-4-7` is the canonical alias
+- AWS Bedrock: `anthropic.claude-opus-4-7`
+- Context 1M tokens, max output 128k tokens
+
+### OpenAI (from developers.openai.com/api/docs/models)
+
+| Model | API ID | Context | Max output | Input $/MTok | Output $/MTok | Reasoning |
+|---|---|---|---|---|---|---|
+| GPT-5.5 | `gpt-5.5` | 1M | 128k | $5 | $30 | none/low/medium/high/xhigh |
+| GPT-5.4 | `gpt-5.4` | 1M | 128k | $2.50 | $15 | (already present) |
+| GPT-5.4 mini | `gpt-5.4-mini` | 400k | 128k | $0.75 | $4.50 | (already present) |
+
+Note: GPT-5.4 is already in `psi.ai.models`. **Only GPT-5.5 is new.** GPT-5.4-mini is not yet in psi's catalog and should be added too.
+
+GPT-5.5 characteristics:
+- Supports reasoning at all effort levels including xhigh
+- `supports-reasoning true`
+- API: `:openai-completions` (same as gpt-5.4)
+- Cache read cost: OpenAI does not publish a separate cache-read price for 5.5 (use 0.0 as current placeholder, same as gpt-5.4)
+
+## Scope
+
+In scope:
+- Add `:opus-4.7` to `psi.ai.models/anthropic-models`.
+- Add `:gpt-5.5` to `psi.ai.models/openai-models`.
+- Add `:gpt-5.4-mini` to `psi.ai.models/openai-models` (present in the OpenAI catalog but missing from psi).
+- Update the `supportsXhigh` logic in `models.ts` equivalent in psi — specifically check if `providers/openai/reasoning.clj` or `providers/anthropic.clj` has any generation-gated capability checks that need updating for the new models.
+- Update `model_registry_test.clj` to assert presence of at least one new model per provider.
+
+Out of scope:
+- Removing or deprecating older models — separate decision, not resolved here.
+- Adding models from other providers (Bedrock, Azure, Vertex, etc.).
+- Changes to the model registry merge logic or user-models loading.
+- UI display changes (model selector labels, footer rendering).
+- Pricing changes for existing models.
+- Cache read pricing for GPT-5.5 if OpenAI does not publish it.
+
+## Acceptance criteria
+
+- `psi.ai.models/anthropic-models` contains `:opus-4.7` with correct `:id "claude-opus-4-7"`, `:supports-reasoning true`, context 1M, max-tokens 128k (expressed as 131072 to match the existing convention), and pricing $5/$25/$6.25/$0.50.
+- `psi.ai.models/openai-models` contains `:gpt-5.5` with `:id "gpt-5.5"`, `:supports-reasoning true`, context 1M, max-tokens 128k, pricing $5/$30.
+- `psi.ai.models/openai-models` contains `:gpt-5.4-mini` with `:id "gpt-5.4-mini"`, `:supports-reasoning true`, context 400k, max-tokens 128k, pricing $0.75/$4.50.
+- `psi.ai.models/all-models` includes all three new entries (derived automatically).
+- `model_registry_test.clj` `init-built-ins-only-test` asserts `(registry/find-model :anthropic "claude-opus-4-7")` and `(registry/find-model :openai "gpt-5.5")` are non-nil.
+- Any model-capability predicate gated on model generation (thinking-level budget, xhigh eligibility) covers the new models.
+- Full unit suite remains green.
+
+## Minimum concepts
+
+- **Model entry**: map with `:id`, `:name`, `:provider`, `:api`, `:base-url`, `:supports-reasoning`, `:supports-images`, `:supports-text`, `:context-window`, `:max-tokens`, and cost fields. Follows the existing shape in `psi.ai.models`.
+- **Capability predicate**: function that inspects a model map to determine support for a feature (e.g., xhigh thinking). Must cover new generations.
+
+## Implementation approach
+
+**Additive map entries** — add new key/value pairs to `anthropic-models` and `openai-models` in `psi.ai.models`. No structural change to the registry or merge logic.
+
+Steps:
+1. Add `:opus-4.7` to `anthropic-models` following the existing `:opus-4.6` shape.
+2. Add `:gpt-5.5` and `:gpt-5.4-mini` to `openai-models` following the existing `:gpt-5.4` shape.
+3. Check `providers/anthropic.clj` `thinking-level->budget` map — Opus 4.7 uses adaptive thinking; confirm whether the existing `:xhigh 32000` budget applies or needs a different value.
+4. Check `providers/openai/reasoning.clj` `thinking-level->effort` map — GPT-5.5 supports xhigh; confirm the existing `"high"` mapping is correct.
+5. Update `model_registry_test.clj` to assert the new models.
+6. Run full unit suite.
+
+## Architecture alignment
+
+- Follow the existing `psi.ai.models` map structure exactly — no new keys, no schema changes.
+- `all-models` is derived from `(merge anthropic-models openai-models)` with `annotate-model`; new entries flow through automatically.
+- `model_registry.clj` and the user-models overlay system require no changes.
+- Tests follow the existing `init-built-ins-only-test` pattern: `(registry/find-model :provider "model-id")`.
+
+## Notes
+
+- Opus 4.7 uses "adaptive thinking" rather than "extended thinking". In the current psi model, this maps to `supports-reasoning true` — no new field needed.
+- The `:xhigh` budget for Opus 4.7 on Anthropic: adaptive thinking uses a dynamic budget rather than a fixed token budget. The existing `thinking-level->budget` map uses `:xhigh 32000` for Opus 4.6 — check whether Anthropic's API treats adaptive thinking differently at the protocol level, or whether the same budget parameter is simply passed and the model manages it adaptively. If no protocol difference, the existing map entry suffices.
+- GPT-5.5 cache read cost: OpenAI's published pricing page does not list a separate cache-read price for 5.5 at time of writing. Use `0.0` as placeholder consistent with the existing gpt-5.4 entry, and note this in a comment for future update.
+- Older model removal: deliberately deferred. If the user wants to remove 3.x Anthropic or gpt-4o/o1 entries, that should be a separate task.


### PR DESCRIPTION
## Summary
- add Claude Opus 4.7, GPT-5.5, and GPT-5.4 Mini built-in model support
- handle Anthropic Opus 4.7 adaptive-thinking request protocol
- normalize legacy string tool schemas before provider requests
- allow adaptive-thinking model metadata in the AI model schema
- cap Opus 4.7 default output tokens at Anthropic's 128k limit

## Validation
- bb test:ai
- live validation against Anthropic Opus 4.7 uncovered and fixed:
  - model schema rejection for `:adaptive-thinking`
  - invalid default `max_tokens` of `131072` instead of `128000`
