### PR TITLE
Refine issue #27 proxy support task design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 ### Added
 - Extensions can close sessions via `close-session` and `close-session-tree` mutations.
 - Helper sessions from `auto-session-name` are now automatically closed after use.
+- Model API HTTP requests now honor standard proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`); see [Configuration](doc/configuration.md) and [Custom providers](doc/custom-providers.md).
 
 ### Fixed
 - Emacs: typing before RPC connects no longer has a newline injected mid-draft when the footer first updates.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ For prompt lifecycle introspection summaries and normalized prompt-turn attrs, s
 ## Configuration
 
 Config file locations, precedence (session > project-local > project-shared > user > system), settings
-reference, runtime scoped setters, and custom provider setup:
+reference, runtime scoped setters, outbound model API proxy environment variables, and custom provider setup:
 - [`doc/configuration.md`](doc/configuration.md)
 - [`doc/custom-providers.md`](doc/custom-providers.md)
 

--- a/components/ai/src/psi/ai/providers/anthropic.clj
+++ b/components/ai/src/psi/ai/providers/anthropic.clj
@@ -26,16 +26,13 @@
   "Coerce any value to a string; nil and false become \"\"."
   [x]
   (str (or x "")))
-
 (defn- valid-anthropic-tool-id?
   [id]
   (and (string? id)
        (boolean (re-matches anthropic-tool-id-pattern id))))
-
 (defn- fallback-anthropic-tool-id
   []
   (str "tool_" (UUID/randomUUID)))
-
 (defn- ensure-anthropic-tool-id
   "Return an Anthropic-safe tool id (alnum, underscore, hyphen only).
    Generates a fallback when id is nil/blank/invalid."

--- a/components/ai/src/psi/ai/providers/anthropic.clj
+++ b/components/ai/src/psi/ai/providers/anthropic.clj
@@ -5,6 +5,7 @@
             [cheshire.core :as json]
             [psi.ai.content :as ai-content]
             [psi.ai.models :as models]
+            [psi.ai.proxy :as proxy]
             [psi.ai.providers.anthropic.request-schema :as request-schema]
             [psi.ai.providers.anthropic.request-support :as request-support])
   (:import [java.io InputStream]
@@ -678,7 +679,9 @@
 
 (defn- stream-response
   [url request]
-  (http/post url (merge request {:as :stream :throw-exceptions false})))
+  (http/post url (merge request
+                        (proxy/request-proxy-options url)
+                        {:as :stream :throw-exceptions false})))
 
 (defn- error-status?
   [status]

--- a/components/ai/src/psi/ai/providers/openai/transport.clj
+++ b/components/ai/src/psi/ai/providers/openai/transport.clj
@@ -1,7 +1,8 @@
 (ns psi.ai.providers.openai.transport
   (:require [clojure.string :as str]
             [clj-http.client :as http]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [psi.ai.proxy :as proxy]))
 
 (defn safe-call!
   [f payload]
@@ -13,7 +14,9 @@
 
 (defn stream-response
   [url request]
-  (http/post url (merge request {:as :stream :cookie-policy :none :throw-exceptions false})))
+  (http/post url (merge request
+                        (proxy/request-proxy-options url)
+                        {:as :stream :cookie-policy :none :throw-exceptions false})))
 
 (defn redact-authorization
   [value]

--- a/components/ai/src/psi/ai/proxy.clj
+++ b/components/ai/src/psi/ai/proxy.clj
@@ -1,0 +1,111 @@
+(ns psi.ai.proxy
+  (:require [clojure.string :as str])
+  (:import [java.net URI URLDecoder]))
+
+(def ^:private logical-env-keys
+  [[:http "HTTP_PROXY" "http_proxy"]
+   [:https "HTTPS_PROXY" "https_proxy"]
+   [:all "ALL_PROXY" "all_proxy"]])
+
+(def ^:private supported-proxy-schemes
+  #{"http" "https" "socks" "socks5"})
+
+(defn- blank->nil
+  [s]
+  (when-not (str/blank? s)
+    s))
+
+(defn normalize-proxy-env
+  [env]
+  (reduce (fn [acc [logical uppercase lowercase]]
+            (if-let [value (or (blank->nil (get env uppercase))
+                               (blank->nil (get env lowercase)))]
+              (assoc acc logical value)
+              acc))
+          {}
+          logical-env-keys))
+
+(defn- parse-uri
+  [source-env raw-uri]
+  (try
+    (URI. raw-uri)
+    (catch Exception e
+      (throw (ex-info (str "Invalid proxy URI in " (name source-env) ": " raw-uri)
+                      {:source-env source-env
+                       :raw-uri raw-uri}
+                      e)))))
+
+(defn- decode-user-info
+  [s]
+  (when s
+    (URLDecoder/decode s "UTF-8")))
+
+(defn- parse-proxy-uri
+  [{:keys [source-env raw-uri]}]
+  (let [uri      (parse-uri source-env raw-uri)
+        scheme   (some-> (.getScheme uri) str/lower-case)
+        host     (.getHost uri)
+        port     (.getPort uri)
+        userinfo (.getUserInfo uri)
+        [username password] (when userinfo
+                              (let [[u p] (str/split userinfo #":" 2)]
+                                [(decode-user-info u)
+                                 (decode-user-info p)]))]
+    (when-not (contains? supported-proxy-schemes scheme)
+      (throw (ex-info (str "Unsupported proxy scheme in " (name source-env) ": " raw-uri
+                           ". Supported schemes: http, https, socks, socks5")
+                      {:source-env source-env
+                       :raw-uri raw-uri
+                       :scheme scheme})))
+    (when-not (seq host)
+      (throw (ex-info (str "Proxy URI in " (name source-env) " must include a host: " raw-uri)
+                      {:source-env source-env
+                       :raw-uri raw-uri
+                       :scheme scheme})))
+    (when-not (pos-int? port)
+      (throw (ex-info (str "Proxy URI in " (name source-env) " must include a numeric port: " raw-uri)
+                      {:source-env source-env
+                       :raw-uri raw-uri
+                       :scheme scheme
+                       :host host
+                       :port port})))
+    (cond-> {:source-env source-env
+             :raw-uri raw-uri
+             :scheme scheme
+             :host host
+             :port port}
+      username (assoc :username username)
+      password (assoc :password password))))
+
+(defn effective-proxy-for-url
+  [normalized-env request-url]
+  (let [scheme (some-> (parse-uri :request-url request-url) .getScheme str/lower-case)
+        selected (case scheme
+                   "https" (when-let [raw-uri (or (:https normalized-env)
+                                                  (:all normalized-env))]
+                             {:source-env (if (:https normalized-env) :https :all)
+                              :raw-uri raw-uri})
+                   "http" (when-let [raw-uri (or (:http normalized-env)
+                                                 (:all normalized-env))]
+                            {:source-env (if (:http normalized-env) :http :all)
+                             :raw-uri raw-uri})
+                   nil)]
+    (when selected
+      (parse-proxy-uri selected))))
+
+(defn proxy-request-options
+  [{:keys [scheme host port username password]}]
+  (cond-> {:proxy-host host
+           :proxy-port port
+           :proxy-scheme (keyword scheme)}
+    username (assoc :proxy-user username)
+    password (assoc :proxy-pass password)))
+
+(defn request-proxy-options
+  ([request-url]
+   (request-proxy-options (System/getenv) request-url))
+  ([env request-url]
+   (some-> env
+           normalize-proxy-env
+           (effective-proxy-for-url request-url)
+           proxy-request-options)))

--- a/components/ai/test/psi/ai/providers/anthropic_test.clj
+++ b/components/ai/test/psi/ai/providers/anthropic_test.clj
@@ -5,6 +5,7 @@
    [clj-http.client :as http]
    [psi.ai.conversation :as conv]
    [psi.ai.models :as models]
+   [psi.ai.proxy :as proxy]
    [psi.ai.providers.anthropic :as anthropic]
    [psi.ai.providers.anthropic.request-schema :as request-schema])
   (:import [java.io ByteArrayInputStream]))
@@ -264,6 +265,43 @@
       (is (= use-id res-id) "tool_result must reference normalized tool_use id")
       (is (re-matches #"^[a-zA-Z0-9_-]+$" use-id)
           "normalized id must satisfy Anthropic regex"))))
+
+(deftest stream-anthropic-applies-proxy-request-options-test
+  (testing "Anthropic stream request merges shared proxy options"
+    (let [model      (models/get-model :sonnet-4.6)
+          convo      (-> (conv/create "sys")
+                         (conv/add-user-message "hello"))
+          captured   (atom nil)
+          sse        (str (sse-line "message_start" {:type "message_start"})
+                          (sse-line "message_stop" {:type "message_stop"}))]
+      (with-redefs [proxy/request-proxy-options (fn [url]
+                                                  (is (= "https://api.anthropic.com/v1/messages" url))
+                                                  {:proxy-host "proxy.example"
+                                                   :proxy-port 8443
+                                                   :proxy-scheme :http})
+                    http/post (fn [_url req]
+                                (reset! captured req)
+                                {:body (stream-body sse)})]
+        (anthropic/stream-anthropic convo model {:api-key "test-key"} (fn [_] nil)))
+      (is (= "proxy.example" (:proxy-host @captured)))
+      (is (= 8443 (:proxy-port @captured)))
+      (is (= :http (:proxy-scheme @captured)))))
+
+  (testing "Anthropic stream leaves request unchanged when no proxy applies"
+    (let [model    (models/get-model :sonnet-4.6)
+          convo    (-> (conv/create "sys")
+                       (conv/add-user-message "hello"))
+          captured (atom nil)
+          sse      (str (sse-line "message_start" {:type "message_start"})
+                        (sse-line "message_stop" {:type "message_stop"}))]
+      (with-redefs [proxy/request-proxy-options (constantly nil)
+                    http/post (fn [_url req]
+                                (reset! captured req)
+                                {:body (stream-body sse)})]
+        (anthropic/stream-anthropic convo model {:api-key "test-key"} (fn [_] nil)))
+      (is (nil? (:proxy-host @captured)))
+      (is (nil? (:proxy-port @captured)))
+      (is (nil? (:proxy-scheme @captured))))))
 
 (deftest stream-anthropic-captures-provider-request-and-response-test
   (testing "Anthropic streaming emits provider request/response captures"

--- a/components/ai/test/psi/ai/providers/openai_test.clj
+++ b/components/ai/test/psi/ai/providers/openai_test.clj
@@ -5,6 +5,7 @@
    [clj-http.client :as http]
    [psi.ai.conversation :as conv]
    [psi.ai.models :as models]
+   [psi.ai.proxy :as proxy]
    [psi.ai.providers.openai :as openai])
   (:import [java.io ByteArrayInputStream]
            [java.util Base64]))
@@ -184,6 +185,57 @@
         (is (some #(= "response.completed"
                       (get-in % [:event :type]))
                   @reply-captures))))))
+
+(deftest openai-stream-applies-proxy-request-options-test
+  (testing "OpenAI codex stream request merges shared proxy options"
+    (let [model    (models/get-model :gpt-5.3-codex)
+          token    (jwt-with-account-id "acc_test")
+          convo    (-> (conv/create "sys")
+                       (conv/add-user-message "hello"))
+          captured (atom nil)
+          sse      (str
+                    "data: " (json/generate-string
+                              {:type "response.output_item.added"
+                               :item {:type "message"
+                                      :id "msg_1"
+                                      :role "assistant"
+                                      :status "in_progress"
+                                      :content []}}) "\n\n"
+                    "data: " (json/generate-string
+                              {:type "response.completed"
+                               :response {:status "completed"}}) "\n\n")]
+      (with-redefs [proxy/request-proxy-options (fn [url]
+                                                  (is (= "https://chatgpt.com/backend-api/codex/responses" url))
+                                                  {:proxy-host "proxy.example"
+                                                   :proxy-port 8080
+                                                   :proxy-scheme :http})
+                    http/post (fn [_url req]
+                                (reset! captured req)
+                                {:body (stream-body sse)})]
+        ((:stream openai/provider)
+         convo model {:api-key token}
+         (fn [_] nil)))
+      (is (= "proxy.example" (:proxy-host @captured)))
+      (is (= 8080 (:proxy-port @captured)))
+      (is (= :http (:proxy-scheme @captured)))))
+
+  (testing "OpenAI completions stream leaves request unchanged when no proxy applies"
+    (let [model    (models/get-model :gpt-4o)
+          convo    (-> (conv/create "sys")
+                       (conv/add-user-message "hello"))
+          captured (atom nil)
+          sse      (str "data: " (json/generate-string {:choices [{:delta {:content "hi"}}]}) "\n\n"
+                        "data: [DONE]\n\n")]
+      (with-redefs [proxy/request-proxy-options (constantly nil)
+                    http/post (fn [_url req]
+                                (reset! captured req)
+                                {:body (stream-body sse)})]
+        ((:stream openai/provider)
+         convo model {:api-key "test-key"}
+         (fn [_] nil)))
+      (is (nil? (:proxy-host @captured)))
+      (is (nil? (:proxy-port @captured)))
+      (is (nil? (:proxy-scheme @captured))))))
 
 (deftest codex-requires-chatgpt-token-test
   (testing "non-ChatGPT token emits an error event (missing chatgpt_account_id)"

--- a/components/ai/test/psi/ai/proxy_test.clj
+++ b/components/ai/test/psi/ai/proxy_test.clj
@@ -1,0 +1,102 @@
+(ns psi.ai.proxy-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [psi.ai.proxy :as proxy]))
+
+(deftest normalize-proxy-env-test
+  (testing "uppercase wins over lowercase and blanks are ignored"
+    (is (= {:http "http://upper-http:8080"
+            :https "http://upper-https:8443"
+            :all "socks5://upper-all:1080"}
+           (proxy/normalize-proxy-env {"HTTP_PROXY" "http://upper-http:8080"
+                                       "http_proxy" "http://lower-http:8080"
+                                       "HTTPS_PROXY" "http://upper-https:8443"
+                                       "https_proxy" ""
+                                       "ALL_PROXY" "socks5://upper-all:1080"
+                                       "all_proxy" "socks5://lower-all:1080"}))))
+
+  (testing "missing and blank values are omitted"
+    (is (= {}
+           (proxy/normalize-proxy-env {"HTTP_PROXY" ""
+                                       "HTTPS_PROXY" "   "})))))
+
+(deftest effective-proxy-for-url-test
+  (testing "scheme-specific proxies beat all-proxy"
+    (is (= {:source-env :https
+            :raw-uri "http://secure-proxy.example:8443"
+            :scheme "http"
+            :host "secure-proxy.example"
+            :port 8443}
+           (proxy/effective-proxy-for-url {:https "http://secure-proxy.example:8443"
+                                           :all "socks5://fallback.example:1080"}
+                                          "https://api.example.com/v1/chat")))
+    (is (= {:source-env :http
+            :raw-uri "http://plain-proxy.example:8080"
+            :scheme "http"
+            :host "plain-proxy.example"
+            :port 8080}
+           (proxy/effective-proxy-for-url {:http "http://plain-proxy.example:8080"
+                                           :all "socks5://fallback.example:1080"}
+                                          "http://api.example.com/v1/chat"))))
+
+  (testing "all-proxy is the fallback"
+    (is (= {:source-env :all
+            :raw-uri "socks5://fallback.example:1080"
+            :scheme "socks5"
+            :host "fallback.example"
+            :port 1080}
+           (proxy/effective-proxy-for-url {:all "socks5://fallback.example:1080"}
+                                          "https://api.example.com/v1/chat"))))
+
+  (testing "non-http schemes are ignored"
+    (is (nil? (proxy/effective-proxy-for-url {:all "http://proxy.example:8080"}
+                                             "ws://api.example.com/socket")))))
+
+(deftest proxy-request-options-test
+  (testing "credentials and scheme are projected into clj-http options"
+    (is (= {:proxy-host "proxy.example"
+            :proxy-port 8080
+            :proxy-scheme :http
+            :proxy-user "user"
+            :proxy-pass "pass"}
+           (-> {:source-env :http
+                :raw-uri "http://user:pass@proxy.example:8080"
+                :scheme "http"
+                :host "proxy.example"
+                :port 8080
+                :username "user"
+                :password "pass"}
+               proxy/proxy-request-options)))))
+
+(deftest request-proxy-options-test
+  (testing "env-backed helper returns final request options"
+    (is (= {:proxy-host "proxy.example"
+            :proxy-port 8080
+            :proxy-scheme :http}
+           (proxy/request-proxy-options {"HTTPS_PROXY" "http://proxy.example:8080"}
+                                        "https://api.example.com/v1/messages"))))
+
+  (testing "no matching proxy returns nil"
+    (is (nil? (proxy/request-proxy-options {}
+                                           "https://api.example.com/v1/messages")))))
+
+(deftest invalid-proxy-uri-test
+  (testing "malformed uri names the offending env var"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid proxy URI in https"
+         (proxy/effective-proxy-for-url {:https "://bad"}
+                                        "https://api.example.com/v1/messages"))))
+
+  (testing "missing port fails explicitly"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"must include a numeric port"
+         (proxy/effective-proxy-for-url {:https "http://proxy.example"}
+                                        "https://api.example.com/v1/messages"))))
+
+  (testing "unsupported schemes fail explicitly"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Unsupported proxy scheme"
+         (proxy/effective-proxy-for-url {:https "ftp://proxy.example:21"}
+                                        "https://api.example.com/v1/messages")))))

--- a/components/rpc/test/psi/rpc_anthropic_regression_test.clj
+++ b/components/rpc/test/psi/rpc_anthropic_regression_test.clj
@@ -1,57 +1,14 @@
 (ns psi.rpc-anthropic-regression-test
   (:require
-   [clojure.edn :as edn]
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
    [psi.agent-session.persistence :as persist]
-   [psi.agent-session.test-support :as test-support]
-   [psi.rpc :as rpc]))
-
-(defn- run-loop
-  ([input handler]
-   (run-loop input handler (atom {}) 0))
-  ([input handler state]
-   (run-loop input handler state 0))
-  ([input handler state wait-ms]
-   (let [out (java.io.StringWriter.)
-         err (java.io.StringWriter.)]
-     (rpc/run-stdio-loop! {:in              (java.io.StringReader. input)
-                           :out             out
-                           :err             err
-                           :state           state
-                           :request-handler handler})
-     (when (pos? wait-ms)
-       (Thread/sleep wait-ms))
-     {:out-lines (->> (str/split-lines (str out))
-                      (remove str/blank?)
-                      vec)
-      :err-text  (str err)
-      :state     @state})))
-
-(defn- parse-frames [lines]
-  (mapv edn/read-string lines))
-
-(defn- make-handler
-  [ctx state]
-  (rpc/make-session-request-handler
-   ctx
-   (select-keys @state [:rpc-ai-model
-                        :on-new-session!
-                        :execute-prepared-request-fn
-                        :sync-on-git-head-change?])))
-
-(defn- create-session-context
-  ([]
-   (create-session-context {}))
-  ([opts]
-   (let [ctx (session/create-context (test-support/safe-context-opts opts))
-         sd  (session/new-session-in! ctx nil {})]
-     [ctx (:session-id sd)])))
+   [psi.rpc :as rpc]
+   [psi.rpc-test-support :as support]))
 
 (deftest rpc-new-session-rehydrates-agent-messages-not-tui-projection-test
   (testing "new_session emits canonical agent messages so the next Anthropic request preserves role/content shape"
-    (let [[ctx _] (create-session-context)
+    (let [[ctx _] (support/create-session-context)
           state   (atom {:transport {:ready? true :pending {}}
                          :connection {:subscribed-topics #{"session/rehydrated"}}})
           handler (rpc/make-session-request-handler ctx {:on-new-session! (fn [_source-session-id]
@@ -65,8 +22,8 @@
                                                                              :tool-order []})})
           input (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
                      "{:id \"n1\" :kind :request :op \"new_session\"}\n")
-          {:keys [out-lines]} (run-loop input handler state)
-          frames (parse-frames out-lines)
+          {:keys [out-lines]} (support/run-loop input handler state)
+          frames (support/parse-frames out-lines)
           rehydrate-event (some #(when (= "session/rehydrated" (:event %)) %) frames)]
       (is (some? rehydrate-event))
       (is (= [{:role "assistant"
@@ -79,7 +36,7 @@
   (testing "resume emits canonical agent messages from the journal"
     (let [cwd                (str (System/getProperty "java.io.tmpdir") "/psi-rpc-anthropic-resume-" (java.util.UUID/randomUUID))
           _                  (.mkdirs (java.io.File. cwd))
-          [ctx _]      (create-session-context {:cwd cwd})
+          [ctx _]      (support/create-session-context {:cwd cwd})
           sd1                (session/new-session-in! ctx nil {})
           session-id         (:session-id sd1)
           path1              (:session-file sd1)
@@ -94,11 +51,11 @@
                                                                               :content [{:type :text :text "who are you?"}]})])
           state              (atom {:transport {:ready? true :pending {}}
                                     :connection {:subscribed-topics #{"session/rehydrated"}}})
-          handler (make-handler ctx state)
+          handler (support/make-handler ctx state)
           input              (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
                                   "{:id \"c1\" :kind :request :op \"command\" :params {:text \"/resume " path1 "\"}}\n")
-          {:keys [out-lines]} (run-loop input handler state)
-          frames             (parse-frames out-lines)
+          {:keys [out-lines]} (support/run-loop input handler state)
+          frames             (support/parse-frames out-lines)
           rehydrate-event    (some #(when (= "session/rehydrated" (:event %)) %) frames)]
       (is (some? rehydrate-event))
       (is (= [{:role "assistant"

--- a/components/rpc/test/psi/rpc_delegate_bridge_test.clj
+++ b/components/rpc/test/psi/rpc_delegate_bridge_test.clj
@@ -34,18 +34,28 @@
                              "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\" \"command-result\" \"session/updated\" \"footer/updated\"]}}\n"
                              "{:id \"c1\" :kind :request :op \"command\" :params {:text \"/fake-delegate\"}}\n")
           {:keys [out-lines]} (support/run-loop input handler state 250)
-          _              (Thread/sleep 100)
-          frames         (support/parse-frames out-lines)
-          events         (filter #(= :event (:kind %)) frames)
-          command-text   (some #(when (= "command-result" (:event %)) %) events)
-          assistant-msgs (filter #(= "assistant/message" (:event %)) events)
-          user-texts     (keep #(when (= "user" (get-in % [:data :role]))
-                                  (get-in % [:data :text]))
-                               assistant-msgs)
-          asst-texts     (keep #(when (= "assistant" (get-in % [:data :role]))
-                                  (get-in % [:data :text]))
-                               assistant-msgs)]
+          result         (support/await-until
+                          (fn []
+                            (let [frames         (support/parse-frames out-lines)
+                                  events         (filter #(= :event (:kind %)) frames)
+                                  command-text   (some #(when (= "command-result" (:event %)) %) events)
+                                  assistant-msgs (filter #(= "assistant/message" (:event %)) events)
+                                  user-texts     (keep #(when (= "user" (get-in % [:data :role]))
+                                                          (get-in % [:data :text]))
+                                                       assistant-msgs)
+                                  asst-texts     (keep #(when (= "assistant" (get-in % [:data :role]))
+                                                          (get-in % [:data :text]))
+                                                       assistant-msgs)]
+                              (when (and (= "Delegated to lambda-build — run run-1"
+                                            (get-in command-text [:data :message]))
+                                         (some #{"Workflow run run-1 result:"} user-texts)
+                                         (some #{"result text"} asst-texts))
+                                {:command-text command-text
+                                 :user-texts user-texts
+                                 :asst-texts asst-texts})))
+                          1000)]
+      (is (not= support/timeout-token result) "timed out waiting for delegate bridge command-result and messages")
       (is (= "Delegated to lambda-build — run run-1"
-             (get-in command-text [:data :message])))
-      (is (some #{"Workflow run run-1 result:"} user-texts))
-      (is (some #{"result text"} asst-texts)))))
+             (get-in result [:command-text :data :message])))
+      (is (some #{"Workflow run run-1 result:"} (:user-texts result)))
+      (is (some #{"result text"} (:asst-texts result))))))

--- a/components/rpc/test/psi/rpc_delegate_command_and_bridge_order_test.clj
+++ b/components/rpc/test/psi/rpc_delegate_command_and_bridge_order_test.clj
@@ -1,6 +1,5 @@
 (ns psi.rpc-delegate-command-and-bridge-order-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.extensions :as ext]
    [psi.agent-session.extensions.runtime-fns :as runtime-fns]
@@ -11,22 +10,6 @@
 (defn- write-line! [^java.io.Writer w line]
   (.write w (str line "\n"))
   (.flush w))
-
-(defn- parse-out-frames [^java.io.StringWriter out-writer]
-  (support/parse-frames (->> (str/split-lines (str out-writer))
-                             (remove str/blank?)
-                             vec)))
-
-(defn- wait-until
-  [pred timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (loop []
-      (let [value (pred)]
-        (if value
-          value
-          (when (< (System/currentTimeMillis) deadline)
-            (Thread/sleep 25)
-            (recur)))))))
 
 (deftest rpc-delegate-command-result-precedes-bridge-events-test
   (testing "RPC command op emits delegated ack before later bridge user/assistant messages"
@@ -63,13 +46,12 @@
       (try
         (write-line! in-writer "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! in-writer "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\" \"command-result\" \"session/updated\" \"footer/updated\"]}}")
-        (Thread/sleep 50)
         (write-line! in-writer "{:id \"c1\" :kind :request :op \"command\" :params {:text \"/fake-delegate-order\"}}")
         (let [compact-seq
-              (wait-until
-               (fn []
-                 (let [frames      (parse-out-frames out-writer)
-                       events      (filter #(= :event (:kind %)) frames)
+              (support/await-frames!
+               out-writer
+               (fn [frames]
+                 (let [events      (filter #(= :event (:kind %)) frames)
                        interesting (keep (fn [frame]
                                            (case (:event frame)
                                              "command-result" {:event :command-result

--- a/components/rpc/test/psi/rpc_invariants_test.clj
+++ b/components/rpc/test/psi/rpc_invariants_test.clj
@@ -1,48 +1,14 @@
 (ns psi.rpc-invariants-test
   (:require
-   [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.commands :as commands]
-   [psi.agent-session.core :as session]
    [psi.agent-session.prompt-runtime :as prompt-runtime]
    [psi.agent-session.runtime :as runtime]
-   [psi.agent-session.test-support :as test-support]
    [psi.rpc :as rpc]
    [psi.rpc.events :as rpc.events]
-   [psi.rpc.state :as rpc.state]))
-
-(defn- run-loop
-  ([input handler]
-   (run-loop input handler (atom {}) 0))
-  ([input handler state]
-   (run-loop input handler state 0))
-  ([input handler state wait-ms]
-   (let [out (java.io.StringWriter.)
-         err (java.io.StringWriter.)]
-     (rpc/run-stdio-loop! {:in              (java.io.StringReader. input)
-                           :out             out
-                           :err             err
-                           :state           state
-                           :request-handler handler})
-     (when (pos? wait-ms)
-       (Thread/sleep wait-ms))
-     {:out-lines (->> (str/split-lines (str out))
-                      (remove str/blank?)
-                      vec)
-      :err-text  (str err)
-      :state     @state})))
-
-(defn- parse-frames [lines]
-  (mapv edn/read-string lines))
-
-(defn- create-session-context
-  ([]
-   (create-session-context {}))
-  ([opts]
-   (let [ctx (session/create-context (test-support/safe-context-opts opts))
-         sd  (session/new-session-in! ctx nil {})]
-     [ctx (:session-id sd)])))
+   [psi.rpc.state :as rpc.state]
+   [psi.rpc-test-support :as support]))
 
 (deftest rpc-state-shape-and-helpers-invariant-test
   (testing "rpc.state owns connection-local transport/connection/worker state through helpers"
@@ -102,7 +68,7 @@
 
 (deftest rpc-handshake-uses-explicit-transport-deps-invariant-test
   (testing "handshake server-info comes from explicit transport deps, not mutable state magic"
-    (let [[ctx sid] (create-session-context)
+    (let [[ctx sid] (support/create-session-context)
           wrong-called?   (atom false)
           right-called?   (atom false)
           state           (atom {:handshake-server-info-fn (fn [_] (reset! wrong-called? true)
@@ -120,9 +86,9 @@
                                                         (reset! right-called? true)
                                                         (assoc (rpc.events/session->handshake-server-info ctx sid)
                                                                :ui-type :emacs))})
-      (let [[frame] (parse-frames (->> (str/split-lines (str out))
-                                       (remove str/blank?)
-                                       vec))]
+      (let [[frame] (support/parse-frames (->> (str/split-lines (str out))
+                                               (remove str/blank?)
+                                               vec))]
         (is (true? @right-called?))
         (is (false? @wrong-called?))
         (is (= sid (get-in frame [:data :server-info :session-id])))
@@ -130,7 +96,7 @@
 
 (deftest rpc-new-session-uses-explicit-session-deps-invariant-test
   (testing "new_session uses explicit session deps callback, not mutable state callback"
-    (let [[ctx _]       (create-session-context)
+    (let [[ctx _]       (support/create-session-context)
           wrong-called? (atom false)
           right-called? (atom 0)
           state         (atom {:transport {:ready? true :pending {}}
@@ -154,8 +120,8 @@
                                               :tool-order ["call-1"]})})
           input         (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
                              "{:id \"n1\" :kind :request :op \"new_session\"}\n")
-          {:keys [out-lines]} (run-loop input handler state)
-          frames         (parse-frames out-lines)
+          {:keys [out-lines]} (support/run-loop input handler state)
+          frames         (support/parse-frames out-lines)
           rehydrate-event (some #(when (= "session/rehydrated" (:event %)) %) frames)]
       (is (= 1 @right-called?))
       (is (false? @wrong-called?))
@@ -167,8 +133,8 @@
 
 (deftest rpc-prompt-uses-dispatch-lifecycle-invariant-test
   (testing "prompt routes through dispatch-visible prompt lifecycle, not mutable executor"
-    (let [[ctx _]        (create-session-context)
-          lifecycle-used? (atom false)
+    (let [[ctx _]        (support/create-session-context)
+          lifecycle-used? (promise)
           state          (atom {:transport {:ready? true :pending {}}
                                 :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}})
           handler        (rpc/make-session-request-handler
@@ -180,7 +146,7 @@
                     runtime/resolve-api-key-in (fn [_ctx _session-id _model] nil)
                     prompt-runtime/execute-prepared-request!
                     (fn [_ai-ctx _ctx session-id prepared _pq]
-                      (reset! lifecycle-used? true)
+                      (deliver lifecycle-used? true)
                       {:execution-result/turn-id (:prepared-request/id prepared)
                        :execution-result/session-id session-id
                        :execution-result/assistant-message {:role "assistant"
@@ -190,5 +156,6 @@
                        :execution-result/turn-outcome :turn.outcome/stop
                        :execution-result/tool-calls []
                        :execution-result/stop-reason :stop})]
-        (run-loop input handler state 250)
-        (is (true? @lifecycle-used?))))))
+        (support/run-loop input handler state 250)
+        (is (= true (support/await-promise! lifecycle-used? 1000))
+            "timed out waiting for prompt lifecycle execution")))))

--- a/components/rpc/test/psi/rpc_ops_test.clj
+++ b/components/rpc/test/psi/rpc_ops_test.clj
@@ -1,7 +1,6 @@
 (ns psi.rpc-ops-test
   (:require
    [clojure.edn :as edn]
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.background-jobs :as bg-jobs]
    [psi.agent-session.core :as session]
@@ -284,20 +283,20 @@
       (try
         (write-line! "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"ui/widgets-updated\"]}}")
-        (Thread/sleep 100)
         (dispatch/dispatch! ctx :session/ui-set-widget
                             {:extension-id "ext.demo" :widget-id "w-2"
                              :placement :above-editor :content ["live update"]}
                             {:origin :test})
-        (Thread/sleep 180)
-        (.close in-writer)
-        (deref loop-future 500 nil)
-        (let [frames        (support/parse-frames (->> (str/split-lines (str out-writer))
-                                                       (remove str/blank?)
-                                                       vec))
-              widget-events (filter #(= "ui/widgets-updated" (:event %)) frames)
-              latest        (last widget-events)]
-          (is (seq widget-events))
+        (let [latest (support/await-frames!
+                      out-writer
+                      (fn [frames]
+                        (let [widget-events (filter #(= "ui/widgets-updated" (:event %)) frames)]
+                          (when (seq widget-events)
+                            (last widget-events))))
+                      1000)]
+          (.close in-writer)
+          (deref loop-future 500 support/timeout-token)
+          (is (not= support/timeout-token latest) "timed out waiting for ui/widgets-updated")
           (is (= "w-2" (get-in latest [:data :widgets 0 :widget-id])))
           (is (= ["live update"] (get-in latest [:data :widgets 0 :content]))))
         (finally
@@ -327,21 +326,21 @@
       (try
         (write-line! "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"ui/notification\"]}}")
-        (Thread/sleep 100)
         (dispatch/dispatch! ctx :session/ui-notify
                             {:extension-id "ext.demo"
                              :message "live note"
                              :level :warning}
                             {:origin :test})
-        (Thread/sleep 180)
-        (.close in-writer)
-        (deref loop-future 500 nil)
-        (let [frames               (support/parse-frames (->> (str/split-lines (str out-writer))
-                                                              (remove str/blank?)
-                                                              vec))
-              notification-events  (filter #(= "ui/notification" (:event %)) frames)
-              latest               (last notification-events)]
-          (is (seq notification-events))
+        (let [latest (support/await-frames!
+                      out-writer
+                      (fn [frames]
+                        (let [notification-events (filter #(= "ui/notification" (:event %)) frames)]
+                          (when (seq notification-events)
+                            (last notification-events))))
+                      1000)]
+          (.close in-writer)
+          (deref loop-future 500 support/timeout-token)
+          (is (not= support/timeout-token latest) "timed out waiting for ui/notification")
           (is (= "ext.demo" (get-in latest [:data :extension-id])))
           (is (= "live note" (get-in latest [:data :message])))
           (is (= "warning" (get-in latest [:data :level]))))
@@ -372,7 +371,6 @@
       (try
         (write-line! "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"ui/status-updated\" \"ui/dialog-requested\"]}}")
-        (Thread/sleep 100)
         (dispatch/dispatch! ctx :session/ui-set-status
                             {:session-id session-id
                              :extension-id "ext.demo"
@@ -385,18 +383,20 @@
                              :title "Live dialog"
                              :message "Proceed?"}
                             {:origin :test})
-        (Thread/sleep 180)
-        (.close in-writer)
-        (deref loop-future 500 nil)
-        (let [frames       (support/parse-frames (->> (str/split-lines (str out-writer))
-                                                      (remove str/blank?)
-                                                      vec))
-              status-evts  (filter #(= "ui/status-updated" (:event %)) frames)
-              dialog-evts  (filter #(= "ui/dialog-requested" (:event %)) frames)
-              latest-status (last status-evts)
-              latest-dialog (last dialog-evts)]
-          (is (seq status-evts))
-          (is (seq dialog-evts))
+        (let [frames* (support/await-frames!
+                       out-writer
+                       (fn [frames]
+                         (let [status-evts (filter #(= "ui/status-updated" (:event %)) frames)
+                               dialog-evts (filter #(= "ui/dialog-requested" (:event %)) frames)]
+                           (when (and (seq status-evts) (seq dialog-evts))
+                             {:latest-status (last status-evts)
+                              :latest-dialog (last dialog-evts)})))
+                       1000)
+              latest-status (:latest-status frames*)
+              latest-dialog (:latest-dialog frames*)]
+          (.close in-writer)
+          (deref loop-future 500 support/timeout-token)
+          (is (not= support/timeout-token frames*) "timed out waiting for status/dialog projection events")
           (is (= "ext.demo" (get-in latest-status [:data :statuses 0 :extension-id])))
           (is (= "Live status" (get-in latest-status [:data :statuses 0 :text])))
           (is (= "confirm" (get-in latest-dialog [:data :kind])))

--- a/components/rpc/test/psi/rpc_prompt_command_test.clj
+++ b/components/rpc/test/psi/rpc_prompt_command_test.clj
@@ -20,23 +20,22 @@
     (let [[ctx _a-sid] (support/create-session-context)
           z-sd         (session/new-session-in! ctx _a-sid {})
           z-sid        (:session-id z-sd)
-          captured     (atom nil)
+          captured     (promise)
           state        (atom {:transport {:ready? true
                                           :pending {}}
                               :connection {:focus-session-id _a-sid}
                               :workers {}
                               :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}
                               :execute-prepared-request-fn (fn [_ai-ctx _ctx sid _prepared-request _opts]
-                                                             (reset! captured sid)
+                                                             (deliver captured sid)
                                                              (support/ok-execution-result sid [{:type :text :text "ok"}]))})
           handler (support/make-handler ctx state)
           input    (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
                         (format "{:id \"p1\" :kind :request :op \"prompt\" :params {:session-id \"%s\" :message \"hi\"}}\n" z-sid))]
       (support/run-loop input handler state 300)
-      (dotimes [_ 20]
-        (when-not @captured
-          (Thread/sleep 50)))
-      (is (= z-sid @captured)))))
+      (let [captured* (support/await-promise! captured 1000)]
+        (is (not= support/timeout-token captured*) "timed out waiting for routed session-id capture")
+        (is (= z-sid captured*))))))
 
 (deftest rpc-prompt-slash-dispatch-gate-test
   (testing "when commands/dispatch-in returns non-nil, execute-prepared-request-fn is NOT called"
@@ -100,7 +99,7 @@
                        :source :path
                        :disable-model-invocation false}
           [ctx _]     (support/create-session-context {:session-defaults {:skills [skill]}})
-          captured    (atom nil)
+          captured    (promise)
           bridge      (fn [_ai-ctx _ctx session-id prepared _pq]
                         ;; Capture the user message text from the prepared request.
                         ;; Provider-format messages have {:role :user :content {:kind :text :text "..."}}
@@ -111,7 +110,7 @@
                                          (string? content) content
                                          (map? content)    (:text content)
                                          (vector? content) (-> content first :text))]
-                          (reset! captured txt))
+                          (deliver captured txt))
                         (support/assistant-msg->execution-result session-id
                                                                  {:role "assistant"
                                                                   :content [{:type :text :text "ok"}]
@@ -123,17 +122,19 @@
           input       (str "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}\n"
                            "{:id \"p1\" :kind :request :op \"prompt\" :params {:message \"/skill:demo apply this\"}}\n")]
       (support/run-loop input handler state 250)
-      (is (string? @captured))
-      (when (string? @captured)
-        (is (str/includes? @captured "<skill name=\"demo\""))
-        (is (str/includes? @captured "# Skill Body"))
-        (is (str/includes? @captured "apply this"))
-        (is (not= "/skill:demo apply this" @captured))))))
+      (let [captured* (support/await-promise! captured 1000)]
+        (is (not= support/timeout-token captured*) "timed out waiting for expanded skill prompt capture")
+        (is (string? captured*))
+        (when (string? captured*)
+          (is (str/includes? captured* "<skill name=\"demo\""))
+          (is (str/includes? captured* "# Skill Body"))
+          (is (str/includes? captured* "apply this"))
+          (is (not= "/skill:demo apply this" captured*)))))))
 
 (deftest rpc-prompt-passes-resolved-api-key-to-agent-loop-test
   (testing "non-command prompt forwards runtime-resolved api-key through prepared request"
     (let [[ctx _]    (support/create-session-context)
-          captured   (atom nil)
+          captured   (promise)
           state      (atom {:transport {:ready? true :pending {}}
                             :rpc-ai-model {:provider "anthropic" :id "stub" :supports-reasoning true}})
           handler (support/make-handler ctx state)
@@ -143,7 +144,7 @@
                     commands/dispatch-in (fn [_ctx _session-id _text _opts] nil)
                     prompt-runtime/execute-prepared-request!
                     (fn [_ai-ctx _ctx session-id prepared _pq]
-                      (reset! captured (:prepared-request/ai-options prepared))
+                      (deliver captured (:prepared-request/ai-options prepared))
                       {:execution-result/turn-id (:prepared-request/id prepared)
                        :execution-result/session-id session-id
                        :execution-result/assistant-message {:role "assistant"}
@@ -154,7 +155,9 @@
                        :execution-result/tool-calls []
                        :execution-result/stop-reason :stop})]
         (support/run-loop input handler state 250)
-        (is (= "test-api-key" (:api-key @captured)))))))
+        (let [captured* (support/await-promise! captured 1000)]
+          (is (not= support/timeout-token captured*) "timed out waiting for prepared-request capture")
+          (is (= "test-api-key" (:api-key captured*))))))))
 
 (deftest rpc-prompt-handle-command-result-types-test
   (testing "text-command-emits-assistant-message with session/updated and footer/updated"

--- a/components/rpc/test/psi/rpc_real_delegate_command_test.clj
+++ b/components/rpc/test/psi/rpc_real_delegate_command_test.clj
@@ -1,6 +1,5 @@
 (ns psi.rpc-real-delegate-command-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.app-runtime :as app]
    [psi.agent-session.context :as context]
@@ -23,22 +22,6 @@
 (defn- write-line! [^java.io.Writer w line]
   (.write w (str line "\n"))
   (.flush w))
-
-(defn- parse-out-frames [^java.io.StringWriter out-writer]
-  (support/parse-frames (->> (str/split-lines (str out-writer))
-                             (remove str/blank?)
-                             vec)))
-
-(defn- wait-until
-  [pred timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (loop []
-      (let [value (pred)]
-        (if value
-          value
-          (when (< (System/currentTimeMillis) deadline)
-            (Thread/sleep 25)
-            (recur)))))))
 
 (deftest real-delegate-command-op-immediate-ack-current-behavior-test
   (testing "real workflow-loader /delegate on the RPC command op emits the immediate ack before async completion"
@@ -94,13 +77,12 @@
       (try
         (write-line! in-writer "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! in-writer "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"assistant/message\" \"command-result\" \"session/updated\" \"footer/updated\"]}}")
-        (Thread/sleep 100)
         (write-line! in-writer "{:id \"c1\" :kind :request :op \"command\" :params {:text \"/delegate lambda-compiler munera tracks work, mementum tracks state and knowledge\"}}")
         (let [interesting
-              (wait-until
-               (fn []
-                 (let [frames (parse-out-frames out-writer)
-                       events (filter #(= :event (:kind %)) frames)
+              (support/await-frames!
+               out-writer
+               (fn [frames]
+                 (let [events (filter #(= :event (:kind %)) frames)
                        xs     (keep (fn [frame]
                                       (case (:event frame)
                                         "command-result" {:kind :ack
@@ -133,16 +115,16 @@
                    (when (= [:ack :user-bridge :assistant-result] compact)
                      xs)))
                5000)
-              messages (wait-until
+              messages (support/await-until
                         (fn []
                           (let [msgs (app-messages/session-messages ctx session-id)]
                             (when (>= (count msgs) 3)
                               msgs)))
                         5000)]
           (.close in-writer)
-          (deref loop-future 1000 nil)
-          (is (some? interesting))
-          (is (some? messages))
+          (deref loop-future 1000 support/timeout-token)
+          (is (not= support/timeout-token interesting) "timed out waiting for delegate bridge events")
+          (is (not= support/timeout-token messages) "timed out waiting for session messages")
           (let [compact-seq (filterv identity
                                      (map (fn [x]
                                             (cond

--- a/components/rpc/test/psi/rpc_test.clj
+++ b/components/rpc/test/psi/rpc_test.clj
@@ -1,6 +1,5 @@
 (ns psi.rpc-test
   (:require
-   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
    [psi.agent-session.dispatch :as dispatch]
@@ -417,20 +416,25 @@
       (try
         (write-line! "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"context/updated\"]}}")
-        (Thread/sleep 100)
         (let [child-id (:psi.agent-session/session-id
                         (mutate 'psi.extension/create-child-session
                                 {:session-name "child"
                                  :tool-defs []
-                                 :thinking-level :off}))]
-          (Thread/sleep 150)
+                                 :thinking-level :off}))
+              context-evts (support/await-frames!
+                            out-writer
+                            (fn [frames]
+                              (let [context-evts (filter #(= "context/updated" (:event %)) frames)
+                                    latest (last context-evts)]
+                                (when (and (<= 2 (count context-evts))
+                                           (= session-id (get-in latest [:data :active-session-id]))
+                                           (some #(= child-id (:id %)) (get-in latest [:data :sessions])))
+                                  context-evts)))
+                            1000)]
           (.close in-writer)
-          (deref loop-future 500 nil)
-          (let [frames        (support/parse-frames (->> (str/split-lines (str out-writer))
-                                                         (remove str/blank?)
-                                                         vec))
-                context-evts (filter #(= "context/updated" (:event %)) frames)
-                latest       (last context-evts)]
+          (deref loop-future 500 support/timeout-token)
+          (is (not= support/timeout-token context-evts) "timed out waiting for context/updated with new child session")
+          (let [latest (last context-evts)]
             (is (<= 2 (count context-evts)))
             (is (= session-id (get-in latest [:data :active-session-id])))
             (is (some #(= child-id (:id %)) (get-in latest [:data :sessions])))))

--- a/components/rpc/test/psi/rpc_test_support.clj
+++ b/components/rpc/test/psi/rpc_test_support.clj
@@ -37,6 +37,8 @@
      :content (vec content)
      :stop-reason :stop})))
 
+(declare await-inflight-workers!)
+
 (defn run-loop
   "Run a stdio loop."
   ([input handler]
@@ -52,15 +54,88 @@
                            :state           state
                            :request-handler handler})
      (when (pos? wait-ms)
-       (Thread/sleep wait-ms))
+       (Thread/sleep wait-ms)
+       (await-inflight-workers! state wait-ms))
      {:out-lines (->> (str/split-lines (str out))
                       (remove str/blank?)
                       vec)
       :err-text  (str err)
       :state     @state})))
 
+(def timeout-token ::timeout)
+(def default-await-timeout-ms 1000)
+(def default-await-poll-ms 25)
+
 (defn parse-frames [lines]
   (mapv edn/read-string lines))
+
+(defn parse-out-frames
+  [^java.io.StringWriter out-writer]
+  (parse-frames (->> (str/split-lines (str out-writer))
+                     (remove str/blank?)
+                     vec)))
+
+(defn await-until
+  ([pred]
+   (await-until pred default-await-timeout-ms))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (let [value (pred)]
+         (if value
+           value
+           (if (< (System/currentTimeMillis) deadline)
+             (do
+               (Thread/sleep default-await-poll-ms)
+               (recur))
+             timeout-token)))))))
+
+(defn await-promise!
+  ([p]
+   (await-promise! p default-await-timeout-ms))
+  ([p timeout-ms]
+   (deref p timeout-ms timeout-token)))
+
+(defn await-frame!
+  ([out-writer pred]
+   (await-frame! out-writer pred default-await-timeout-ms))
+  ([out-writer pred timeout-ms]
+   (await-until (fn []
+                  (some pred (parse-out-frames out-writer)))
+                timeout-ms)))
+
+(defn await-frames!
+  ([out-writer pred]
+   (await-frames! out-writer pred default-await-timeout-ms))
+  ([out-writer pred timeout-ms]
+   (await-until (fn []
+                  (let [frames (parse-out-frames out-writer)]
+                    (when-let [value (pred frames)]
+                      value)))
+                timeout-ms)))
+
+(defn inflight-workers
+  [state]
+  (vec (get-in @state [:workers :inflight-futures] [])))
+
+(defn worker-complete?
+  [worker]
+  (cond
+    (nil? worker) true
+    (instance? java.util.concurrent.Future worker) (.isDone ^java.util.concurrent.Future worker)
+    (instance? Thread worker) (not (.isAlive ^Thread worker))
+    :else true))
+
+(defn await-inflight-workers!
+  ([state]
+   (await-inflight-workers! state default-await-timeout-ms))
+  ([state timeout-ms]
+   (await-until (fn []
+                  (let [workers (inflight-workers state)]
+                    (when (and (seq workers)
+                               (every? worker-complete? workers))
+                      workers)))
+                timeout-ms)))
 
 (defn enqueue-active-dialog!
   "Directly place a dialog into the active slot of canonical ui-state.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -102,6 +102,59 @@ layers.
 Both `:model-provider` and `:model-id` must be set together; a partial entry is
 ignored and the next lower source is used instead.
 
+---
+
+## Outbound model API proxy configuration
+
+Psi inherits outbound proxy settings for model API HTTP traffic from the process
+environment. There is no parallel proxy field in session config, project config,
+or custom provider definitions.
+
+Supported environment variables:
+
+- `HTTPS_PROXY` / `https_proxy` — used for `https://...` model API URLs
+- `HTTP_PROXY` / `http_proxy` — used for `http://...` model API URLs
+- `ALL_PROXY` / `all_proxy` — fallback when the scheme-specific variable is absent
+
+Precedence rules:
+
+1. uppercase wins over lowercase for the same logical variable
+2. scheme-specific wins over `ALL_PROXY`
+3. blank values behave as unset
+
+Supported proxy URI schemes in this implementation:
+
+- `http://`
+- `https://`
+- `socks://`
+- `socks5://`
+
+Proxy URIs must include both host and numeric port. Invalid or unsupported proxy
+URIs fail explicitly when psi prepares the provider request.
+
+`NO_PROXY` / `no_proxy` is not currently supported for model API transport in
+this implementation.
+
+Examples:
+
+```bash
+# HTTPS model APIs through an HTTP proxy
+export HTTPS_PROXY=http://proxy.example:8443
+psi
+
+# HTTP model APIs through a dedicated HTTP proxy
+export HTTP_PROXY=http://proxy.example:8080
+psi
+
+# Shared fallback proxy, including SOCKS5
+export ALL_PROXY=socks5://proxy.example:1080
+psi
+```
+
+These environment variables affect the shared OpenAI and Anthropic transport
+paths used by built-in providers and by custom providers that reuse those same
+transport implementations.
+
 ### `:thinking-level` values
 
 | Value | Meaning |

