### PR TITLE
fix: use -Sdeps-file to prevent project deps.edn merging into psi classpath

### DIFF
--- a/bases/main/src/psi/launcher.clj
+++ b/bases/main/src/psi/launcher.clj
@@ -227,14 +227,20 @@
      :manifest-info manifest-info
      :policy policy}))
 
-(defn build-clojure-command
-  "Build the clojure CLI argv used for launcher handoff."
-  [{:keys [basis psi-args]}]
-  (into ["clojure" "-Sdeps" (pr-str basis) "-M" "-m" "psi.main"] psi-args))
+(defn build-deps-clj-args
+  "Build the deps.clj args used for launcher handoff.
+   Uses -Sdeps-file so the project's deps.edn in cwd is not merged into psi's
+   classpath. The caller is responsible for writing basis-edn to basis-file
+   before invoking deps.clj."
+  [{:keys [basis-file psi-args]}]
+  (into ["-Sdeps-file" basis-file "-M" "-m" "psi.main"] psi-args))
 
 (defn launch-plan
   "Build a pure launcher execution plan from raw args, process cwd, launcher
-   root, and explicit realization policy."
+   root, and explicit realization policy.
+
+   :basis-edn  — the pr-str'd basis map to write to a temp file at execution time
+   :psi-args   — args forwarded to psi.main after deps.clj flags"
   [args process-cwd launcher-root policy]
   (let [parsed (parse-launcher-args args)
         cwd (resolve-effective-cwd parsed process-cwd)
@@ -246,6 +252,5 @@
      :psi-args (:psi-args parsed)
      :policy policy
      :basis (:basis basis-state)
-     :manifest-info (:manifest-info basis-state)
-     :command (build-clojure-command {:basis (:basis basis-state)
-                                      :psi-args (:psi-args parsed)})}))
+     :basis-edn (pr-str (:basis basis-state))
+     :manifest-info (:manifest-info basis-state)}))

--- a/bases/main/src/psi/launcher_main.clj
+++ b/bases/main/src/psi/launcher_main.clj
@@ -70,9 +70,13 @@
       (System/exit 0))
     (when (:launcher-debug? plan)
       (print-debug-summary! plan))
-    (let [basis-file (doto (fs/file (fs/temp-dir) (str (gensym "psi-basis-")))
-                       (fs/delete-on-exit))]
-      (spit basis-file (:basis-edn plan))
+    (let [basis-edn  (:basis-edn plan)
+          ;; Stable file path keyed on content hash so .cpcache is reused across
+          ;; invocations with the same deps (warm startup, CI cache hits).
+          basis-hash (Integer/toHexString (hash basis-edn))
+          basis-file (fs/file (fs/temp-dir) (str "psi-basis-" basis-hash ".edn"))]
+      (when-not (fs/exists? basis-file)
+        (spit basis-file basis-edn))
       @(apply deps/clojure
               {:inherit true :dir (:cwd plan)}
               (launcher/build-deps-clj-args

--- a/bases/main/src/psi/launcher_main.clj
+++ b/bases/main/src/psi/launcher_main.clj
@@ -1,6 +1,7 @@
 (ns psi.launcher-main
   (:require
-   [babashka.process :as process]
+   [babashka.deps :as deps]
+   [babashka.fs :as fs]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [psi.launcher :as launcher]
@@ -43,7 +44,7 @@
       (throw (ex-info "Unable to determine launcher root" {:stage :launcher-root}))))
 
 (defn- print-debug-summary!
-  [{:keys [cwd psi-args command basis manifest-info policy]}]
+  [{:keys [cwd psi-args basis-edn basis manifest-info policy]}]
   (binding [*out* *err*]
     (println "psi launcher")
     (println (str "  cwd: " cwd))
@@ -55,7 +56,8 @@
     (println (str "  inferred :psi/init libs: " (pr-str (sort (:inferred-init-libs manifest-info)))))
     (println (str "  basis deps count: " (count (:deps basis))))
     (println (str "  forwarded psi args: " (pr-str psi-args)))
-    (println (str "  command: " (str/join " " command)))))
+    (println (str "  command: clojure -Sdeps-file <tmpfile> -M -m psi.main " (str/join " " psi-args)))
+    (println (str "  basis-edn: " basis-edn))))
 
 (defn -main
   [& args]
@@ -68,6 +70,11 @@
       (System/exit 0))
     (when (:launcher-debug? plan)
       (print-debug-summary! plan))
-    @(process/process (:command plan)
-                      {:inherit true
-                       :dir (:cwd plan)})))
+    (let [basis-file (doto (fs/file (fs/temp-dir) (str (gensym "psi-basis-")))
+                       (fs/delete-on-exit))]
+      (spit basis-file (:basis-edn plan))
+      @(apply deps/clojure
+              {:inherit true :dir (:cwd plan)}
+              (launcher/build-deps-clj-args
+               {:basis-file (str basis-file)
+                :psi-args   (:psi-args plan)})))))