--- a/doc/custom-providers.md
+++ b/doc/custom-providers.md
@@ -93,6 +93,11 @@ same way but set `:api` to `:anthropic-messages`.
 For Anthropic-compatible providers, psi uses the Anthropic transport and will
 send the configured key through the compatible auth path.
 
+Custom providers do not define their own proxy fields. When a custom provider
+uses psi's built-in OpenAI-compatible or Anthropic-compatible transport path, it
+inherits the same environment-driven outbound proxy behavior documented in
+[`doc/configuration.md`](configuration.md).
+
 ## Local servers and custom headers
 
 The `:auth` map supports more than just an API key:

--- a/munera/open/076-model-api-proxy-support/design.md
+++ b/munera/open/076-model-api-proxy-support/design.md
@@ -5,6 +5,7 @@
 - Issue URL: https://github.com/hugoduncan/psi/issues/27
 - Issue title: Add proxy support (socks, http, https, ...) for accessing model API
 - Refinement branch: issue-27-proxy-support-model-api
+- Worktree: /Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api
 
 ## Intent
 Enable psi to reach model APIs through outbound proxies so users in restricted or corporate network environments can use psi without ad hoc source changes.
@@ -12,51 +13,59 @@ Enable psi to reach model APIs through outbound proxies so users in restricted o
 ## Problem
 psi currently supports provider-level endpoint, header, and authentication customization, but the issue requests transport-level outbound proxy support. In environments where all outbound traffic must traverse an HTTP, HTTPS, or SOCKS proxy, provider configuration alone is insufficient if the underlying HTTP client cannot be directed through a proxy by psi.
 
+## Users and scenarios
+### Primary user
+An operator running psi in an environment where direct outbound access is blocked and all model API traffic must go through an organizational proxy.
+
+### Core scenarios
+1. A user configures proxy support without editing source code.
+2. A user runs psi against a supported model provider and the outbound model API requests traverse the configured proxy.
+3. A user can tell from the docs which proxy forms are supported, where the configuration is set, and what scope that configuration has.
+4. A user gets the same proxy behavior across providers that use psi's shared model API transport path.
+
 ## Scope
 ### In scope
 - A user-visible configuration surface for outbound proxying of model API requests.
-- Support for the common proxy families explicitly named in the issue: HTTP, HTTPS, and SOCKS, or a documented proxy surface that covers those corporate egress scenarios equivalently.
+- Support for the common proxy families explicitly named in the issue: HTTP, HTTPS, and SOCKS, or a documented canonical proxy surface that covers those corporate egress scenarios equivalently.
 - Behavior that applies to model API access across psi's provider integrations rather than being limited to a single provider definition.
 - Clear user documentation for configuring and using proxy support in restricted environments.
-- Validation that proxy configuration is actually applied to outbound model API traffic.
+- Executable verification that proxy configuration is applied to outbound model API traffic.
 
 ### Out of scope
 - General corporate-environment setup beyond outbound model API proxying.
 - Changes to model behavior, prompt behavior, or non-network provider capabilities.
 - Unrelated provider feature work.
 - Proxy support for arbitrary external integrations unless they are part of the same model API transport path.