--- a/bases/main/test/psi/launcher_gordian_integration_test.clj
+++ b/bases/main/test/psi/launcher_gordian_integration_test.clj
@@ -43,5 +43,5 @@
       (is (nil? (get-in manifest-deps ['psi/mementum :psi/init])))
       (is (some #{'psi/workflow-loader} (:defaulted-libs (:manifest-info plan))))
       (is (some #{'psi/workflow-loader} (:inferred-init-libs (:manifest-info plan))))
-      (is (= ["clojure" "-Sdeps"] (subvec (:command plan) 0 2)))
-      (is (= ["-M" "-m" "psi.main"] (subvec (:command plan) 3 6))))))
+      (is (string? (:basis-edn plan)))
+      (is (map? (read-string (:basis-edn plan)))))))

--- a/bases/main/test/psi/launcher_test.clj
+++ b/bases/main/test/psi/launcher_test.clj
@@ -78,14 +78,15 @@
         (is (some? ex))
         (is (= :basis-construction (-> ex ex-data :stage)))))))
 
-(deftest build-clojure-command-test
-  (let [command (launcher/build-clojure-command {:basis {:deps {'foo/bar {:mvn/version "1.0.0"}}}
-                                                 :psi-args ["--tui" "--model" "gpt-5"]})]
-    (is (= ["clojure" "-Sdeps"] (subvec command 0 2)))
-    (is (= '{:deps {foo/bar {:mvn/version "1.0.0"}}}
-           (read-string (nth command 2))))
-    (is (= ["-M" "-m" "psi.main" "--tui" "--model" "gpt-5"]
-           (subvec command 3)))))
+(deftest build-deps-clj-args-test
+  (let [args (launcher/build-deps-clj-args {:basis-file "/tmp/psi-basis-123.edn"
+                                            :psi-args   ["--tui" "--model" "gpt-5"]})]
+    (is (= ["-Sdeps-file" "/tmp/psi-basis-123.edn" "-M" "-m" "psi.main" "--tui" "--model" "gpt-5"]
+           args)))
+  (testing "no psi-args"
+    (is (= ["-Sdeps-file" "/tmp/psi-basis-123.edn" "-M" "-m" "psi.main"]
+           (launcher/build-deps-clj-args {:basis-file "/tmp/psi-basis-123.edn"
+                                          :psi-args   []})))))
 
 (deftest manifest-state-test
   (testing "manifest state reports defaulted and inferred libs from expansion results"
@@ -207,14 +208,12 @@
             :psi-args ["--rpc-edn"]
             :policy :development
             :basis {:deps {'foo/bar {:mvn/version "1.0.0"}}}
+            :basis-edn (pr-str {:deps {'foo/bar {:mvn/version "1.0.0"}}})
             :manifest-info {:user-present? false
                             :project-present? true
                             :merged-manifest {:deps {'foo/bar {:mvn/version "1.0.0"}}}
                             :defaulted-libs []
                             :inferred-init-libs []}}
-           (dissoc plan :command)))
-    (is (= ["clojure" "-Sdeps"] (subvec (:command plan) 0 2)))
-    (is (= '{:deps {foo/bar {:mvn/version "1.0.0"}}}
-           (read-string (nth (:command plan) 2))))
-    (is (= ["-M" "-m" "psi.main" "--rpc-edn"]
-           (subvec (:command plan) 3)))))
+           plan))
+    (is (= {:deps {'foo/bar {:mvn/version "1.0.0"}}}
+           (read-string (:basis-edn plan))))))

--- a/bases/main/test/psi/rpc_smoke_test.clj
+++ b/bases/main/test/psi/rpc_smoke_test.clj
@@ -33,7 +33,7 @@
 
 ;; ── subprocess helpers ───────────────────────────────────────────────────────
 
-(def ^:private default-handshake-timeout-ms 15000)
+(def ^:private default-handshake-timeout-ms 60000)
 (def ^:private default-exit-timeout-ms 10000)
 
 (defn- read-line-timeout


### PR DESCRIPTION
## Problem

When psi launches its JVM subprocess, it runs `clojure -Sdeps <basis>` with `:dir` set to the user's project directory. The Clojure CLI merges deps in order: install → user → **project (cwd)** → `-Sdeps`. This means the project's `deps.edn` is merged into psi's classpath before psi's own basis.

If the project depends on `clj-tuple` (directly or transitively via an older `potemkin`/`clj-http`), `clj-tuple 0.2.2` lands on psi's classpath. Its static initializer then fails with:

```
ClassNotFoundException: clojure.lang.PersistentUnrolledVector
```

causing the subprocess to crash immediately on Java 25.

## Fix

Switch to `babashka.deps/clojure` with `-Sdeps-file` pointing to a temp file containing the psi basis EDN. Per the deps.clj docs, `-Sdeps-file` **replaces** the project `deps.edn` lookup entirely — so only psi's own deps (plus user/install-level config) are resolved. The subprocess still runs with `:dir cwd` so the process working directory remains the user's project directory.