+- Defining enterprise policy, credential management, or proxy infrastructure provisioning outside psi.
 
-## Users and scenarios
-### Primary user
-An operator running psi in an environment where direct outbound access is blocked and all model API traffic must go through an organizational proxy.
+## Required behavior
+1. psi must expose one canonical user-facing way to configure outbound proxying for model API traffic.
+2. That configuration must affect the actual HTTP transport used for model API requests.
+3. The behavior must apply at the shared model API transport boundary for providers that use that shared path, not as a one-off provider-specific patch unless a provider genuinely bypasses the shared path and that exception is documented.
+4. The resulting feature must be usable without ad hoc source changes or local code patching.
+5. The implementation must document any provider or transport paths that do not participate in the shared proxy behavior.
 
-### Core scenarios
-1. A user sets proxy configuration once and psi uses it for model API requests.
-2. A user can configure a proxy without editing source code.
-3. A user can understand from the docs which configuration keys or environment variables control proxy behavior.
-4. A user can use the same proxy behavior regardless of which supported model provider is selected, as long as the provider uses psi's normal model API transport path.
+## Configuration-surface requirements
+The implementation may choose the exact mechanism during implementation, but the design requires these invariants:
+- exactly one canonical configuration story for users,
+- no requirement for per-run source edits,
+- clear statement of whether configuration is global, per provider, or a layered combination,
+- clear statement of precedence if more than one configuration source is intentionally supported,
+- the same documented story in both runtime behavior and user-facing docs.
 
-## Design decisions
-### Configuration surface
-psi must expose one canonical proxy-configuration surface for model API transport. That surface may be environment-driven, config-driven, or a clearly documented combination, but the implementation must not require per-run code changes.
-
-### Transport applicability
-Proxy configuration must affect outbound model API HTTP traffic generated by psi's model-provider path. The design is satisfied only if the proxy setting influences the actual transport used for those requests.
-
-### Provider breadth
-If multiple providers share the same transport stack, proxy support must be implemented at that shared layer so behavior is consistent across providers that use it.
-
-### Documentation requirement
-The final feature is incomplete unless user-facing documentation explains:
-- what forms of proxy are supported,
-- how a user enables them,
-- whether configuration is global or per provider,
-- and any constraints or non-goals.
+## Documentation requirements
+User-facing documentation must state:
+- which proxy families are supported,
+- how to configure them,
+- whether the setting is global or provider-scoped,
+- any precedence or override rules,
+- any unsupported modes, boundaries, or caveats relevant to operators in restricted environments.
 
 ## Constraints
 - The design must fit the existing provider/runtime architecture rather than introducing provider-specific special cases without necessity.
 - The design must preserve a single obvious way to configure outbound model API proxying.
 - The design must be testable without depending on external corporate infrastructure.
+- The implementation must be shaped so unsupported proxy forms fail as explicit documented non-goals rather than silent partial support.
 
 ## Acceptance criteria
 1. A user can configure psi so outbound model API requests are sent through a proxy.
@@ -64,16 +73,18 @@ The final feature is incomplete unless user-facing documentation explains:
 3. Proxy configuration applies to the relevant model API transport path without requiring ad hoc code changes.
 4. The behavior works across the intended provider/model API path rather than only for one narrow provider-specific path.
 5. The implementation includes executable verification that proxy configuration is honored by the transport layer used for model API requests.
-6. Any unsupported proxy mode or boundary is documented explicitly so operators know what is and is not covered.
+6. Any unsupported proxy mode, provider path, or transport boundary is documented explicitly so operators know what is and is not covered.
+7. The final implementation leaves users with one unambiguous configuration story rather than multiple conflicting proxy mechanisms.
 
-## Ambiguity check
-This design is clear at the task-design level.
+## Non-ambiguity statement
+This design is complete and unambiguous at the task-design level.
 
-Resolved choices:
-- The problem to solve is transport-level outbound proxy support for model API access.
+Resolved design decisions:
+- The task is specifically about transport-level outbound proxy support for model API access.
 - The feature must be user-configurable and documented.
-- The feature must apply at the shared model API transport boundary rather than as a one-off provider patch.
+- The feature must apply at the shared model API transport boundary wherever that boundary is used.
+- Unsupported boundaries, if any remain, must be documented explicitly.
 
-Known implementation latitude that does not make the task ambiguous:
-- The exact canonical configuration mechanism may be chosen during implementation, provided it remains singular, documented, and satisfies the acceptance criteria.
-- The exact proof technique may be chosen during implementation, provided it executable verifies that the configured proxy is used.
+Implementation latitude that remains acceptable and does not create design ambiguity:
+- The exact canonical configuration mechanism may be chosen during implementation, provided it remains singular from the user's perspective and satisfies the acceptance criteria.
+- The exact proof technique may be chosen during implementation, provided it executably verifies that configured proxy behavior reaches the transport used for model API requests.

--- a/munera/open/076-model-api-proxy-support/design.md
+++ b/munera/open/076-model-api-proxy-support/design.md
@@ -1,0 +1,131 @@
+Issue provenance
+- GitHub issue: #27
+- URL: https://github.com/hugoduncan/psi/issues/27
+- Title: Add proxy support (socks, http, https, ...) for accessing model API
+
+Goal
+Add a complete, explicit design for outbound proxy support on psi model API access so users in restricted or corporate network environments can route model traffic through supported proxies without ad hoc code changes.
+
+Problem
+psi can already target custom providers, base URLs, and custom headers, but that does not by itself guarantee transport-level proxy support for outbound requests to model APIs. Users in environments that require HTTP, HTTPS, or SOCKS proxy egress may be unable to use psi at all unless proxy handling is a first-class supported capability.
+
+Intent
+Define the product behavior, configuration surface, scope boundaries, and acceptance criteria for proxy-mediated model API access across psi’s model-provider/runtime surfaces.
+
+Scope
+In scope
+- outbound proxy support for model API requests made by psi
+- support for the proxy classes explicitly called out in the issue: HTTP, HTTPS, and SOCKS, or a clearly documented compatibility surface that satisfies those classes
+- a canonical configuration surface for proxy use
+- precedence and interaction rules when multiple configuration sources could apply
+- how proxy configuration applies across built-in and custom providers when they use psi’s canonical outbound model request path
+- documentation sufficient for a user in a restricted network environment to configure and verify proxy usage
+- tests that prove proxy configuration is interpreted and applied correctly on the canonical model API request path
+
+Out of scope
+- changing prompt behavior, model behavior, or provider semantics unrelated to transport routing
+- introducing unrelated provider features
+- solving all corporate-environment concerns beyond proxying outbound model API traffic
+- guaranteeing support for provider SDK/network paths that bypass psi’s canonical outbound HTTP path, unless this task explicitly converges them onto that path
+- advanced proxy auth schemes or enterprise certificate-management work beyond what is required to make the supported proxy surface explicit
+
+Users and scenarios
+- A user behind a corporate outbound proxy needs psi to reach Anthropic, OpenAI, or compatible model APIs.
+- A user wants one documented way to configure proxying without patching code locally.
+- A user may need either a global proxy setting for all model traffic or a provider-specific override when different providers require different network routing.
+
+Required design decisions
+1. Canonical configuration surface
+The design must choose and document the supported configuration surfaces for proxying model API traffic. The surface must be explicit and minimal.
+
+The design must state whether proxy configuration is supported through:
+- environment variables only
+- psi config only
+- both environment variables and psi config
+
+If both are supported, the design must define exact precedence.
+
+2. Proxy targeting scope
+The design must state whether proxy configuration is:
+- global for all model API traffic
+- overrideable per provider
+- both, with explicit precedence and fallback
+
+3. Supported proxy kinds
+The design must explicitly state the supported proxy kinds and their canonical representation:
+- HTTP
+- HTTPS
+- SOCKS
+
+If SOCKS support is version-limited or library-limited, that limitation must be stated explicitly.
+
+4. Canonical request-path applicability
+The design must identify the canonical outbound model request path(s) that honor proxy configuration.
+
+The design must state:
+- which psi provider/runtime components are in scope for proxy application
+- whether all model providers already share a common HTTP boundary
+- if not, whether this task requires convergence onto a shared proxy-aware boundary or explicitly limits support to the providers already using that boundary
+
+5. Error and visibility behavior
+The design must specify the expected user-visible behavior when proxy configuration is invalid or unusable.
+
+At minimum it must decide whether psi should:
+- fail fast during request setup when proxy configuration is malformed
+- surface connection/setup failures with explicit mention that proxy configuration was involved when that is knowable
+- expose the effective proxy source in diagnostics, logs, or introspection, and if so at what level while avoiding secret leakage
+
+6. Documentation surface
+The design must require user-facing documentation that covers:
+- how to configure proxy support
+- configuration precedence
+- supported schemes/examples
+- known limitations
+- how to verify that proxy-mediated access is being attempted
+
+Solution shape
+The preferred shape is a single canonical proxy-resolution layer for outbound model API requests.
+
+That layer should:
+- resolve the effective proxy configuration from the supported sources
+- validate and normalize the configured proxy value(s)
+- expose a canonical proxy configuration value to the outbound HTTP execution path
+- avoid provider-by-provider ad hoc proxy handling when the transport path is shared
+
+If provider-specific overrides are supported, they should compose with the shared resolver rather than introducing separate unrelated code paths.
+
+Configuration contract
+The final implementation derived from this design must provide one unambiguous configuration contract.
+
+This design intentionally does not lock the exact syntax yet, but the eventual syntax must satisfy all of the following:
+- a user can tell where to place proxy configuration
+- a user can tell how to express at least HTTP, HTTPS, and SOCKS proxy endpoints
+- a user can tell whether a setting applies globally or only to one provider
+- a user can tell which source wins when both environment and psi config specify proxy settings
+
+Acceptance criteria
+- psi has a documented, canonical way to configure outbound proxying for model API traffic.
+- The design defines whether proxy support is global, per-provider, or both, and the precedence rules are explicit.
+- The design explicitly covers HTTP, HTTPS, and SOCKS proxy scenarios, including any supported-scope limitations.
+- The design identifies the runtime/provider request path(s) that must honor proxy configuration.
+- The design defines how invalid or unsupported proxy configuration fails and what users can observe.
+- The design requires user-facing documentation with concrete configuration examples.
+- The design is specific enough that an implementation task can proceed without needing further scope clarification about configuration source, precedence, or affected request paths.
+
+Constraints
+- Keep the design small and implementation-guiding rather than speculative.
+- Prefer one obvious configuration model over a wide compatibility matrix.
+- Avoid introducing multiple competing proxy surfaces unless there is a clear migration or compatibility reason.
+- Preserve the project’s preference for explicit canonical surfaces over silent fallback behavior.
+
+Architecture alignment
+- psi already emphasizes canonical shared runtime surfaces over adapter-local or caller-local behavior.
+- This task should follow that pattern by defining proxy support once at the canonical outbound model API transport boundary, not separately in each UI or command path.
+- If provider implementations currently diverge, the design should call that out and choose either convergence or explicit limitation.
+
+Open ambiguities after this refinement pass
+- None. The task design is clear at the behavior/design level.
+
+Non-goals for this task
+- selecting a specific third-party HTTP client library replacement, unless existing runtime constraints make that unavoidable
+- adding a broader enterprise networking subsystem beyond the proxy capability needed for model API access

--- a/munera/open/076-model-api-proxy-support/design.md
+++ b/munera/open/076-model-api-proxy-support/design.md
@@ -1,131 +1,79 @@
-Issue provenance
+# 076 Model API proxy support
+
+## Provenance
 - GitHub issue: #27
-- URL: https://github.com/hugoduncan/psi/issues/27
-- Title: Add proxy support (socks, http, https, ...) for accessing model API
+- Issue URL: https://github.com/hugoduncan/psi/issues/27
+- Issue title: Add proxy support (socks, http, https, ...) for accessing model API
+- Refinement branch: issue-27-proxy-support-model-api
 
-Goal
-Add a complete, explicit design for outbound proxy support on psi model API access so users in restricted or corporate network environments can route model traffic through supported proxies without ad hoc code changes.
+## Intent
+Enable psi to reach model APIs through outbound proxies so users in restricted or corporate network environments can use psi without ad hoc source changes.
 
-Problem
-psi can already target custom providers, base URLs, and custom headers, but that does not by itself guarantee transport-level proxy support for outbound requests to model APIs. Users in environments that require HTTP, HTTPS, or SOCKS proxy egress may be unable to use psi at all unless proxy handling is a first-class supported capability.
+## Problem
+psi currently supports provider-level endpoint, header, and authentication customization, but the issue requests transport-level outbound proxy support. In environments where all outbound traffic must traverse an HTTP, HTTPS, or SOCKS proxy, provider configuration alone is insufficient if the underlying HTTP client cannot be directed through a proxy by psi.
 
-Intent
-Define the product behavior, configuration surface, scope boundaries, and acceptance criteria for proxy-mediated model API access across psi’s model-provider/runtime surfaces.
+## Scope
+### In scope
+- A user-visible configuration surface for outbound proxying of model API requests.
+- Support for the common proxy families explicitly named in the issue: HTTP, HTTPS, and SOCKS, or a documented proxy surface that covers those corporate egress scenarios equivalently.
+- Behavior that applies to model API access across psi's provider integrations rather than being limited to a single provider definition.
+- Clear user documentation for configuring and using proxy support in restricted environments.
+- Validation that proxy configuration is actually applied to outbound model API traffic.
 
-Scope
-In scope
-- outbound proxy support for model API requests made by psi
-- support for the proxy classes explicitly called out in the issue: HTTP, HTTPS, and SOCKS, or a clearly documented compatibility surface that satisfies those classes
-- a canonical configuration surface for proxy use
-- precedence and interaction rules when multiple configuration sources could apply
-- how proxy configuration applies across built-in and custom providers when they use psi’s canonical outbound model request path
-- documentation sufficient for a user in a restricted network environment to configure and verify proxy usage
-- tests that prove proxy configuration is interpreted and applied correctly on the canonical model API request path
+### Out of scope
+- General corporate-environment setup beyond outbound model API proxying.
+- Changes to model behavior, prompt behavior, or non-network provider capabilities.
+- Unrelated provider feature work.
+- Proxy support for arbitrary external integrations unless they are part of the same model API transport path.
 
-Out of scope
-- changing prompt behavior, model behavior, or provider semantics unrelated to transport routing
-- introducing unrelated provider features
-- solving all corporate-environment concerns beyond proxying outbound model API traffic
-- guaranteeing support for provider SDK/network paths that bypass psi’s canonical outbound HTTP path, unless this task explicitly converges them onto that path
-- advanced proxy auth schemes or enterprise certificate-management work beyond what is required to make the supported proxy surface explicit
+## Users and scenarios
+### Primary user
+An operator running psi in an environment where direct outbound access is blocked and all model API traffic must go through an organizational proxy.
 
-Users and scenarios
-- A user behind a corporate outbound proxy needs psi to reach Anthropic, OpenAI, or compatible model APIs.
-- A user wants one documented way to configure proxying without patching code locally.
-- A user may need either a global proxy setting for all model traffic or a provider-specific override when different providers require different network routing.
+### Core scenarios
+1. A user sets proxy configuration once and psi uses it for model API requests.
+2. A user can configure a proxy without editing source code.
+3. A user can understand from the docs which configuration keys or environment variables control proxy behavior.
+4. A user can use the same proxy behavior regardless of which supported model provider is selected, as long as the provider uses psi's normal model API transport path.
 
-Required design decisions
-1. Canonical configuration surface
-The design must choose and document the supported configuration surfaces for proxying model API traffic. The surface must be explicit and minimal.
+## Design decisions
+### Configuration surface
+psi must expose one canonical proxy-configuration surface for model API transport. That surface may be environment-driven, config-driven, or a clearly documented combination, but the implementation must not require per-run code changes.
 
-The design must state whether proxy configuration is supported through:
-- environment variables only
-- psi config only
-- both environment variables and psi config
+### Transport applicability
+Proxy configuration must affect outbound model API HTTP traffic generated by psi's model-provider path. The design is satisfied only if the proxy setting influences the actual transport used for those requests.
 
-If both are supported, the design must define exact precedence.
+### Provider breadth
+If multiple providers share the same transport stack, proxy support must be implemented at that shared layer so behavior is consistent across providers that use it.
 
-2. Proxy targeting scope
-The design must state whether proxy configuration is:
-- global for all model API traffic
-- overrideable per provider
-- both, with explicit precedence and fallback
+### Documentation requirement
+The final feature is incomplete unless user-facing documentation explains:
+- what forms of proxy are supported,
+- how a user enables them,
+- whether configuration is global or per provider,
+- and any constraints or non-goals.
 
-3. Supported proxy kinds
-The design must explicitly state the supported proxy kinds and their canonical representation:
-- HTTP
-- HTTPS
-- SOCKS
+## Constraints
+- The design must fit the existing provider/runtime architecture rather than introducing provider-specific special cases without necessity.
+- The design must preserve a single obvious way to configure outbound model API proxying.
+- The design must be testable without depending on external corporate infrastructure.
 
-If SOCKS support is version-limited or library-limited, that limitation must be stated explicitly.
+## Acceptance criteria
+1. A user can configure psi so outbound model API requests are sent through a proxy.
+2. The supported proxy types and configuration surface are documented in user-facing documentation.
+3. Proxy configuration applies to the relevant model API transport path without requiring ad hoc code changes.
+4. The behavior works across the intended provider/model API path rather than only for one narrow provider-specific path.
+5. The implementation includes executable verification that proxy configuration is honored by the transport layer used for model API requests.
+6. Any unsupported proxy mode or boundary is documented explicitly so operators know what is and is not covered.
 
-4. Canonical request-path applicability
-The design must identify the canonical outbound model request path(s) that honor proxy configuration.
+## Ambiguity check
+This design is clear at the task-design level.
 
-The design must state:
-- which psi provider/runtime components are in scope for proxy application
-- whether all model providers already share a common HTTP boundary
-- if not, whether this task requires convergence onto a shared proxy-aware boundary or explicitly limits support to the providers already using that boundary
+Resolved choices:
+- The problem to solve is transport-level outbound proxy support for model API access.
+- The feature must be user-configurable and documented.
+- The feature must apply at the shared model API transport boundary rather than as a one-off provider patch.
 
-5. Error and visibility behavior
-The design must specify the expected user-visible behavior when proxy configuration is invalid or unusable.
-
-At minimum it must decide whether psi should:
-- fail fast during request setup when proxy configuration is malformed
-- surface connection/setup failures with explicit mention that proxy configuration was involved when that is knowable
-- expose the effective proxy source in diagnostics, logs, or introspection, and if so at what level while avoiding secret leakage
-
-6. Documentation surface
-The design must require user-facing documentation that covers:
-- how to configure proxy support
-- configuration precedence
-- supported schemes/examples
-- known limitations
-- how to verify that proxy-mediated access is being attempted
-
-Solution shape
-The preferred shape is a single canonical proxy-resolution layer for outbound model API requests.
-
-That layer should:
-- resolve the effective proxy configuration from the supported sources
-- validate and normalize the configured proxy value(s)
-- expose a canonical proxy configuration value to the outbound HTTP execution path
-- avoid provider-by-provider ad hoc proxy handling when the transport path is shared
-
-If provider-specific overrides are supported, they should compose with the shared resolver rather than introducing separate unrelated code paths.
-
-Configuration contract
-The final implementation derived from this design must provide one unambiguous configuration contract.
-
-This design intentionally does not lock the exact syntax yet, but the eventual syntax must satisfy all of the following:
-- a user can tell where to place proxy configuration
-- a user can tell how to express at least HTTP, HTTPS, and SOCKS proxy endpoints
-- a user can tell whether a setting applies globally or only to one provider
-- a user can tell which source wins when both environment and psi config specify proxy settings
-
-Acceptance criteria
-- psi has a documented, canonical way to configure outbound proxying for model API traffic.
-- The design defines whether proxy support is global, per-provider, or both, and the precedence rules are explicit.
-- The design explicitly covers HTTP, HTTPS, and SOCKS proxy scenarios, including any supported-scope limitations.
-- The design identifies the runtime/provider request path(s) that must honor proxy configuration.
-- The design defines how invalid or unsupported proxy configuration fails and what users can observe.
-- The design requires user-facing documentation with concrete configuration examples.
-- The design is specific enough that an implementation task can proceed without needing further scope clarification about configuration source, precedence, or affected request paths.
-
-Constraints
-- Keep the design small and implementation-guiding rather than speculative.
-- Prefer one obvious configuration model over a wide compatibility matrix.
-- Avoid introducing multiple competing proxy surfaces unless there is a clear migration or compatibility reason.
-- Preserve the project’s preference for explicit canonical surfaces over silent fallback behavior.
-
-Architecture alignment
-- psi already emphasizes canonical shared runtime surfaces over adapter-local or caller-local behavior.
-- This task should follow that pattern by defining proxy support once at the canonical outbound model API transport boundary, not separately in each UI or command path.
-- If provider implementations currently diverge, the design should call that out and choose either convergence or explicit limitation.
-
-Open ambiguities after this refinement pass
-- None. The task design is clear at the behavior/design level.
-
-Non-goals for this task
-- selecting a specific third-party HTTP client library replacement, unless existing runtime constraints make that unavoidable
-- adding a broader enterprise networking subsystem beyond the proxy capability needed for model API access
+Known implementation latitude that does not make the task ambiguous:
+- The exact canonical configuration mechanism may be chosen during implementation, provided it remains singular, documented, and satisfies the acceptance criteria.
+- The exact proof technique may be chosen during implementation, provided it executable verifies that the configured proxy is used.

--- a/munera/open/076-model-api-proxy-support/design.md
+++ b/munera/open/076-model-api-proxy-support/design.md
@@ -3,6 +3,9 @@
 ## Provenance
 - GitHub issue: #27
 - Issue URL: https://github.com/hugoduncan/psi/issues/27
+- GitHub PR: #66
+- PR URL: https://github.com/hugoduncan/psi/pull/66
+- PR branch: issue-27-proxy-support-model-api
 - Issue title: Add proxy support (socks, http, https, ...) for accessing model API
 - Refinement branch: issue-27-proxy-support-model-api
 - Worktree: /Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api
@@ -100,6 +103,53 @@ This yields one unambiguous story: psi inherits proxy settings from the process 
 5. Add provider-level tests proving that OpenAI and Anthropic transport calls pass the expected proxy options to `http/post` when the relevant environment variables are set.
 6. Update user docs to describe the canonical environment-based configuration story, supported proxy variable names, precedence, and caveats.
 
+## Intended implementation slices
+1. Inspect the existing transport helper seams in `components/ai/src/psi/ai/providers/openai/transport.clj` and `components/ai/src/psi/ai/providers/anthropic.clj` and choose the narrowest shared enrichment point that both providers can use without changing provider protocols.
+2. Add a dedicated proxy helper namespace under `components/ai/src/psi/ai/` with pure functions for environment normalization, URL-scheme selection, proxy URI parsing, and clj-http option projection.
+3. Keep environment reading at the edge of that helper so tests can exercise pure logic with injected env maps instead of mutating process state globally.
+4. Extend the provider transport call path so the final request map passed into `clj-http.client/post` is `(merge existing-options proxy-options)` and remains directly observable to existing stubs.
+5. Add focused unit tests for the helper first, then provider transport tests for both OpenAI and Anthropic integration points.
+6. Update docs only after the exact supported URI forms and any `NO_PROXY` limitation are proven by the implementation/tests.
+
+## Builder-oriented implementation approach
+### Files and namespaces expected to change
+- Add one new shared helper namespace under `components/ai/src/psi/ai/`, likely `proxy.clj` or equivalently named, containing only proxy normalization/selection/projection logic.
+- Update `components/ai/src/psi/ai/providers/openai/transport.clj` so the final options map passed to `clj-http.client/post` is enriched by the shared proxy helper.
+- Update `components/ai/src/psi/ai/providers/anthropic.clj` at the equivalent `http/post` boundary with the same enrichment call.
+- Add focused tests under the `components/ai/test/psi/ai/` tree for the shared helper and update provider transport tests in the existing OpenAI and Anthropic test namespaces.
+- Update user docs in `README.md`, `doc/psi-project-config.md`, and `doc/custom-providers.md` only where they describe real supported behavior after implementation is proved.
+
+### Integration point constraints
+- The builder must not add proxy parameters to provider protocol methods, runtime session state, or model definitions.
+- The builder must not thread proxy state through unrelated runtime layers if the provider transport already has enough information via request URL and process environment.
+- The builder should enrich only the final clj-http request options map, preserving current provider-owned request body, headers, auth, capture hooks, response decoding, and exception behavior.
+- If the codebase already has a common request-options helper used by both providers, extend that helper instead of inserting duplicate calls in multiple places; otherwise a direct shared helper call at each provider `http/post` boundary is acceptable.
+
+### Expected helper API shape
+The implementation should be explicit enough that a later builder does not need to invent the helper contract. A suitable public surface is:
+- `normalize-proxy-env` — pure, takes an env map, returns normalized logical proxy config.
+- `effective-proxy-for-url` — pure, takes normalized config plus request URL, returns either `nil` or a parsed effective proxy map.
+- `proxy-request-options` — pure, takes parsed effective proxy data, returns a clj-http-compatible options map.
+- `request-proxy-options` or equivalent convenience helper — edge function that reads the process env once and returns the final options map for a given request URL.
+
+Names may differ, but the separation of concerns must remain: normalize env → resolve effective proxy → project request options.
+
+### Expected request enrichment flow
+For each provider transport call:
+1. Construct the current provider request map exactly as today.
+2. Determine the request URL string already being posted.
+3. Call the shared proxy helper with that URL.
+4. Merge the returned options into the final request map immediately before `http/post`.
+5. Leave the no-proxy case as an empty map merge so current behavior is unchanged.
+
+The implementation should prefer a shape equivalent to:
+```clojure
+(let [request-options {...provider-owned request options...}
+      proxy-options   (proxy/request-proxy-options request-url)]
+  (http/post request-url (merge request-options proxy-options)))
+```
+If a shared helper returns the final merged map instead, that is acceptable only if the provider-owned request map remains directly observable to tests and capture seams.
+
 ## Key algorithms and rules
 ### 1. Environment normalization
 Input: current process environment map.
@@ -133,7 +183,8 @@ Input: effective proxy URI.
 
 Projection rules:
 - parse the proxy URI once into its components;
-- map supported schemes to clj-http options in the form expected by the client, including host, port, and protocol-specific flags;
+- require a host and numeric port; missing host/port is an error, not an implicit default;
+- map supported schemes to clj-http options in the exact form expected by the client, including host, port, and protocol-specific flags;
 - attach auth fields only if present in the proxy URI and supported by clj-http;
 - merge the resulting proxy options with existing request options without changing existing headers/body/as/throw-exceptions behavior.
 
@@ -183,7 +234,7 @@ The final concrete keys must match `clj-http` expectations, but the helper shoul
 - If there is already a common request-helper seam for provider transports, prefer extending that seam instead of duplicating helper calls.
 
 ### Documentation surfaces
-- Update `README.md` and/or `doc/configuration.md` with the canonical proxy configuration story.
+- Update `README.md` and/or `doc/psi-project-config.md` with the canonical proxy configuration story.
 - Add or update a focused doc section describing:
   - supported variables,
   - precedence,
@@ -194,8 +245,14 @@ The final concrete keys must match `clj-http` expectations, but the helper shoul
 
 ### User-visible command/config surfaces
 - No new slash command.
-- No new `.psi/models.edn` field.
+- No new `.psi/project.edn` or model-definition proxy field.
 - No new resolver/API surface is required for this task unless the implementation adds introspection for diagnostics; if so, it must be documented as auxiliary, not as the primary configuration mechanism.
+
+## Architectural fit and constraints
+- The change must preserve the current separation between provider semantics and transport mechanics.
+- The helper should be pure-by-default and not require wider runtime state threading.
+- Existing request capture/test seams should remain intact so current provider tests can continue to observe the final request map at the `http/post` boundary.
+- The implementation must not introduce a parallel proxy story in project config or provider definitions.
 
 ## Invariants
 - One canonical user configuration story: environment variables.
@@ -208,6 +265,8 @@ The final concrete keys must match `clj-http` expectations, but the helper shoul
 ## Edge cases and explicit decisions
 - If both uppercase and lowercase environment variables are present with different values, uppercase wins.
 - If both scheme-specific and `ALL_PROXY` are present, the scheme-specific value wins.
+- Blank env values behave as unset.
+- Request URLs without `http` or `https` schemes are outside the supported proxy surface and should not silently coerce into a supported scheme.
 - SOCKS support is in scope only if `clj-http` supports the required option projection cleanly from the same helper. If a named SOCKS variant is not actually supported by the underlying client, the implementation must fail clearly and document the limitation instead of claiming broad SOCKS support.
 - `NO_PROXY` support is optional in this task design only if the implementation surface cannot support it coherently with the chosen client options. The final implementation must either support it and document matching rules, or document it as unsupported.
 - Proxy support applies only to model API HTTP traffic; it does not imply proxying unrelated runtime subsystems.
@@ -215,11 +274,21 @@ The final concrete keys must match `clj-http` expectations, but the helper shoul
 
 ## Verification expectations
 The implementation is done only when all of the following are true:
-1. Focused unit tests cover environment normalization, precedence, effective-proxy selection, malformed URI handling, and unsupported-scheme handling.
+1. Focused unit tests cover environment normalization, precedence, effective-proxy selection, malformed URI handling, missing host/port handling, and unsupported-scheme handling.
 2. OpenAI transport tests prove that an applicable proxy environment variable yields proxy options in the final `http/post` request map.
 3. Anthropic transport tests prove the same.
 4. Tests also prove that no proxy options are added when no relevant environment variable is set.
-5. Docs clearly describe the supported proxy configuration story and any boundaries or caveats.
+5. If proxy credentials are supported, tests prove they are projected correctly and not leaked in any diagnostic surface that is asserted.
+6. Docs clearly describe the supported proxy configuration story and any boundaries or caveats.
+
+### Verification commands to expect during implementation
+The builder should expect to run focused AI-component tests first, then broader verification only if needed. At minimum, verification should include:
+- focused tests for the new proxy helper namespace,
+- focused Anthropic transport tests,
+- focused OpenAI transport tests,
+- any doc or lint checks normally run for touched files if the repository has a standard task for them.
+
+Exact commands may follow existing project conventions, but the builder must preserve a narrow feedback loop and record the real commands/results in `implementation.md`.
 
 ## Alternatives considered
 ### Add proxy fields to provider definitions
@@ -230,6 +299,9 @@ Rejected because it duplicates well-understood process-environment behavior, add
 
 ### Implement proxy logic separately inside each provider
 Rejected because the built-in providers already share the same HTTP client boundary and duplicated logic would drift.
+
+### Add broad runtime/global networking settings first
+Rejected for this task because the requested behavior is specifically model API reachability and the narrowest correct change is at the shared AI transport boundary already used by the affected providers.
 
 ## Acceptance criteria
 1. A user can configure psi so outbound model API requests are sent through a proxy by setting documented environment variables before launching psi.

--- a/munera/open/076-model-api-proxy-support/design.md
+++ b/munera/open/076-model-api-proxy-support/design.md
@@ -11,7 +11,15 @@
 Enable psi to reach model APIs through outbound proxies so users in restricted or corporate network environments can use psi without ad hoc source changes.
 
 ## Problem
-psi currently supports provider-level endpoint, header, and authentication customization, but the issue requests transport-level outbound proxy support. In environments where all outbound traffic must traverse an HTTP, HTTPS, or SOCKS proxy, provider configuration alone is insufficient if the underlying HTTP client cannot be directed through a proxy by psi.
+psi currently supports provider-level endpoint, header, and authentication customization, but the issue requests transport-level outbound proxy support. In environments where all outbound traffic must traverse an HTTP, HTTPS, or SOCKS proxy, provider configuration alone is insufficient if the underlying shared HTTP transport cannot be directed through a proxy by psi.
+
+## Existing architecture and fit
+- Model API calls currently flow through the shared AI transport layer in `components/ai/`.
+- The built-in Anthropic and OpenAI providers both issue HTTP requests through `clj-http.client/post`.
+- Custom provider definitions change API base URLs, auth, headers, and model metadata, but they do not currently provide a dedicated transport-proxy surface.
+- Because the transport boundary is shared, proxy behavior should be introduced once in the common request-options path used by provider transport functions, instead of inventing provider-specific proxy logic.
+
+This task therefore fits the existing architecture by adding a canonical proxy-configuration projection into provider request option construction, while keeping provider protocol semantics unchanged.
 
 ## Users and scenarios
 ### Primary user
@@ -22,14 +30,16 @@ An operator running psi in an environment where direct outbound access is blocke
 2. A user runs psi against a supported model provider and the outbound model API requests traverse the configured proxy.
 3. A user can tell from the docs which proxy forms are supported, where the configuration is set, and what scope that configuration has.
 4. A user gets the same proxy behavior across providers that use psi's shared model API transport path.
+5. A user can still override provider base URLs independently of proxying; proxy configuration affects transport routing, not model/provider identity.
 
 ## Scope
 ### In scope
 - A user-visible configuration surface for outbound proxying of model API requests.
-- Support for the common proxy families explicitly named in the issue: HTTP, HTTPS, and SOCKS, or a documented canonical proxy surface that covers those corporate egress scenarios equivalently.
+- Support for the common proxy families explicitly named in the issue: HTTP, HTTPS, and SOCKS.
 - Behavior that applies to model API access across psi's provider integrations rather than being limited to a single provider definition.
 - Clear user documentation for configuring and using proxy support in restricted environments.
 - Executable verification that proxy configuration is applied to outbound model API traffic.
+- Configuration parsing and normalization sufficient to support a single canonical runtime state shape for proxy settings.
 
 ### Out of scope
 - General corporate-environment setup beyond outbound model API proxying.
@@ -37,38 +47,192 @@ An operator running psi in an environment where direct outbound access is blocke
 - Unrelated provider feature work.
 - Proxy support for arbitrary external integrations unless they are part of the same model API transport path.
 - Defining enterprise policy, credential management, or proxy infrastructure provisioning outside psi.
+- Runtime UI for interactively editing proxy settings.
 
-## Required behavior
-1. psi must expose one canonical user-facing way to configure outbound proxying for model API traffic.
-2. That configuration must affect the actual HTTP transport used for model API requests.
-3. The behavior must apply at the shared model API transport boundary for providers that use that shared path, not as a one-off provider-specific patch unless a provider genuinely bypasses the shared path and that exception is documented.
-4. The resulting feature must be usable without ad hoc source changes or local code patching.
-5. The implementation must document any provider or transport paths that do not participate in the shared proxy behavior.
+## Chosen implementation strategy
+Implement proxy support as a shared transport concern in `components/ai/`, backed by one canonical configuration source: environment-driven proxy settings read by psi at runtime and translated into clj-http request options.
 
-## Configuration-surface requirements
-The implementation may choose the exact mechanism during implementation, but the design requires these invariants:
-- exactly one canonical configuration story for users,
-- no requirement for per-run source edits,
-- clear statement of whether configuration is global, per provider, or a layered combination,
-- clear statement of precedence if more than one configuration source is intentionally supported,
-- the same documented story in both runtime behavior and user-facing docs.
+### Why this strategy fits
+- `clj-http` already supports proxy-related request options, so psi can rely on the existing HTTP client rather than adding a new transport stack.
+- Environment-driven proxy configuration matches operator expectations in restricted environments and avoids inventing a new project-specific config file surface for a feature that is usually deployment-scoped.
+- A shared request-options helper keeps Anthropic, OpenAI, and compatible custom providers aligned through one mechanism.
+- This approach preserves the current provider model architecture: provider definitions continue to describe endpoint/auth/model semantics, while transport routing concerns stay at the transport boundary.
 
-## Documentation requirements
-User-facing documentation must state:
-- which proxy families are supported,
-- how to configure them,
-- whether the setting is global or provider-scoped,
-- any precedence or override rules,
-- any unsupported modes, boundaries, or caveats relevant to operators in restricted environments.
+## Canonical configuration story
+The canonical user-facing configuration surface is environment variables.
 
-## Constraints
-- The design must fit the existing provider/runtime architecture rather than introducing provider-specific special cases without necessity.
-- The design must preserve a single obvious way to configure outbound model API proxying.
-- The design must be testable without depending on external corporate infrastructure.
-- The implementation must be shaped so unsupported proxy forms fail as explicit documented non-goals rather than silent partial support.
+### Supported environment variables
+- `HTTP_PROXY`
+- `HTTPS_PROXY`
+- `ALL_PROXY`
+- lowercase equivalents when present (`http_proxy`, `https_proxy`, `all_proxy`)
+- `NO_PROXY` / `no_proxy` only if the implementation can support it coherently through clj-http for the same transport path; otherwise it must be explicitly documented as unsupported in this task's implementation.
+
+### Canonical semantics
+- `HTTPS_PROXY` applies to HTTPS model API URLs.
+- `HTTP_PROXY` applies to HTTP model API URLs.
+- `ALL_PROXY` is the fallback when the scheme-specific variable is absent.
+- Scheme-specific variables take precedence over `ALL_PROXY`.
+- Uppercase and lowercase names are treated as equivalent, with uppercase winning if both are set to different values.
+- Provider/model config files do not gain a separate proxy field in this task.
+- Users configure proxies outside psi and then run psi normally.
+
+This yields one unambiguous story: psi inherits proxy settings from the process environment and applies them to model API transport.
+
+## Required runtime behavior
+1. When a built-in or compatible provider transport prepares an outbound HTTP request, psi must resolve the effective proxy from the request URL scheme and the environment.
+2. psi must translate that resolved proxy into the clj-http request options expected by the underlying client.
+3. If no proxy environment variable applies, psi must preserve current direct-connection behavior.
+4. If a proxy URI is malformed or unsupported, psi must fail explicitly with a clear diagnostic rather than silently ignoring the setting.
+5. Proxy support must apply consistently across the shared model API transport path, including built-in OpenAI and Anthropic providers and custom providers that reuse those transport implementations.
+6. Provider capture callbacks must continue to work; proxy support must not remove existing request/response capture behavior.
+7. Proxy support must not alter request payloads, auth semantics, or provider selection logic.
+
+## Main procedural approach
+1. Add a small shared helper namespace in `components/ai/` responsible for:
+   - reading proxy-related environment variables,
+   - normalizing them into a canonical internal map,
+   - selecting the effective proxy for a target request URL,
+   - converting the chosen proxy into clj-http request options.
+2. Route all model-provider `http/post` calls through a shared request-options merge that includes those proxy options.
+3. Keep provider request construction separate from transport option enrichment: request body/headers stay provider-owned; proxy transport options are added immediately before the `http/post` boundary.
+4. Add focused unit tests around proxy resolution and request-option injection.
+5. Add provider-level tests proving that OpenAI and Anthropic transport calls pass the expected proxy options to `http/post` when the relevant environment variables are set.
+6. Update user docs to describe the canonical environment-based configuration story, supported proxy variable names, precedence, and caveats.
+
+## Key algorithms and rules
+### 1. Environment normalization
+Input: current process environment map.
+
+Normalization rules:
+- read uppercase and lowercase forms for each supported variable;
+- for each logical key, prefer uppercase over lowercase when both are present;
+- ignore blank values;
+- keep only the proxy variables relevant to transport resolution.
+
+Canonical normalized shape:
+```clojure
+{:http  "http://proxy.example:8080"
+ :https "http://secure-proxy.example:8443"
+ :all   "socks5://proxy.example:1080"
+ :no-proxy "example.com,localhost"} ; only if supported in the implementation
+```
+
+### 2. Effective-proxy selection
+Input: normalized proxy config and request URL.
+
+Selection rules:
+- parse the request URL scheme;
+- for `https` URLs, choose `:https` first, else `:all`;
+- for `http` URLs, choose `:http` first, else `:all`;
+- for any other scheme, do not proxy and treat it as outside the supported surface unless the underlying transport already supports it and the implementation chooses to cover it explicitly;
+- if `NO_PROXY` support is implemented, bypass the proxy when the target host matches the bypass rules.
+
+### 3. Request-option projection
+Input: effective proxy URI.
+
+Projection rules:
+- parse the proxy URI once into its components;
+- map supported schemes to clj-http options in the form expected by the client, including host, port, and protocol-specific flags;
+- attach auth fields only if present in the proxy URI and supported by clj-http;
+- merge the resulting proxy options with existing request options without changing existing headers/body/as/throw-exceptions behavior.
+
+### 4. Failure behavior
+- malformed proxy URI => explicit exception with the offending environment variable name;
+- unsupported proxy scheme => explicit exception listing the supported schemes for this task;
+- absent proxy => no added proxy options.
+
+## Main data structures and state shapes
+### Normalized proxy config
+```clojure
+{:http     string?
+ :https    string?
+ :all      string?
+ :no-proxy string?} ; optional, only if supported
+```
+
+### Parsed effective proxy
+```clojure
+{:source-env :https
+ :raw-uri    "http://proxy.example:8080"
+ :scheme     :http
+ :host       "proxy.example"
+ :port       8080
+ :username   "user"      ; optional
+ :password   "secret"    ; optional, avoid logging raw secret
+}
+```
+
+### Request option enrichment output
+A plain clj-http options map merged into the provider's existing request map, for example:
+```clojure
+{:proxy-host "proxy.example"
+ :proxy-port 8080
+ :proxy-user "user"
+ :proxy-pass "secret"
+ :proxy-scheme :http}
+```
+
+The final concrete keys must match `clj-http` expectations, but the helper should expose one internal projection boundary so providers do not each reinvent it.
+
+## Interface surfaces to add or change
+### Code surfaces
+- Add a shared proxy helper namespace under `components/ai/src/psi/ai/`.
+- Update OpenAI transport code to enrich outbound `http/post` options with resolved proxy settings.
+- Update Anthropic transport code to enrich outbound `http/post` options with resolved proxy settings.
+- If there is already a common request-helper seam for provider transports, prefer extending that seam instead of duplicating helper calls.
+
+### Documentation surfaces
+- Update `README.md` and/or `doc/configuration.md` with the canonical proxy configuration story.
+- Add or update a focused doc section describing:
+  - supported variables,
+  - precedence,
+  - supported proxy URI forms,
+  - whether `NO_PROXY` is supported,
+  - examples for HTTP/HTTPS and SOCKS usage.
+- Update `doc/custom-providers.md` to clarify that custom providers reuse the same transport-level proxy behavior when they go through the built-in OpenAI or Anthropic transport paths.
+
+### User-visible command/config surfaces
+- No new slash command.
+- No new `.psi/models.edn` field.
+- No new resolver/API surface is required for this task unless the implementation adds introspection for diagnostics; if so, it must be documented as auxiliary, not as the primary configuration mechanism.
+
+## Invariants
+- One canonical user configuration story: environment variables.
+- Transport-level proxy support is orthogonal to provider definition and model selection.
+- OpenAI and Anthropic transports must resolve proxy configuration the same way.
+- Direct behavior remains unchanged when proxy variables are unset.
+- Proxy parsing and selection logic lives in one shared place.
+- Secrets from proxy credentials must not be exposed in request-capture logs without redaction.
+
+## Edge cases and explicit decisions
+- If both uppercase and lowercase environment variables are present with different values, uppercase wins.
+- If both scheme-specific and `ALL_PROXY` are present, the scheme-specific value wins.
+- SOCKS support is in scope only if `clj-http` supports the required option projection cleanly from the same helper. If a named SOCKS variant is not actually supported by the underlying client, the implementation must fail clearly and document the limitation instead of claiming broad SOCKS support.
+- `NO_PROXY` support is optional in this task design only if the implementation surface cannot support it coherently with the chosen client options. The final implementation must either support it and document matching rules, or document it as unsupported.
+- Proxy support applies only to model API HTTP traffic; it does not imply proxying unrelated runtime subsystems.
+- Existing tests that stub `http/post` must keep working; helper injection should remain observable at the final request map passed into `http/post`.
+
+## Verification expectations
+The implementation is done only when all of the following are true:
+1. Focused unit tests cover environment normalization, precedence, effective-proxy selection, malformed URI handling, and unsupported-scheme handling.
+2. OpenAI transport tests prove that an applicable proxy environment variable yields proxy options in the final `http/post` request map.
+3. Anthropic transport tests prove the same.
+4. Tests also prove that no proxy options are added when no relevant environment variable is set.
+5. Docs clearly describe the supported proxy configuration story and any boundaries or caveats.
+
+## Alternatives considered
+### Add proxy fields to provider definitions
+Rejected because proxying is a deployment/transport concern, not model-definition identity. It would create a second competing configuration story and force duplicate settings across providers.
+
+### Add a new psi-specific config file surface for proxy settings
+Rejected because it duplicates well-understood process-environment behavior, adds new configuration machinery, and is less natural for corporate execution environments.
+
+### Implement proxy logic separately inside each provider
+Rejected because the built-in providers already share the same HTTP client boundary and duplicated logic would drift.
 
 ## Acceptance criteria
-1. A user can configure psi so outbound model API requests are sent through a proxy.
+1. A user can configure psi so outbound model API requests are sent through a proxy by setting documented environment variables before launching psi.
 2. The supported proxy types and configuration surface are documented in user-facing documentation.
 3. Proxy configuration applies to the relevant model API transport path without requiring ad hoc code changes.
 4. The behavior works across the intended provider/model API path rather than only for one narrow provider-specific path.
@@ -77,14 +241,6 @@ User-facing documentation must state:
 7. The final implementation leaves users with one unambiguous configuration story rather than multiple conflicting proxy mechanisms.
 
 ## Non-ambiguity statement
-This design is complete and unambiguous at the task-design level.
+This design is complete and unambiguous for implementation handoff.
 
-Resolved design decisions:
-- The task is specifically about transport-level outbound proxy support for model API access.
-- The feature must be user-configurable and documented.
-- The feature must apply at the shared model API transport boundary wherever that boundary is used.
-- Unsupported boundaries, if any remain, must be documented explicitly.
-
-Implementation latitude that remains acceptable and does not create design ambiguity:
-- The exact canonical configuration mechanism may be chosen during implementation, provided it remains singular from the user's perspective and satisfies the acceptance criteria.
-- The exact proof technique may be chosen during implementation, provided it executably verifies that configured proxy behavior reaches the transport used for model API requests.
+No material ambiguities remain. The later builder should not invent a different configuration surface or provider-specific mechanism; the intended implementation is shared, environment-driven transport proxy support at the `components/ai` HTTP boundary, with explicit tests and docs.

--- a/munera/open/076-model-api-proxy-support/implementation.md
+++ b/munera/open/076-model-api-proxy-support/implementation.md
@@ -1,0 +1,11 @@
+Issue provenance
+- GitHub issue: #27
+- URL: https://github.com/hugoduncan/psi/issues/27
+
+2026-05-01/02 — refinement notes
+- created task `076-model-api-proxy-support`
+- anchored design on issue #27 and the existing triage comment intent/scope
+- made configuration-surface choice an explicit required design decision so implementation will not proceed with ambiguous env-vs-config semantics
+- made request-path applicability explicit because proxy support is only meaningful if the canonical outbound model transport boundary is named
+- constrained scope away from general enterprise networking and unrelated provider changes
+- declared ambiguity status clear for design-level refinement: no remaining ambiguity about the task’s intent, scope, acceptance surface, or required design decisions

--- a/munera/open/076-model-api-proxy-support/implementation.md
+++ b/munera/open/076-model-api-proxy-support/implementation.md
@@ -3,6 +3,7 @@
 - 2026-05-01: Created task from GitHub issue #27 (`https://github.com/hugoduncan/psi/issues/27`).
 - 2026-05-01: Used existing issue worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api` on branch `issue-27-proxy-support-model-api`.
 - 2026-05-01: Confirmed canonical task id `076` because existing open/closed task ids already reached `075` and `076` was unused.
-- 2026-05-01: Refined the issue into a task-design artifact focused on transport-level outbound proxy support for model API requests.
-- 2026-05-01: Tightened the design so the user-facing configuration story, transport applicability, provider breadth, documentation obligations, and unsupported-boundary disclosure are explicit.
-- 2026-05-01: Declared the design clear at the task level; remaining choices are implementation decisions, not unresolved scope ambiguity.
+- 2026-05-01: Read the issue comment history and current transport code in `components/ai/src/psi/ai/providers/openai/transport.clj` and `components/ai/src/psi/ai/providers/anthropic.clj` to ground the design in the real HTTP boundary.
+- 2026-05-01: Replaced the earlier behavior-only design with an implementation-grade design that explicitly chooses environment-driven proxy configuration, shared transport helper extraction, provider integration points, proxy precedence rules, data shapes, edge cases, and verification expectations.
+- 2026-05-01: Explicitly rejected provider-local proxy fields and a new psi-specific proxy config file to preserve one canonical operator story.
+- 2026-05-01: Declared the design clear; no material task-level ambiguities remain after specifying the intended implementation mechanism and boundaries.

--- a/munera/open/076-model-api-proxy-support/implementation.md
+++ b/munera/open/076-model-api-proxy-support/implementation.md
@@ -1,7 +1,8 @@
 # Implementation notes
 
 - 2026-05-01: Created task from GitHub issue #27 (`https://github.com/hugoduncan/psi/issues/27`).
-- 2026-05-01: Chose canonical task id `076` because existing open/closed task ids already reached `075` and `076` was unused.
+- 2026-05-01: Used existing issue worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api` on branch `issue-27-proxy-support-model-api`.
+- 2026-05-01: Confirmed canonical task id `076` because existing open/closed task ids already reached `075` and `076` was unused.
 - 2026-05-01: Refined the issue into a task-design artifact focused on transport-level outbound proxy support for model API requests.
-- 2026-05-01: Captured issue scope from the issue body and owner triage comment; preserved implementation latitude only where it does not create task ambiguity.
+- 2026-05-01: Tightened the design so the user-facing configuration story, transport applicability, provider breadth, documentation obligations, and unsupported-boundary disclosure are explicit.
 - 2026-05-01: Declared the design clear at the task level; remaining choices are implementation decisions, not unresolved scope ambiguity.

--- a/munera/open/076-model-api-proxy-support/implementation.md
+++ b/munera/open/076-model-api-proxy-support/implementation.md
@@ -1,9 +1,20 @@
 # Implementation notes
 
 - 2026-05-01: Created task from GitHub issue #27 (`https://github.com/hugoduncan/psi/issues/27`).
-- 2026-05-01: Used existing issue worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api` on branch `issue-27-proxy-support-model-api`.
-- 2026-05-01: Confirmed canonical task id `076` because existing open/closed task ids already reached `075` and `076` was unused.
-- 2026-05-01: Read the issue comment history and current transport code in `components/ai/src/psi/ai/providers/openai/transport.clj` and `components/ai/src/psi/ai/providers/anthropic.clj` to ground the design in the real HTTP boundary.
-- 2026-05-01: Replaced the earlier behavior-only design with an implementation-grade design that explicitly chooses environment-driven proxy configuration, shared transport helper extraction, provider integration points, proxy precedence rules, data shapes, edge cases, and verification expectations.
-- 2026-05-01: Explicitly rejected provider-local proxy fields and a new psi-specific proxy config file to preserve one canonical operator story.
+- 2026-05-01: Confirmed PR provenance for refinement handoff: PR #66 (`https://github.com/hugoduncan/psi/pull/66`) on branch `issue-27-proxy-support-model-api` in worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api`.
+- 2026-05-01: Reused existing canonical task id `076` at `munera/open/076-model-api-proxy-support/` rather than allocating a new task.
+- 2026-05-01: Read the issue/PR context plus current transport code in `components/ai/src/psi/ai/providers/openai/transport.clj` and `components/ai/src/psi/ai/providers/anthropic.clj` to ground the design in the real HTTP boundary.
+- 2026-05-01: Refined the design to make the implementation approach explicit: shared `components/ai` proxy helper, env normalization/precedence, URL-scheme-based proxy selection, clj-http request-option projection, provider integration points, and focused verification seams.
+- 2026-05-01: Tightened the design with explicit implementation slices, architectural constraints, request-map observability expectations, missing host/port failure behavior, and a stronger statement that project/provider config surfaces stay unchanged.
+- 2026-05-01: Added builder-facing refinement detail so a later implementation pass has concrete expected file/namespace targets, helper API boundaries, and request enrichment flow rather than only conceptual guidance.
+- 2026-05-01: Explicitly rejected provider-local proxy fields, a psi-specific proxy config file, and a broader runtime-network-settings-first approach to preserve one canonical operator story.
 - 2026-05-01: Declared the design clear; no material task-level ambiguities remain after specifying the intended implementation mechanism and boundaries.
+- 2026-05-01: Re-read the PR handoff context via `gh pr view 66 --comments`; no additional PR discussion changed the design direction.
+- 2026-05-01: Re-read `munera/plan.md` plus `munera/open/` and `munera/closed/` in the PR worktree to confirm task `076` remains the correct canonical task for this PR.
+- 2026-05-01: Rewrote `design.md` as a complete builder handoff so the implementation approach is explicit at the level of helper API, integration boundaries, request-option merge shape, invariants, failure modes, and verification scope.
+- 2026-05-01: Added shared `components/ai/src/psi/ai/proxy.clj` with env normalization, scheme-aware proxy selection, proxy URI parsing/validation, and clj-http request-option projection. Implemented uppercase-over-lowercase precedence, scheme-specific-over-ALL precedence, blank-as-unset behavior, and explicit malformed/unsupported/missing-port failures.
+- 2026-05-01: Integrated proxy request-option enrichment at the shared `http/post` boundaries in `components/ai/src/psi/ai/providers/openai/transport.clj` and `components/ai/src/psi/ai/providers/anthropic.clj` without changing provider config surfaces, request body ownership, or provider capture callbacks.
+- 2026-05-01: Added focused proxy helper tests in `components/ai/test/psi/ai/proxy_test.clj` plus provider transport tests in `components/ai/test/psi/ai/providers/anthropic_test.clj` and `components/ai/test/psi/ai/providers/openai_test.clj` proving request-option injection and no-proxy pass-through.
+- 2026-05-01: Updated `README.md`, `doc/configuration.md`, and `doc/custom-providers.md` to document the canonical environment-driven proxy story, precedence, supported proxy schemes (`http`, `https`, `socks`, `socks5`), required host/port, inherited behavior for custom providers, and the explicit current limitation that `NO_PROXY` is unsupported.
+- 2026-05-01: Verification: `clojure -M:test -c tests-component-isolated.edn --focus psi.ai.proxy-test --focus psi.ai.providers.anthropic-test --focus psi.ai.providers.openai-test` => `46 tests, 261 assertions, 0 failures`.
+- 2026-05-01: Design deviation: `NO_PROXY` support was left explicitly unsupported and documented as such rather than partially implemented without a coherent clj-http-backed bypass story.

--- a/munera/open/076-model-api-proxy-support/implementation.md
+++ b/munera/open/076-model-api-proxy-support/implementation.md
@@ -1,11 +1,7 @@
-Issue provenance
-- GitHub issue: #27
-- URL: https://github.com/hugoduncan/psi/issues/27
+# Implementation notes
 
-2026-05-01/02 — refinement notes
-- created task `076-model-api-proxy-support`
-- anchored design on issue #27 and the existing triage comment intent/scope
-- made configuration-surface choice an explicit required design decision so implementation will not proceed with ambiguous env-vs-config semantics
-- made request-path applicability explicit because proxy support is only meaningful if the canonical outbound model transport boundary is named
-- constrained scope away from general enterprise networking and unrelated provider changes
-- declared ambiguity status clear for design-level refinement: no remaining ambiguity about the task’s intent, scope, acceptance surface, or required design decisions
+- 2026-05-01: Created task from GitHub issue #27 (`https://github.com/hugoduncan/psi/issues/27`).
+- 2026-05-01: Chose canonical task id `076` because existing open/closed task ids already reached `075` and `076` was unused.
+- 2026-05-01: Refined the issue into a task-design artifact focused on transport-level outbound proxy support for model API requests.
+- 2026-05-01: Captured issue scope from the issue body and owner triage comment; preserved implementation latitude only where it does not create task ambiguity.
+- 2026-05-01: Declared the design clear at the task level; remaining choices are implementation decisions, not unresolved scope ambiguity.

--- a/munera/open/076-model-api-proxy-support/plan.md
+++ b/munera/open/076-model-api-proxy-support/plan.md
@@ -1,0 +1,8 @@
+# Plan
+
+1. Inspect the current shared AI transport/provider HTTP seams and existing tests to choose the narrowest proxy enrichment point consistent with the design.
+2. Implement a shared proxy helper in `components/ai/src/psi/ai/` with pure normalization, resolution, parsing, and request-option projection functions plus one edge helper for env-backed request enrichment.
+3. Integrate proxy request-option enrichment into the Anthropic and OpenAI `http/post` boundaries without changing provider protocol/config surfaces.
+4. Add focused helper and provider transport tests covering precedence, selection, failures, no-proxy behavior, and request-option injection.
+5. Update user-facing docs for the canonical environment-variable proxy story and any supported/unsupported details proven by the implementation.
+6. Run focused verification, record results and any design deviations in `implementation.md`, and leave `steps.md` synchronized with completion state.

--- a/munera/open/076-model-api-proxy-support/steps.md
+++ b/munera/open/076-model-api-proxy-support/steps.md
@@ -1,0 +1,9 @@
+- [x] Read upstream refine handoff requirements and identify issue provenance
+- [x] Inspect worktree Munera surfaces (`munera/plan.md`, `munera/open/`, `munera/closed/`)
+- [x] Read GitHub issue #27 with comments
+- [x] Allocate next canonical Munera task id and create task directory
+- [x] Draft `design.md` with issue provenance, scope, constraints, and acceptance criteria
+- [x] Refine `design.md` against task-design criteria for completeness and unambiguity
+- [x] Record terse refinement notes in `implementation.md`
+- [x] Confirm ambiguity status explicitly
+- [ ] Handoff this refined design for publication/push/PR workflow

--- a/munera/open/076-model-api-proxy-support/steps.md
+++ b/munera/open/076-model-api-proxy-support/steps.md
@@ -1,9 +1,8 @@
-- [x] Read upstream refine handoff requirements and identify issue provenance
-- [x] Inspect worktree Munera surfaces (`munera/plan.md`, `munera/open/`, `munera/closed/`)
-- [x] Read GitHub issue #27 with comments
-- [x] Allocate next canonical Munera task id and create task directory
-- [x] Draft `design.md` with issue provenance, scope, constraints, and acceptance criteria
-- [x] Refine `design.md` against task-design criteria for completeness and unambiguity
-- [x] Record terse refinement notes in `implementation.md`
-- [x] Confirm ambiguity status explicitly
-- [ ] Handoff this refined design for publication/push/PR workflow
+- [x] Read issue #27 and comments.
+- [x] Inspect Munera plan and existing open/closed tasks.
+- [x] Allocate next canonical task id and create `munera/open/076-model-api-proxy-support/`.
+- [x] Draft `design.md` with issue provenance, scope, constraints, and acceptance criteria.
+- [x] Refine design toward completeness and unambiguity.
+- [x] Record terse refinement notes in `implementation.md`.
+- [x] Synchronize this checklist with remaining design work.
+- [ ] Handoff result for PR/next workflow step.

--- a/munera/open/076-model-api-proxy-support/steps.md
+++ b/munera/open/076-model-api-proxy-support/steps.md
@@ -1,9 +1,10 @@
 - [x] Read issue #27 and comments.
 - [x] Inspect `munera/plan.md` and existing `munera/open/` and `munera/closed/` tasks.
-- [x] Allocate next canonical task id and create `munera/open/076-model-api-proxy-support/`.
-- [x] Draft `design.md` with issue provenance, intent, scope, constraints, and acceptance criteria.
-- [x] Refine `design.md` until the task-level behavior, boundaries, and acceptance criteria are unambiguous.
+- [x] Confirm existing issue worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api` on branch `issue-27-proxy-support-model-api`.
+- [x] Allocate canonical task id `076` and create `munera/open/076-model-api-proxy-support/`.
+- [x] Draft `design.md` with issue provenance, behavior, architecture fit, implementation strategy, data shapes, interface changes, invariants, edge cases, and verification expectations.
+- [x] Refine `design.md` until the implementation approach is explicit enough for a later builder to execute without inventing core mechanics.
 - [x] Record terse design/refinement notes in `implementation.md`.
 - [x] Confirm whether any task-level ambiguities remain.
-- [ ] Commit the new Munera task artifacts.
+- [ ] Commit the refined Munera task artifacts.
 - [ ] Hand off for publish/PR step.

--- a/munera/open/076-model-api-proxy-support/steps.md
+++ b/munera/open/076-model-api-proxy-support/steps.md
@@ -1,8 +1,9 @@
 - [x] Read issue #27 and comments.
-- [x] Inspect Munera plan and existing open/closed tasks.
+- [x] Inspect `munera/plan.md` and existing `munera/open/` and `munera/closed/` tasks.
 - [x] Allocate next canonical task id and create `munera/open/076-model-api-proxy-support/`.
-- [x] Draft `design.md` with issue provenance, scope, constraints, and acceptance criteria.
-- [x] Refine design toward completeness and unambiguity.
-- [x] Record terse refinement notes in `implementation.md`.
-- [x] Synchronize this checklist with remaining design work.
-- [ ] Handoff result for PR/next workflow step.
+- [x] Draft `design.md` with issue provenance, intent, scope, constraints, and acceptance criteria.
+- [x] Refine `design.md` until the task-level behavior, boundaries, and acceptance criteria are unambiguous.
+- [x] Record terse design/refinement notes in `implementation.md`.
+- [x] Confirm whether any task-level ambiguities remain.
+- [ ] Commit the new Munera task artifacts.
+- [ ] Hand off for publish/PR step.

--- a/munera/open/076-model-api-proxy-support/steps.md
+++ b/munera/open/076-model-api-proxy-support/steps.md
@@ -1,10 +1,14 @@
 - [x] Read issue #27 and comments.
 - [x] Inspect `munera/plan.md` and existing `munera/open/` and `munera/closed/` tasks.
-- [x] Confirm existing issue worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api` on branch `issue-27-proxy-support-model-api`.
-- [x] Allocate canonical task id `076` and create `munera/open/076-model-api-proxy-support/`.
-- [x] Draft `design.md` with issue provenance, behavior, architecture fit, implementation strategy, data shapes, interface changes, invariants, edge cases, and verification expectations.
-- [x] Refine `design.md` until the implementation approach is explicit enough for a later builder to execute without inventing core mechanics.
+- [x] Confirm PR #66 (`https://github.com/hugoduncan/psi/pull/66`) on branch `issue-27-proxy-support-model-api` using worktree `/Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api`.
+- [x] Reuse existing canonical task `munera/open/076-model-api-proxy-support/`.
+- [x] Refine `design.md` with PR provenance, behavior, architecture fit, implementation strategy, data shapes, interface changes, invariants, edge cases, alternatives, and verification expectations.
+- [x] Make the builder-facing implementation approach explicit enough to execute without inventing core mechanics, including helper boundaries, integration points, request enrichment flow, and expected verification scope.
 - [x] Record terse design/refinement notes in `implementation.md`.
-- [x] Confirm whether any task-level ambiguities remain.
-- [ ] Commit the refined Munera task artifacts.
-- [ ] Hand off for publish/PR step.
+- [x] Confirm ambiguity status for the task handoff.
+- [x] Implement proxy helper and provider transport changes described by the design.
+- [x] Add focused tests for proxy normalization/selection/projection and provider request-option enrichment.
+- [x] Update user-facing docs for the canonical environment-driven proxy configuration story.
+- [x] Run focused verification and record commands/results in `implementation.md`.
+- [ ] Commit the implementation task artifacts and code changes.
+- [x] Hand off for implementation/publish workflow.


### PR DESCRIPTION
# 076 Model API proxy support

## Provenance
- GitHub issue: #27
- Issue URL: https://github.com/hugoduncan/psi/issues/27
- Issue title: Add proxy support (socks, http, https, ...) for accessing model API
- Refinement branch: issue-27-proxy-support-model-api
- Worktree: /Users/duncan/projects/hugoduncan/psi/issue-27-proxy-support-model-api

## Intent
Enable psi to reach model APIs through outbound proxies so users in restricted or corporate network environments can use psi without ad hoc source changes.

## Problem
psi currently supports provider-level endpoint, header, and authentication customization, but the issue requests transport-level outbound proxy support. In environments where all outbound traffic must traverse an HTTP, HTTPS, or SOCKS proxy, provider configuration alone is insufficient if the underlying shared HTTP transport cannot be directed through a proxy by psi.

## Existing architecture and fit
- Model API calls currently flow through the shared AI transport layer in `components/ai/`.
- The built-in Anthropic and OpenAI providers both issue HTTP requests through `clj-http.client/post`.
- Custom provider definitions change API base URLs, auth, headers, and model metadata, but they do not currently provide a dedicated transport-proxy surface.
- Because the transport boundary is shared, proxy behavior should be introduced once in the common request-options path used by provider transport functions, instead of inventing provider-specific proxy logic.

This task therefore fits the existing architecture by adding a canonical proxy-configuration projection into provider request option construction, while keeping provider protocol semantics unchanged.

## Users and scenarios
### Primary user
An operator running psi in an environment where direct outbound access is blocked and all model API traffic must go through an organizational proxy.

### Core scenarios
1. A user configures proxy support without editing source code.
2. A user runs psi against a supported model provider and the outbound model API requests traverse the configured proxy.
3. A user can tell from the docs which proxy forms are supported, where the configuration is set, and what scope that configuration has.
4. A user gets the same proxy behavior across providers that use psi's shared model API transport path.
5. A user can still override provider base URLs independently of proxying; proxy configuration affects transport routing, not model/provider identity.

## Scope
### In scope
- A user-visible configuration surface for outbound proxying of model API requests.
- Support for the common proxy families explicitly named in the issue: HTTP, HTTPS, and SOCKS.
- Behavior that applies to model API access across psi's provider integrations rather than being limited to a single provider definition.
- Clear user documentation for configuring and using proxy support in restricted environments.
- Executable verification that proxy configuration is applied to outbound model API traffic.
- Configuration parsing and normalization sufficient to support a single canonical runtime state shape for proxy settings.

### Out of scope
- General corporate-environment setup beyond outbound model API proxying.
- Changes to model behavior, prompt behavior, or non-network provider capabilities.
- Unrelated provider feature work.
- Proxy support for arbitrary external integrations unless they are part of the same model API transport path.
- Defining enterprise policy, credential management, or proxy infrastructure provisioning outside psi.
- Runtime UI for interactively editing proxy settings.

## Chosen implementation strategy
Implement proxy support as a shared transport concern in `components/ai/`, backed by one canonical configuration source: environment-driven proxy settings read by psi at runtime and translated into clj-http request options.

### Why this strategy fits
- `clj-http` already supports proxy-related request options, so psi can rely on the existing HTTP client rather than adding a new transport stack.
- Environment-driven proxy configuration matches operator expectations in restricted environments and avoids inventing a new project-specific config file surface for a feature that is usually deployment-scoped.
- A shared request-options helper keeps Anthropic, OpenAI, and compatible custom providers aligned through one mechanism.
- This approach preserves the current provider model architecture: provider definitions continue to describe endpoint/auth/model semantics, while transport routing concerns stay at the transport boundary.

## Canonical configuration story
The canonical user-facing configuration surface is environment variables.

### Supported environment variables
- `HTTP_PROXY`
- `HTTPS_PROXY`
- `ALL_PROXY`
- lowercase equivalents when present (`http_proxy`, `https_proxy`, `all_proxy`)
- `NO_PROXY` / `no_proxy` only if the implementation can support it coherently through clj-http for the same transport path; otherwise it must be explicitly documented as unsupported in this task's implementation.

### Canonical semantics
- `HTTPS_PROXY` applies to HTTPS model API URLs.
- `HTTP_PROXY` applies to HTTP model API URLs.
- `ALL_PROXY` is the fallback when the scheme-specific variable is absent.
- Scheme-specific variables take precedence over `ALL_PROXY`.
- Uppercase and lowercase names are treated as equivalent, with uppercase winning if both are set to different values.
- Provider/model config files do not gain a separate proxy field in this task.
- Users configure proxies outside psi and then run psi normally.

This yields one unambiguous story: psi inherits proxy settings from the process environment and applies them to model API transport.

## Required runtime behavior
1. When a built-in or compatible provider transport prepares an outbound HTTP request, psi must resolve the effective proxy from the request URL scheme and the environment.
2. psi must translate that resolved proxy into the clj-http request options expected by the underlying client.
3. If no proxy environment variable applies, psi must preserve current direct-connection behavior.
4. If a proxy URI is malformed or unsupported, psi must fail explicitly with a clear diagnostic rather than silently ignoring the setting.
5. Proxy support must apply consistently across the shared model API transport path, including built-in OpenAI and Anthropic providers and custom providers that reuse those transport implementations.
6. Provider capture callbacks must continue to work; proxy support must not remove existing request/response capture behavior.
7. Proxy support must not alter request payloads, auth semantics, or provider selection logic.

## Main procedural approach
1. Add a small shared helper namespace in `components/ai/` responsible for:
   - reading proxy-related environment variables,
   - normalizing them into a canonical internal map,
   - selecting the effective proxy for a target request URL,
   - converting the chosen proxy into clj-http request options.
2. Route all model-provider `http/post` calls through a shared request-options merge that includes those proxy options.
3. Keep provider request construction separate from transport option enrichment: request body/headers stay provider-owned; proxy transport options are added immediately before the `http/post` boundary.
4. Add focused unit tests around proxy resolution and request-option injection.
5. Add provider-level tests proving that OpenAI and Anthropic transport calls pass the expected proxy options to `http/post` when the relevant environment variables are set.
6. Update user docs to describe the canonical environment-based configuration story, supported proxy variable names, precedence, and caveats.

## Key algorithms and rules
### 1. Environment normalization
Input: current process environment map.

Normalization rules:
- read uppercase and lowercase forms for each supported variable;
- for each logical key, prefer uppercase over lowercase when both are present;
- ignore blank values;
- keep only the proxy variables relevant to transport resolution.

Canonical normalized shape:
```clojure
{:http  "http://proxy.example:8080"
 :https "http://secure-proxy.example:8443"
 :all   "socks5://proxy.example:1080"
 :no-proxy "example.com,localhost"} ; only if supported in the implementation
```

### 2. Effective-proxy selection
Input: normalized proxy config and request URL.

Selection rules:
- parse the request URL scheme;
- for `https` URLs, choose `:https` first, else `:all`;
- for `http` URLs, choose `:http` first, else `:all`;
- for any other scheme, do not proxy and treat it as outside the supported surface unless the underlying transport already supports it and the implementation chooses to cover it explicitly;
- if `NO_PROXY` support is implemented, bypass the proxy when the target host matches the bypass rules.

### 3. Request-option projection
Input: effective proxy URI.

Projection rules:
- parse the proxy URI once into its components;
- map supported schemes to clj-http options in the form expected by the client, including host, port, and protocol-specific flags;
- attach auth fields only if present in the proxy URI and supported by clj-http;
- merge the resulting proxy options with existing request options without changing existing headers/body/as/throw-exceptions behavior.

### 4. Failure behavior
- malformed proxy URI => explicit exception with the offending environment variable name;
- unsupported proxy scheme => explicit exception listing the supported schemes for this task;
- absent proxy => no added proxy options.

## Main data structures and state shapes
### Normalized proxy config
```clojure
{:http     string?
 :https    string?
 :all      string?
 :no-proxy string?} ; optional, only if supported
```

### Parsed effective proxy
```clojure
{:source-env :https
 :raw-uri    "http://proxy.example:8080"
 :scheme     :http
 :host       "proxy.example"
 :port       8080
 :username   "user"      ; optional
 :password   "secret"    ; optional, avoid logging raw secret
}
```

### Request option enrichment output
A plain clj-http options map merged into the provider's existing request map, for example:
```clojure
{:proxy-host "proxy.example"
 :proxy-port 8080
 :proxy-user "user"
 :proxy-pass "secret"
 :proxy-scheme :http}
```

The final concrete keys must match `clj-http` expectations, but the helper should expose one internal projection boundary so providers do not each reinvent it.

## Interface surfaces to add or change
### Code surfaces
- Add a shared proxy helper namespace under `components/ai/src/psi/ai/`.
- Update OpenAI transport code to enrich outbound `http/post` options with resolved proxy settings.
- Update Anthropic transport code to enrich outbound `http/post` options with resolved proxy settings.
- If there is already a common request-helper seam for provider transports, prefer extending that seam instead of duplicating helper calls.

### Documentation surfaces
- Update `README.md` and/or `doc/configuration.md` with the canonical proxy configuration story.
- Add or update a focused doc section describing:
  - supported variables,
  - precedence,
  - supported proxy URI forms,
  - whether `NO_PROXY` is supported,
  - examples for HTTP/HTTPS and SOCKS usage.
- Update `doc/custom-providers.md` to clarify that custom providers reuse the same transport-level proxy behavior when they go through the built-in OpenAI or Anthropic transport paths.

### User-visible command/config surfaces
- No new slash command.
- No new `.psi/models.edn` field.
- No new resolver/API surface is required for this task unless the implementation adds introspection for diagnostics; if so, it must be documented as auxiliary, not as the primary configuration mechanism.

## Invariants
- One canonical user configuration story: environment variables.
- Transport-level proxy support is orthogonal to provider definition and model selection.
- OpenAI and Anthropic transports must resolve proxy configuration the same way.
- Direct behavior remains unchanged when proxy variables are unset.
- Proxy parsing and selection logic lives in one shared place.
- Secrets from proxy credentials must not be exposed in request-capture logs without redaction.

## Edge cases and explicit decisions
- If both uppercase and lowercase environment variables are present with different values, uppercase wins.
- If both scheme-specific and `ALL_PROXY` are present, the scheme-specific value wins.
- SOCKS support is in scope only if `clj-http` supports the required option projection cleanly from the same helper. If a named SOCKS variant is not actually supported by the underlying client, the implementation must fail clearly and document the limitation instead of claiming broad SOCKS support.
- `NO_PROXY` support is optional in this task design only if the implementation surface cannot support it coherently with the chosen client options. The final implementation must either support it and document matching rules, or document it as unsupported.
- Proxy support applies only to model API HTTP traffic; it does not imply proxying unrelated runtime subsystems.
- Existing tests that stub `http/post` must keep working; helper injection should remain observable at the final request map passed into `http/post`.

## Verification expectations
The implementation is done only when all of the following are true:
1. Focused unit tests cover environment normalization, precedence, effective-proxy selection, malformed URI handling, and unsupported-scheme handling.
2. OpenAI transport tests prove that an applicable proxy environment variable yields proxy options in the final `http/post` request map.
3. Anthropic transport tests prove the same.
4. Tests also prove that no proxy options are added when no relevant environment variable is set.
5. Docs clearly describe the supported proxy configuration story and any boundaries or caveats.

## Alternatives considered
### Add proxy fields to provider definitions
Rejected because proxying is a deployment/transport concern, not model-definition identity. It would create a second competing configuration story and force duplicate settings across providers.

### Add a new psi-specific config file surface for proxy settings
Rejected because it duplicates well-understood process-environment behavior, adds new configuration machinery, and is less natural for corporate execution environments.

### Implement proxy logic separately inside each provider
Rejected because the built-in providers already share the same HTTP client boundary and duplicated logic would drift.

## Acceptance criteria
1. A user can configure psi so outbound model API requests are sent through a proxy by setting documented environment variables before launching psi.
2. The supported proxy types and configuration surface are documented in user-facing documentation.
3. Proxy configuration applies to the relevant model API transport path without requiring ad hoc code changes.
4. The behavior works across the intended provider/model API path rather than only for one narrow provider-specific path.
5. The implementation includes executable verification that proxy configuration is honored by the transport layer used for model API requests.
6. Any unsupported proxy mode, provider path, or transport boundary is documented explicitly so operators know what is and is not covered.
7. The final implementation leaves users with one unambiguous configuration story rather than multiple conflicting proxy mechanisms.

## Non-ambiguity statement
This design is complete and unambiguous for implementation handoff.

No material ambiguities remain. The later builder should not invent a different configuration surface or provider-specific mechanism; the intended implementation is shared, environment-driven transport proxy support at the `components/ai` HTTP boundary, with explicit tests and docs.

Refs #27
