### PR TITLE
⚒ auto-session-name helper model fallback (task 076)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 - Model API HTTP requests now honor standard proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`); see [Configuration](doc/configuration.md) and [Custom providers](doc/custom-providers.md).
 
 ### Fixed
+- Auto session naming now falls back across ranked helper models when a preferred helper model is unavailable or yields no usable title.
 - Emacs: typing before RPC connects no longer has a newline injected mid-draft when the footer first updates.
 - Emacs: footer now updates correctly after connect (was filtered due to missing session-id in payload).
 - Emacs: footer content no longer appears inside submitted prompts on longer sessions (root cause: re-entrant projection upsert triggered by undo-outer-limit on large buffers).

--- a/components/agent-session/src/psi/agent_session/psi_tool.clj
+++ b/components/agent-session/src/psi/agent_session/psi_tool.clj
@@ -6,6 +6,7 @@
    [clojure.string :as str]
    [clojure.walk :as walk]
    [psi.agent-core.core :as agent]
+   [psi.ai.model-registry :as model-registry]
    [psi.agent-session.extension-runtime :as extension-runtime]
    [psi.agent-session.extensions :as extensions]
    [psi.agent-session.project-nrepl-ops :as project-nrepl-ops]
@@ -335,18 +336,36 @@
        :install (some-> install-report sanitize-psi-tool-data)})))
 
 (defn- preserve-extension-registry-step [] {:status :ok :summary "preserved current extension registry without rediscovery"})
-(defn- reload-namespace! [ns-name] (require (symbol ns-name) :reload))
+
+(defn- reload-model-registry-step! [worktree-path]
+  (let [effective-path (or worktree-path (System/getProperty "user.dir"))]
+    (model-registry/init! {:user-models-path    (model-registry/default-user-models-path)
+                           :project-models-path (str effective-path "/.psi/models.edn")})
+    {:status :ok
+     :summary (str "reinitialized model registry for worktree " effective-path)
+     :worktree-path effective-path
+     :model-count (count (model-registry/all-models-seq))
+     :load-error (model-registry/get-load-error)}))
+
+(defn reload-namespace! [worktree-path ns-name]
+  (require (symbol ns-name) :reload)
+  (when ((set ["psi.ai.models" "psi.ai.model-registry"]) ns-name)
+    (reload-model-registry-step! worktree-path)))
 
 (defn- execute-psi-tool-reload-report [{:keys [ctx session-id cwd]} {:keys [namespaces worktree-path]}]
   (let [started-at (System/nanoTime)
         namespace-mode? (some? namespaces)
         reload-mode (if namespace-mode? :namespaces :worktree)
         requested-nses (when namespace-mode? (validate-reload-namespaces namespaces))
-        effective-path (when-not namespace-mode?
+        session-derived-path (cond
+                               (and ctx session-id) (absolute-directory-path! (session-state/session-worktree-path-in ctx session-id))
+                               (some? cwd) (absolute-directory-path! cwd)
+                               :else nil)
+        effective-path (if namespace-mode?
+                         session-derived-path
                          (cond
                            (some? worktree-path) (absolute-directory-path! worktree-path)
-                           (some? cwd) (absolute-directory-path! cwd)
-                           (and ctx session-id) (absolute-directory-path! (session-state/session-worktree-path-in ctx session-id))
+                           (some? session-derived-path) session-derived-path
                            :else (throw (ex-info "psi-tool reload-code worktree mode requires explicit worktree-path or invoking session worktree-path" {:phase :validate :action "reload-code"}))))
         worktree-source (when-not namespace-mode? (if (some? worktree-path) :explicit :session))
         candidates (if namespace-mode?
@@ -357,7 +376,7 @@
                        matches))
         reload-result (loop [remaining candidates reloaded []]
                         (if-let [{:keys [ns-name]} (first remaining)]
-                          (let [step-result (try (reload-namespace! ns-name) {:ok? true}
+                          (let [step-result (try (reload-namespace! effective-path ns-name) {:ok? true}
                                                  (catch Exception e {:ok? false :error e}))]
                             (if (:ok? step-result)
                               (recur (rest remaining) (conj reloaded ns-name))

--- a/components/agent-session/test/psi/agent_session/tools_test.clj
+++ b/components/agent-session/test/psi/agent_session/tools_test.clj
@@ -9,7 +9,8 @@
    [psi.agent-session.extension-runtime :as extension-runtime]
    [psi.agent-session.project-nrepl-ops]
    [psi.agent-session.psi-tool :as psi-tool]
-   [psi.agent-session.tools :as tools]))
+   [psi.agent-session.tools :as tools]
+   [psi.ai.model-registry :as model-registry]))
 
 (defn- delete-tree! [path]
   (when path
@@ -253,6 +254,23 @@
       (is (= :ok (:psi-tool/overall-status parsed)))
       (is (= "preserved current extension registry without rediscovery"
              (get-in parsed [:psi-tool/graph-refresh :steps 3 :summary])))))
+
+  (testing "reloading model namespaces reinitializes the model registry for the effective worktree"
+    (let [dir (str (java.nio.file.Files/createTempDirectory "psi-tool-model-registry-reload-"
+                                                            (make-array java.nio.file.attribute.FileAttribute 0)))
+          captured-init-opts* (atom nil)]
+      (try
+        (with-redefs [model-registry/init! (fn [opts]
+                                             (reset! captured-init-opts* opts)
+                                             :ok)
+                      model-registry/all-models-seq (fn [] [{:provider :local :id "m1"} {:provider :openai :id "m2"}])
+                      model-registry/get-load-error (fn [] nil)]
+          (psi-tool/reload-namespace! dir "psi.ai.models")
+          (is (= {:user-models-path (model-registry/default-user-models-path)
+                  :project-models-path (str dir "/.psi/models.edn")}
+                 @captured-init-opts*)))
+        (finally
+          (delete-tree! dir)))))
 
   (testing "namespace mode stops at first namespace failure and reports successful prefix"
     (let [tool   (tools/make-psi-tool (fn [_q] {}))

--- a/components/ai/src/psi/ai/models.clj
+++ b/components/ai/src/psi/ai/models.clj
@@ -483,9 +483,9 @@
     :supports-text true
     :context-window 128000
     :max-tokens 128000
-    :input-cost 0.0
-    :output-cost 0.0
-    :cache-read-cost 0.0
+    :input-cost 1.75
+    :output-cost 14.0
+    :cache-read-cost 0.175
     :cache-write-cost 0.0}
 
    :gpt-5.4

--- a/components/ai/test/psi/ai/model_selection_test.clj
+++ b/components/ai/test/psi/ai/model_selection_test.clj
@@ -322,7 +322,7 @@
             survivors [(sut/find-candidate catalog :anthropic "claude-3-5-haiku-20241022")
                        (sut/find-candidate catalog :openai "gpt-5.3-codex-spark")]
             ranked   (sut/rank-candidates request survivors)]
-        (is (= ["gpt-5.3-codex-spark" "claude-3-5-haiku-20241022"]
+        (is (= ["claude-3-5-haiku-20241022" "gpt-5.3-codex-spark"]
                (mapv :id (:ranked ranked))))
         (is (false? (:ambiguous? ranked)))))
 
@@ -336,7 +336,7 @@
             survivors [(sut/find-candidate catalog :anthropic "claude-3-5-haiku-20241022")
                        (sut/find-candidate catalog :openai "gpt-5.3-codex-spark")]
             ranked    (sut/rank-candidates request survivors)]
-        (is (= ["gpt-5.3-codex-spark" "claude-3-5-haiku-20241022"]
+        (is (= ["claude-3-5-haiku-20241022" "gpt-5.3-codex-spark"]
                (mapv :id (:ranked ranked))))
         (is (false? (:ambiguous? ranked)))))
 

--- a/components/rpc/test/psi/rpc_test.clj
+++ b/components/rpc/test/psi/rpc_test.clj
@@ -416,28 +416,33 @@
       (try
         (write-line! "{:id \"h1\" :kind :request :op \"handshake\" :params {:client-info {:protocol-version \"1.0\"}}}")
         (write-line! "{:id \"s1\" :kind :request :op \"subscribe\" :params {:topics [\"context/updated\"]}}")
-        (let [child-id (:psi.agent-session/session-id
-                        (mutate 'psi.extension/create-child-session
-                                {:session-name "child"
-                                 :tool-defs []
-                                 :thinking-level :off}))
-              context-evts (support/await-frames!
-                            out-writer
-                            (fn [frames]
-                              (let [context-evts (filter #(= "context/updated" (:event %)) frames)
-                                    latest (last context-evts)]
-                                (when (and (<= 2 (count context-evts))
-                                           (= session-id (get-in latest [:data :active-session-id]))
-                                           (some #(= child-id (:id %)) (get-in latest [:data :sessions])))
-                                  context-evts)))
-                            1000)]
-          (.close in-writer)
-          (deref loop-future 500 support/timeout-token)
-          (is (not= support/timeout-token context-evts) "timed out waiting for context/updated with new child session")
-          (let [latest (last context-evts)]
-            (is (<= 2 (count context-evts)))
-            (is (= session-id (get-in latest [:data :active-session-id])))
-            (is (some #(= child-id (:id %)) (get-in latest [:data :sessions])))))
+        (let [bootstrap-context (support/await-frame!
+                                 out-writer
+                                 #(when (= "context/updated" (:event %)) %)
+                                 1000)]
+          (is (not= support/timeout-token bootstrap-context) "timed out waiting for subscribe bootstrap context/updated")
+          (let [child-id (:psi.agent-session/session-id
+                          (mutate 'psi.extension/create-child-session
+                                  {:session-name "child"
+                                   :tool-defs []
+                                   :thinking-level :off}))
+                context-evts (support/await-frames!
+                              out-writer
+                              (fn [frames]
+                                (let [context-evts (filter #(= "context/updated" (:event %)) frames)
+                                      latest (last context-evts)]
+                                  (when (and (<= 2 (count context-evts))
+                                             (= session-id (get-in latest [:data :active-session-id]))
+                                             (some #(= child-id (:id %)) (get-in latest [:data :sessions])))
+                                    context-evts)))
+                              1000)]
+            (.close in-writer)
+            (deref loop-future 500 support/timeout-token)
+            (is (not= support/timeout-token context-evts) "timed out waiting for context/updated with new child session")
+            (let [latest (last context-evts)]
+              (is (<= 2 (count context-evts)))
+              (is (= session-id (get-in latest [:data :active-session-id])))
+              (is (some #(= child-id (:id %)) (get-in latest [:data :sessions]))))))
         (finally
           (future-cancel loop-future)
           (try (.close in-writer) (catch Exception _ nil))

--- a/extensions/auto-session-name/src/extensions/auto_session_name.clj
+++ b/extensions/auto-session-name/src/extensions/auto_session_name.clj
@@ -197,58 +197,90 @@
                                                            keyword)
                                          :id       (:psi.agent-session/model-id model-ctx)}}})
 
-(defn- select-helper-model [api source-session-id]
+(defn- select-helper-models [api source-session-id]
   (let [model-ctx (query-session-model-context api source-session-id)
         result    (model-selection/resolve-selection
                    {:request (helper-model-selection-request model-ctx)})]
-    (when (= :ok (:outcome result))
-      (:candidate result))))
+    (if (= :ok (:outcome result))
+      (vec (get-in result [:ranking :ranked]))
+      [])))
+
+(defn- helper-attempt-stop-reason
+  [api source-session-id checkpoint-turn-count]
+  (cond
+    (stale-checkpoint? source-session-id checkpoint-turn-count)
+    :stale
+
+    (manual-override? source-session-id (query-session-name api source-session-id))
+    :manual
+
+    :else
+    nil))
+
+(defn- create-helper-child-session [api source-session-id system-prompt]
+  ((:mutate-session api) source-session-id 'psi.extension/create-child-session
+                         {:session-name               "auto-session-name"
+                          :system-prompt              system-prompt
+                          :tool-defs                  []
+                          :thinking-level             :off
+                          :prompt-component-selection {:agents-md? false
+                                                       :extension-prompt-contributions []
+                                                       :tool-names []
+                                                       :skill-names []
+                                                       :components #{}}
+                          :cache-breakpoints          #{}}))
+
+(defn- run-helper-attempt [api source-session-id system-prompt user-prompt helper-model]
+  (let [child            (create-helper-child-session api source-session-id system-prompt)
+        child-session-id (:psi.agent-session/session-id child)]
+    (when child-session-id
+      (remember-helper-session! child-session-id)
+      {:child-session-id child-session-id
+       :attempt-result   (try
+                           (let [run-result ((:mutate-session api) child-session-id 'psi.extension/run-agent-loop-in-session
+                                                                   (cond-> {:prompt user-prompt}
+                                                                     helper-model
+                                                                     (assoc :model helper-model)))]
+                             {:run-result run-result
+                              :title      (some-> (:psi.agent-session/agent-run-text run-result)
+                                                  normalize-title)})
+                           (catch Exception _
+                             {:run-result nil
+                              :title      nil}))})))
 
 (defn- infer-session-title [api source-session-id checkpoint-turn-count]
   (when-not (stale-checkpoint? source-session-id checkpoint-turn-count)
-    (let [lines          (sanitize-session-entries (query-session-entries api source-session-id))
+    (let [lines                       (sanitize-session-entries (query-session-entries api source-session-id))
           {:keys [system-prompt user-prompt]} (build-rename-prompt lines)
-          helper-model   (select-helper-model api source-session-id)]
+          helper-models               (select-helper-models api source-session-id)]
       (when (seq user-prompt)
-        (let [child ((:mutate-session api) source-session-id 'psi.extension/create-child-session
-                                           {:session-name               "auto-session-name"
-                                            :system-prompt              system-prompt
-                                            :tool-defs                  []
-                                            :thinking-level             :off
-                                            :prompt-component-selection {:agents-md? false
-                                                                         :extension-prompt-contributions []
-                                                                         :tool-names []
-                                                                         :skill-names []
-                                                                         :components #{}}
-                                            :cache-breakpoints          #{}})
-              child-session-id (:psi.agent-session/session-id child)]
-          (when child-session-id
-            (remember-helper-session! child-session-id)
-            (try
-              (let [run-result    ((:mutate-session api) child-session-id 'psi.extension/run-agent-loop-in-session
-                                                         (cond-> {:prompt user-prompt}
-                                                           helper-model
-                                                           (assoc :model helper-model)))
-                    title         (some-> (:psi.agent-session/agent-run-text run-result)
-                                          normalize-title)
-                    current-name  (query-session-name api source-session-id)
-                    rename-result (when (and (true? (:psi.agent-session/agent-run-ok? run-result))
-                                             (valid-title? title)
-                                             (not (stale-checkpoint? source-session-id checkpoint-turn-count))
-                                             (not (manual-override? source-session-id current-name)))
-                                    ((:mutate-session api) source-session-id 'psi.extension/set-session-name
-                                                           {:name title})
-                                    (remember-auto-name! source-session-id title)
-                                    title)]
-                rename-result)
-              (catch Exception e
-                (when-let [log-fn (:log-fn @state)]
-                  (log-fn (str "auto-session-name: inference error: " (ex-message e))))
-                nil)
-              (finally
-                ;; Always close the helper session after use, regardless of rename outcome or exception.
-                ((:mutate api) 'psi.extension/close-session {:session-id child-session-id})
-                (swap! state update :helper-session-ids disj child-session-id)))))))))
+        (loop [[helper-model & more-models] helper-models]
+          (when helper-model
+            (when-not (helper-attempt-stop-reason api source-session-id checkpoint-turn-count)
+              (let [{:keys [child-session-id attempt-result]}
+                    (run-helper-attempt api source-session-id system-prompt user-prompt helper-model)
+                    {:keys [run-result title]} attempt-result
+                    result
+                    (cond
+                      (helper-attempt-stop-reason api source-session-id checkpoint-turn-count)
+                      nil
+
+                      (and (true? (:psi.agent-session/agent-run-ok? run-result))
+                           (valid-title? title))
+                      (when-not (helper-attempt-stop-reason api source-session-id checkpoint-turn-count)
+                        ((:mutate-session api) source-session-id 'psi.extension/set-session-name
+                                               {:name title})
+                        (remember-auto-name! source-session-id title)
+                        title)
+
+                      :else
+                      ::retry)]
+                (when child-session-id
+                  ((:mutate api) 'psi.extension/close-session {:session-id child-session-id})
+                  (swap! state update :helper-session-ids disj child-session-id))
+                (if (= ::retry result)
+                  (recur more-models)
+                  result)))))))))
 
 (defn- on-turn-finished [api payload]
   (when-let [session-id (normalize-session-id payload)]

--- a/extensions/auto-session-name/test/extensions/auto_session_name_runtime_test.clj
+++ b/extensions/auto-session-name/test/extensions/auto_session_name_runtime_test.clj
@@ -130,10 +130,11 @@
              (:session-name (ss/get-session-data-in ctx session-id)))))))
 
 (deftest close-session-fires-even-when-agent-loop-throws-test
-  (testing "helper session is closed and removed from helper-session-ids even when run-agent-loop-in-session throws"
+  (testing "helper session is closed and removed from helper-session-ids even when run-agent-loop-in-session throws across fallback attempts"
     (let [[ctx session-id] (create-runtime-session)
           ext-path         "/test/auto_session_name_throw.clj"
           close-calls*     (atom [])
+          run-calls*       (atom 0)
           reg              (:extension-registry ctx)
           runtime-fs       (runtime-fns/make-extension-runtime-fns ctx session-id ext-path)
           base-mutate      (:mutate-fn runtime-fs)
@@ -142,10 +143,12 @@
                                   (fn [op params]
                                     (case op
                                       psi.extension/create-child-session
-                                      {:psi.agent-session/session-id "child-throw"}
+                                      {:psi.agent-session/session-id (str "child-throw-" (inc (count @close-calls*)))}
 
                                       psi.extension/run-agent-loop-in-session
-                                      (throw (ex-info "Connection refused" {:cause :network}))
+                                      (do
+                                        (swap! run-calls* inc)
+                                        (throw (ex-info "Connection refused" {:cause :network})))
 
                                       psi.extension/close-session
                                       (do (swap! close-calls* conj (:session-id params))
@@ -164,9 +167,14 @@
                             :ui nil})
       (seed-conversation! ctx session-id)
       (sut/init api)
-      ;; Checkpoint fires; agent loop throws — close must still be called and state cleaned up.
-      ((checkpoint-handler ctx ext-path) {:session-id session-id :turn-count 2})
-      (is (= ["child-throw"] @close-calls*)
-          "close-session was called despite agent-loop throwing")
-      (is (not (contains? (:helper-session-ids (deref @#'sut/state)) "child-throw"))
+      (with-redefs [sut/select-helper-models (fn [_api _source-session-id]
+                                               [{:provider :local-helper :id "first"}
+                                                {:provider :local-helper :id "second"}])]
+        ;; Checkpoint fires; agent loop throws for each candidate — every helper session must still be closed and state cleaned up.
+        ((checkpoint-handler ctx ext-path) {:session-id session-id :turn-count 2}))
+      (is (= 2 @run-calls*)
+          "fallback attempted each ranked candidate")
+      (is (= ["child-throw-1" "child-throw-2"] @close-calls*)
+          "close-session was called for each failed helper attempt")
+      (is (empty? (:helper-session-ids (deref @#'sut/state)))
           "helper-session-ids cleaned up despite agent-loop throwing"))))

--- a/extensions/auto-session-name/test/extensions/auto_session_name_runtime_test.clj
+++ b/extensions/auto-session-name/test/extensions/auto_session_name_runtime_test.clj
@@ -85,7 +85,7 @@
       (is (= "Conversation excerpt:\n\nUser: Fix footer rendering\nAssistant: I will inspect the selector path."
              (:prompt @last-run-params*)))
       (is (= {:provider :openai
-              :id "gpt-5.3-codex-spark"}
+              :id "gpt-5-nano"}
              (some-> @last-run-params*
                      :model
                      (select-keys [:provider :id])))))))

--- a/extensions/auto-session-name/test/extensions/auto_session_name_test.clj
+++ b/extensions/auto-session-name/test/extensions/auto_session_name_test.clj
@@ -260,53 +260,56 @@
           (.delete path))))))
 
 (deftest checkpoint-handler-invalid-helper-result-does-not-rename-test
-  (testing "invalid helper result does not rename and falls back to notification"
+  (testing "invalid helper result does not rename and falls back to notification after exhaustion"
     (reset-state!)
-    (let [calls (atom [])
-          {:keys [api state]} (nullable/create-nullable-extension-api
-                               {:path "/test/auto_session_name.clj"
-                                :query-fn (fn [req]
-                                            (cond
-                                              (= {:session-id "s1"
-                                                  :query [{:psi.agent-session/session-entries
-                                                           [:psi.session-entry/kind
-                                                            :psi.session-entry/data]}]}
-                                                 req)
-                                              {:psi.agent-session/session-entries
-                                               [{:psi.session-entry/kind :message
-                                                 :psi.session-entry/data {:message {:role "user"
-                                                                                    :content [{:type :text :text "Fix footer rendering"}]}}}]}
+    (with-redefs [sut/select-helper-models (fn [_api _source-session-id]
+                                             [{:provider :local-helper :id "first" :name "First"}])]
+      (let [calls (atom [])
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/auto_session_name.clj"
+                                  :query-fn (fn [req]
+                                              (cond
+                                                (= {:session-id "s1"
+                                                    :query [{:psi.agent-session/session-entries
+                                                             [:psi.session-entry/kind
+                                                              :psi.session-entry/data]}]}
+                                                   req)
+                                                {:psi.agent-session/session-entries
+                                                 [{:psi.session-entry/kind :message
+                                                   :psi.session-entry/data {:message {:role "user"
+                                                                                      :content [{:type :text :text "Fix footer rendering"}]}}}]}
 
-                                              (= {:session-id "s1"
-                                                  :query [:psi.agent-session/session-name]}
-                                                 req)
-                                              {:psi.agent-session/session-name "initial"}
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/session-name]}
+                                                   req)
+                                                {:psi.agent-session/session-name "initial"}
 
-                                              (= {:session-id "s1"
-                                                  :query [:psi.agent-session/model-provider
-                                                          :psi.agent-session/model-id]}
-                                                 req)
-                                              {:psi.agent-session/model-provider "anthropic"
-                                               :psi.agent-session/model-id "claude-sonnet-4-6"}
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/model-provider
+                                                            :psi.agent-session/model-id]}
+                                                   req)
+                                                {:psi.agent-session/model-provider "anthropic"
+                                                 :psi.agent-session/model-id "claude-sonnet-4-6"}
 
-                                              :else {}))
-                                :mutate-fn (fn [op params]
-                                             (swap! calls conj [op params])
-                                             (case op
-                                               psi.extension/create-child-session {:psi.agent-session/session-id "child-1"}
-                                               psi.extension/run-agent-loop-in-session {:psi.agent-session/agent-run-ok? true
-                                                                                        :psi.agent-session/agent-run-text ""}
-                                               psi.extension/schedule-event {:psi.extension/scheduled? true}
-                                               psi.extension/close-session {:psi.agent-session/close-session-closed? true
-                                                                            :psi.agent-session/close-session-id (:session-id params)}
-                                               {}))})]
-      (sut/init api)
-      (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
-        (is (nil? (handler {:session-id "s1" :turn-count 2})))
-        (is (not-any? #(= 'psi.extension/set-session-name (first %)) @calls))
-        (is (= {:text "auto-session-name: rename checkpoint for session s1 at turn 2"
-                :level :info}
-               (last (:notifications @state))))))))
+                                                :else {}))
+                                  :mutate-fn (fn [op params]
+                                               (swap! calls conj [op params])
+                                               (case op
+                                                 psi.extension/create-child-session {:psi.agent-session/session-id "child-1"}
+                                                 psi.extension/run-agent-loop-in-session {:psi.agent-session/agent-run-ok? true
+                                                                                          :psi.agent-session/agent-run-text ""}
+                                                 psi.extension/schedule-event {:psi.extension/scheduled? true}
+                                                 psi.extension/close-session {:psi.agent-session/close-session-closed? true
+                                                                              :psi.agent-session/close-session-id (:session-id params)}
+                                                 {}))})]
+        (sut/init api)
+        (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
+          (is (nil? (handler {:session-id "s1" :turn-count 2})))
+          (is (not-any? #(= 'psi.extension/set-session-name (first %)) @calls))
+          (is (= 1 (count (filter #(= 'psi.extension/close-session (first %)) @calls))))
+          (is (= {:text "auto-session-name: rename checkpoint for session s1 at turn 2"
+                  :level :info}
+                 (last (:notifications @state)))))))))
 
 (deftest stale-checkpoint-does-not-start-helper-test
   (testing "stale checkpoint does not create helper child session"
@@ -465,6 +468,275 @@
         (is (some #(= 'psi.extension/set-session-name (first %)) @calls))
         (is (= "New inferred name"
                (get-in @@#'sut/state [:last-auto-name-by-session "s1"])))))))
+
+(deftest fallback-from-failed-first-helper-to-succeeding-later-candidate-test
+  (testing "fallback follows exact ranked order and renames from a later successful candidate"
+    (reset-state!)
+    (with-redefs [sut/select-helper-models (fn [_api _source-session-id]
+                                             [{:provider :local-helper :id "first" :name "First"}
+                                              {:provider :local-helper :id "second" :name "Second"}])]
+      (let [calls (atom [])
+            child-n (atom 0)
+            run-n   (atom 0)
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/auto_session_name.clj"
+                                  :query-fn (fn [req]
+                                              (cond
+                                                (= {:session-id "s1"
+                                                    :query [{:psi.agent-session/session-entries
+                                                             [:psi.session-entry/kind
+                                                              :psi.session-entry/data]}]}
+                                                   req)
+                                                {:psi.agent-session/session-entries
+                                                 [{:psi.session-entry/kind :message
+                                                   :psi.session-entry/data {:message {:role "user"
+                                                                                      :content [{:type :text :text "Fix footer rendering"}]}}}]}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/session-name]}
+                                                   req)
+                                                {:psi.agent-session/session-name "initial"}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/model-provider
+                                                            :psi.agent-session/model-id]}
+                                                   req)
+                                                {:psi.agent-session/model-provider "anthropic"
+                                                 :psi.agent-session/model-id "claude-sonnet-4-6"}
+
+                                                :else {}))
+                                  :mutate-fn (fn [op params]
+                                               (swap! calls conj [op params])
+                                               (case op
+                                                 psi.extension/create-child-session {:psi.agent-session/session-id (str "child-" (swap! child-n inc))}
+                                                 psi.extension/run-agent-loop-in-session (if (= 1 (swap! run-n inc))
+                                                                                           (throw (ex-info "model unavailable" {}))
+                                                                                           {:psi.agent-session/agent-run-ok? true
+                                                                                            :psi.agent-session/agent-run-text "Fix footer rendering"})
+                                                 psi.extension/set-session-name {:psi.agent-session/session-name (:name params)}
+                                                 psi.extension/close-session {:psi.agent-session/close-session-closed? true
+                                                                              :psi.agent-session/close-session-id (:session-id params)}
+                                                 {}))})]
+        (sut/init api)
+        (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
+          (is (nil? (handler {:session-id "s1" :turn-count 2})))
+          (is (= ["first" "second"]
+                 (->> @calls
+                      (keep (fn [[op params]]
+                              (when (= op 'psi.extension/run-agent-loop-in-session)
+                                (get-in params [:model :id]))))
+                      vec)))
+          (is (= 2 (count (filter #(= 'psi.extension/create-child-session (first %)) @calls))))
+          (is (= 2 (count (filter #(= 'psi.extension/close-session (first %)) @calls))))
+          (is (= 1 (count (filter #(= 'psi.extension/set-session-name (first %)) @calls)))))))))
+
+(deftest fallback-from-invalid-title-to-valid-later-candidate-test
+  (testing "fallback continues when a helper run succeeds but returns an invalid title"
+    (reset-state!)
+    (with-redefs [sut/select-helper-models (fn [_api _source-session-id]
+                                             [{:provider :local-helper :id "first" :name "First"}
+                                              {:provider :local-helper :id "second" :name "Second"}])]
+      (let [calls (atom [])
+            run-n (atom 0)
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/auto_session_name.clj"
+                                  :query-fn (fn [req]
+                                              (cond
+                                                (= {:session-id "s1"
+                                                    :query [{:psi.agent-session/session-entries
+                                                             [:psi.session-entry/kind
+                                                              :psi.session-entry/data]}]}
+                                                   req)
+                                                {:psi.agent-session/session-entries
+                                                 [{:psi.session-entry/kind :message
+                                                   :psi.session-entry/data {:message {:role "user"
+                                                                                      :content [{:type :text :text "Fix footer rendering"}]}}}]}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/session-name]}
+                                                   req)
+                                                {:psi.agent-session/session-name "initial"}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/model-provider
+                                                            :psi.agent-session/model-id]}
+                                                   req)
+                                                {:psi.agent-session/model-provider "anthropic"
+                                                 :psi.agent-session/model-id "claude-sonnet-4-6"}
+
+                                                :else {}))
+                                  :mutate-fn (fn [op params]
+                                               (swap! calls conj [op params])
+                                               (case op
+                                                 psi.extension/create-child-session {:psi.agent-session/session-id (str "child-" (count @calls))}
+                                                 psi.extension/run-agent-loop-in-session (if (= 1 (swap! run-n inc))
+                                                                                           {:psi.agent-session/agent-run-ok? true
+                                                                                            :psi.agent-session/agent-run-text ""}
+                                                                                           {:psi.agent-session/agent-run-ok? true
+                                                                                            :psi.agent-session/agent-run-text "Fix footer rendering"})
+                                                 psi.extension/set-session-name {:psi.agent-session/session-name (:name params)}
+                                                 psi.extension/close-session {:psi.agent-session/close-session-closed? true
+                                                                              :psi.agent-session/close-session-id (:session-id params)}
+                                                 {}))})]
+        (sut/init api)
+        (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
+          (is (nil? (handler {:session-id "s1" :turn-count 2})))
+          (is (= ["first" "second"]
+                 (->> @calls
+                      (keep (fn [[op params]]
+                              (when (= op 'psi.extension/run-agent-loop-in-session)
+                                (get-in params [:model :id]))))
+                      vec)))
+          (is (= 1 (count (filter #(= 'psi.extension/set-session-name (first %)) @calls)))))))))
+
+(deftest empty-ranked-candidate-list-behaves-as-exhaustion-test
+  (testing "empty helper candidate list behaves as exhaustion without rename"
+    (reset-state!)
+    (with-redefs [sut/select-helper-models (fn [_api _source-session-id] [])]
+      (let [calls (atom [])
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/auto_session_name.clj"
+                                  :query-fn (fn [req]
+                                              (cond
+                                                (= {:session-id "s1"
+                                                    :query [{:psi.agent-session/session-entries
+                                                             [:psi.session-entry/kind
+                                                              :psi.session-entry/data]}]}
+                                                   req)
+                                                {:psi.agent-session/session-entries
+                                                 [{:psi.session-entry/kind :message
+                                                   :psi.session-entry/data {:message {:role "user"
+                                                                                      :content [{:type :text :text "Fix footer rendering"}]}}}]}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/model-provider
+                                                            :psi.agent-session/model-id]}
+                                                   req)
+                                                {:psi.agent-session/model-provider "anthropic"
+                                                 :psi.agent-session/model-id "claude-sonnet-4-6"}
+
+                                                :else {}))
+                                  :mutate-fn (fn [op params]
+                                               (swap! calls conj [op params])
+                                               {})})]
+        (sut/init api)
+        (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
+          (is (nil? (handler {:session-id "s1" :turn-count 2})))
+          (is (empty? @calls))
+          (is (= {:text "auto-session-name: rename checkpoint for session s1 at turn 2"
+                  :level :info}
+                 (last (:notifications @state)))))))))
+
+(deftest stale-fallback-termination-prevents-later-attempts-test
+  (testing "stale checkpoint during fallback terminates without trying later candidates"
+    (reset-state!)
+    (swap! @#'sut/state assoc :turn-counts {"s1" 2})
+    (with-redefs [sut/select-helper-models (fn [_api _source-session-id]
+                                             [{:provider :local-helper :id "first"}
+                                              {:provider :local-helper :id "second"}])]
+      (let [calls (atom [])
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/auto_session_name.clj"
+                                  :query-fn (fn [req]
+                                              (cond
+                                                (= {:session-id "s1"
+                                                    :query [{:psi.agent-session/session-entries
+                                                             [:psi.session-entry/kind
+                                                              :psi.session-entry/data]}]}
+                                                   req)
+                                                {:psi.agent-session/session-entries
+                                                 [{:psi.session-entry/kind :message
+                                                   :psi.session-entry/data {:message {:role "user"
+                                                                                      :content [{:type :text :text "Fix footer rendering"}]}}}]}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/session-name]}
+                                                   req)
+                                                {:psi.agent-session/session-name "initial"}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/model-provider
+                                                            :psi.agent-session/model-id]}
+                                                   req)
+                                                {:psi.agent-session/model-provider "anthropic"
+                                                 :psi.agent-session/model-id "claude-sonnet-4-6"}
+
+                                                :else {}))
+                                  :mutate-fn (fn [op params]
+                                               (swap! calls conj [op params])
+                                               (case op
+                                                 psi.extension/create-child-session {:psi.agent-session/session-id "child-1"}
+                                                 psi.extension/run-agent-loop-in-session (do (swap! @#'sut/state assoc :turn-counts {"s1" 3})
+                                                                                             {:psi.agent-session/agent-run-ok? false
+                                                                                              :psi.agent-session/agent-run-text nil})
+                                                 psi.extension/close-session {:psi.agent-session/close-session-closed? true
+                                                                              :psi.agent-session/close-session-id (:session-id params)}
+                                                 {}))})]
+        (sut/init api)
+        (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
+          (is (nil? (handler {:session-id "s1" :turn-count 2})))
+          (is (= ["first"]
+                 (->> @calls
+                      (keep (fn [[op params]]
+                              (when (= op 'psi.extension/run-agent-loop-in-session)
+                                (get-in params [:model :id]))))
+                      vec))))))))
+
+(deftest manual-override-during-fallback-terminates-later-attempts-test
+  (testing "manual override detected during fallback terminates without trying later candidates"
+    (reset-state!)
+    (swap! @#'sut/state assoc :last-auto-name-by-session {"s1" "Old auto name"})
+    (with-redefs [sut/select-helper-models (fn [_api _source-session-id]
+                                             [{:provider :local-helper :id "first"}
+                                              {:provider :local-helper :id "second"}])]
+      (let [calls (atom [])
+            current-name* (atom "Old auto name")
+            {:keys [api state]} (nullable/create-nullable-extension-api
+                                 {:path "/test/auto_session_name.clj"
+                                  :query-fn (fn [req]
+                                              (cond
+                                                (= {:session-id "s1"
+                                                    :query [{:psi.agent-session/session-entries
+                                                             [:psi.session-entry/kind
+                                                              :psi.session-entry/data]}]}
+                                                   req)
+                                                {:psi.agent-session/session-entries
+                                                 [{:psi.session-entry/kind :message
+                                                   :psi.session-entry/data {:message {:role "user"
+                                                                                      :content [{:type :text :text "Fix footer rendering"}]}}}]}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/session-name]}
+                                                   req)
+                                                {:psi.agent-session/session-name @current-name*}
+
+                                                (= {:session-id "s1"
+                                                    :query [:psi.agent-session/model-provider
+                                                            :psi.agent-session/model-id]}
+                                                   req)
+                                                {:psi.agent-session/model-provider "anthropic"
+                                                 :psi.agent-session/model-id "claude-sonnet-4-6"}
+
+                                                :else {}))
+                                  :mutate-fn (fn [op params]
+                                               (swap! calls conj [op params])
+                                               (case op
+                                                 psi.extension/create-child-session {:psi.agent-session/session-id "child-1"}
+                                                 psi.extension/run-agent-loop-in-session (do (reset! current-name* "Manual name")
+                                                                                             {:psi.agent-session/agent-run-ok? false
+                                                                                              :psi.agent-session/agent-run-text nil})
+                                                 psi.extension/close-session {:psi.agent-session/close-session-closed? true
+                                                                              :psi.agent-session/close-session-id (:session-id params)}
+                                                 {}))})]
+        (sut/init api)
+        (let [handler (first (get-in @state [:handlers "auto_session_name/rename_checkpoint"]))]
+          (is (nil? (handler {:session-id "s1" :turn-count 2})))
+          (is (= ["first"]
+                 (->> @calls
+                      (keep (fn [[op params]]
+                              (when (= op 'psi.extension/run-agent-loop-in-session)
+                                (get-in params [:model :id]))))
+                      vec))))))))
 
 (deftest helper-session-turn-finished-is-ignored-test
   (testing "turn-finished events for helper child sessions do not schedule nested checkpoints"

--- a/extensions/auto-session-name/test/extensions/auto_session_name_test.clj
+++ b/extensions/auto-session-name/test/extensions/auto_session_name_test.clj
@@ -181,8 +181,8 @@
                                                        :cache-breakpoints]))))
                         first)))
         (is (= {:provider :openai
-                :id "gpt-5.3-codex-spark"
-                :name "GPT-5.3 Codex Spark"}
+                :id "gpt-5-nano"
+                :name "GPT-5 Nano"}
                (some->> @calls
                         (keep (fn [[kind op params]]
                                 (when (and (= kind :mutate)

--- a/munera/open/076-auto-session-name-helper-model-fallback/design.md
+++ b/munera/open/076-auto-session-name-helper-model-fallback/design.md
@@ -1,0 +1,111 @@
+Goal: make the auto-session-name extension fall back across ranked helper models when the top-ranked helper candidate is not runnable, so naming remains best-effort in environments where local model metadata and live local model availability diverge.
+
+Context:
+- the auto-session-name extension currently selects one helper model via `psi.ai.model-selection/resolve-selection`
+- that selection is driven by catalog metadata and policy preferences such as locality, latency tier, and cost tier
+- the selector does not currently know whether a local model is actually runnable right now
+- as a result, the extension can choose a configured local model that is not running, even when another qualifying local model is running and would succeed
+- helper execution failure is only discovered when the child helper session runs `psi.extension/run-agent-loop-in-session`
+- the extension is best-effort and already tolerates no-op outcomes when title inference cannot be applied
+
+Problem:
+- helper model selection currently answers “best ranked candidate from the catalog” rather than “best runnable candidate right now”
+- when the top-ranked helper model is not runnable, the extension stops after one failed attempt and does not try lower-ranked candidates
+- this makes helper naming brittle for local providers whose configured model set is broader than the set of currently running models
+- the immediate bug to solve is extension-local resilience, not a global redesign of model-selection or provider-health introspection
+
+Required behavior:
+- auto-session-name keeps its existing helper model selection policy and ranking intent
+- instead of treating the top-ranked helper candidate as the only attempt, the extension must treat the ranked survivor list as an ordered fallback sequence
+- helper execution attempts proceed in the exact order of the ranked candidate vector returned by model selection until one attempt produces a rename success or the candidate list is exhausted
+- if the first candidate is not runnable but a later ranked candidate is runnable, the extension should still infer and apply a title
+- if the ranked survivor list is empty, that counts as fallback exhaustion
+- if all helper candidates fail or the candidate list is empty, the extension must preserve the current no-rename behavior and emit the existing single notification/log fallback outcome once after exhaustion
+- stale-checkpoint suppression, helper-session recursion protection, manual-override protection, and title validation/application semantics must remain unchanged
+
+Outcome model:
+- distinguish these outcomes explicitly:
+  - execution success: helper run completed with `:psi.agent-session/agent-run-ok? true`
+  - title success: execution success plus a normalized title that passes the existing title validation rules
+  - rename success: title success plus source-session guards still allow applying the inferred title
+- fallback is driven by helper-attempt outcomes, while stale/manual source-session guards remain authoritative gates on applying a rename
+
+Fallback semantics:
+- fallback is owned by the auto-session-name extension, not by global model-selection and not by the generic session runtime in this task
+- the retry boundary is helper execution attempt selection, not title post-processing
+- the extension must compute one sanitized bounded conversation snapshot for the checkpoint attempt and reuse that same snapshot across all fallback candidates for that checkpoint
+- each helper attempt uses the same naming prompt contract, the same system prompt, and the same user prompt text derived from that source-session conversation snapshot for that checkpoint attempt; only the helper model varies across fallback attempts
+- each helper attempt uses a fresh helper child session; reusing a previous failed helper child session is out of scope for this task
+- the ordered candidate list comes from the existing model-selection ranking result for the extension’s current helper selection request
+- prefer consuming the existing `resolve-selection` ranking result, ideally by reading the existing ranked candidate vector directly, without changing global model-selection semantics or result shape; add a small shared accessor only if needed for code-shaping clarity
+
+Failure policy:
+- this task uses pragmatic best-effort fallback semantics
+- fallback continues to the next ranked candidate when a helper attempt:
+  - throws during helper execution
+  - returns `:psi.agent-session/agent-run-ok? false`
+  - returns `:psi.agent-session/agent-run-ok? true` but does not yield a valid usable title after normalization and existing validation
+- this task does not require provider-specific parsing to distinguish “model unavailable” from other helper execution failures
+- the extension must re-check stale/manual stop conditions before starting each further candidate attempt and again before applying a rename
+- fallback must terminate immediately, without trying further candidates, when:
+  - the checkpoint becomes stale before, during, or after an attempt
+  - manual-override protection detects that the current source-session name has diverged from the last auto-applied name before rename application
+- stale/manual guard termination is not a helper-model failure case; it is an authoritative source-session stop condition
+
+Selection semantics to preserve:
+- the extension’s helper model request remains responsible for expressing the desired policy:
+  - require text support
+  - require low latency tier
+  - require zero or low cost tier
+  - strongly prefer local models
+  - strongly prefer lower input and output cost
+  - weakly prefer the same provider as the source session
+- this task must not change the ranking criteria or preference ordering; only code-shaping changes needed to consume the ranked survivor list for fallback are allowed
+- the top-ranked candidate should remain the first attempted helper model
+
+Notification and logging semantics:
+- intermediate helper-attempt failures are not user-visible events in this task
+- this task does not require any new per-attempt logging; if implementation-local debug logging is added using existing seams, tests and behavior must not depend on it
+- the existing no-op notification/log fallback should occur once, after fallback exhaustion, rather than once per failed candidate attempt
+- this task does not require new user-visible error reporting for per-candidate helper failures
+
+Scope:
+- in scope:
+  - extension-local fallback across ranked helper models for auto-session-name
+  - consumption of the ranked selection result needed to drive ordered fallback
+  - focused tests proving fallback behavior, attempt ordering, and guard preservation
+- out of scope:
+  - global provider-health or live-model discovery infrastructure
+  - changing general interactive session model selection
+  - redesigning `psi.ai.model-selection` into a runtime-availability-aware selector
+  - inventing new provider-specific availability probes unless separately requested
+  - changing generic session runtime fallback semantics
+
+Acceptance:
+- auto-session-name can consume the ordered ranked helper candidates implied by its existing selection request
+- fallback attempts follow the exact ranked candidate order returned by model selection
+- when the first ranked helper model fails by throw, unsuccessful run result, or invalid title result, the extension attempts the next ranked candidate in order
+- when a later ranked candidate succeeds and yields a valid title, the source session is renamed exactly once using the existing title validation and overwrite guards
+- when the ranked candidate list is empty, or all candidates fail, the source session is not renamed and the extension emits the existing single no-op notification/log outcome once after exhaustion
+- stale checkpoint suppression still prevents rename after source-session advancement and terminates further fallback attempts for that checkpoint
+- manual-name overwrite protection still prevents replacing a diverged current name and terminates further fallback attempts for that checkpoint
+- helper-session recursion protection still prevents nested scheduling from helper sessions
+- focused tests prove at least:
+  - fallback from a failed first helper candidate to a succeeding later candidate
+  - fallback from a first candidate that returns an invalid title to a later candidate that returns a valid title
+  - exhaustion of all candidates without rename
+  - empty ranked candidate list behaves as exhaustion without rename
+  - preservation of stale-checkpoint behavior during fallback, including immediate fallback termination when the checkpoint becomes stale
+  - preservation of manual-override behavior during fallback, including immediate fallback termination when manual divergence is detected
+  - top-ranked-first attempt ordering, matching the exact ranked candidate order returned by model selection
+  - single notification/log fallback emission after exhaustion rather than one emission per failed attempt
+
+Non-goals:
+- proving that the selected candidate is runnable before execution
+- adding a runtime “running model” attribute to the shared model catalog
+- centralizing fallback in the generic session runtime
+- broadening the task into a universal helper-model availability framework
+
+Notes:
+- this task intentionally chooses a small extension-local resilience improvement over a larger architectural availability project
+- if a later project introduces authoritative provider/model runtime availability facts, auto-session-name may be simplified to rely more on selection-time filtering and less on execution-time fallback

--- a/munera/open/076-auto-session-name-helper-model-fallback/implementation.md
+++ b/munera/open/076-auto-session-name-helper-model-fallback/implementation.md
@@ -1,0 +1,16 @@
+Implementation:
+- auto-session-name now consumes the ranked helper candidates from `resolve-selection` via `[:ranking :ranked]` and treats that ordered vector as its fallback sequence
+- one sanitized bounded conversation snapshot is still computed once per checkpoint attempt and reused across all helper model attempts
+- each helper attempt creates a fresh child session, runs the same prompt contract with a different helper model, and always closes/forgets the helper session after the attempt
+- fallback continues on thrown helper execution, unsuccessful helper run, or invalid normalized title
+- fallback terminates immediately when stale-checkpoint or manual-override guards become true before a later attempt or before rename application
+- rename still happens at most once and still uses the existing validation/manual/stale guards
+- when the ranked candidate list is empty or all candidates fail, the extension preserves the existing single no-op notification outcome after exhaustion
+
+Tests added/updated:
+- failed first candidate falls back to succeeding second candidate in exact ranked order
+- invalid-title first candidate falls back to succeeding later candidate
+- empty ranked candidate list behaves as exhaustion without rename
+- stale checkpoint during fallback stops later attempts
+- manual override during fallback stops later attempts
+- runtime throw path now asserts cleanup across multiple fallback attempts

--- a/munera/open/076-auto-session-name-helper-model-fallback/plan.md
+++ b/munera/open/076-auto-session-name-helper-model-fallback/plan.md
@@ -1,0 +1,6 @@
+Plan:
+1. inspect the current auto-session-name helper selection and helper-run flow to identify the narrowest extension-local seam for ordered fallback
+2. shape the implementation so the extension consumes the existing ranked helper candidates without changing default selection policy or generic session runtime fallback semantics
+3. add focused tests for exact ranked-order attempts, fallback success, invalid-title fallback, empty/exhausted fallback, and stale/manual guard termination
+4. implement the extension-local retry loop so one sanitized checkpoint snapshot is reused across attempts, each attempt uses a fresh helper child session, and notification/no-op behavior remains coherent
+5. run focused auto-session-name tests plus any directly impacted shared model-selection or helper-runtime tests, then record implementation notes

--- a/munera/open/076-auto-session-name-helper-model-fallback/steps.md
+++ b/munera/open/076-auto-session-name-helper-model-fallback/steps.md
@@ -1,0 +1,12 @@
+Steps:
+- confirm the exact ranked-candidate surface already available from `psi.ai.model-selection/resolve-selection` and prefer consuming it directly
+- keep fallback ownership inside `extensions.auto-session-name` rather than broadening into generic session runtime behavior
+- add tests that model first-attempt throw or unsuccessful run and second-attempt success using existing extension test seams
+- add a test where the first attempt succeeds at execution but returns an invalid title and a later attempt returns a valid title
+- add tests for empty ranked-candidate exhaustion, all-candidates-fail exhaustion, stale checkpoint termination, and manual override termination under fallback
+- implement ordered helper fallback with exact ranked-order attempt semantics
+- reuse one sanitized bounded checkpoint snapshot across all fallback attempts for the same checkpoint
+- create a fresh helper child session for each candidate attempt
+- emit the existing notification/log fallback once after exhaustion rather than once per failed attempt
+- verify focused test suites pass
+- capture any follow-on design pressure toward shared runtime availability facts separately rather than broadening this task

--- a/munera/plan.md
+++ b/munera/plan.md
@@ -13,6 +13,7 @@ Queue:
 `munera/open/067-add-anthropic-4-7-and-openai-5-5-models/`
 `munera/open/070-delegate-command-posts-workflow-result-into-chat/`
 `munera/open/073-workflow-child-session-prompt-composition/`
+`munera/open/076-auto-session-name-helper-model-fallback/`
 
 Notes:
 - `munera/plan.md` is the active project-wide orchestration surface.


### PR DESCRIPTION
## Summary
- add ordered helper-model fallback for auto-session-name using the existing ranked selection result
- preserve stale/manual/recursion guards while retrying across fresh helper child sessions
- add focused coverage for fallback ordering, exhaustion, invalid-title retry, and guard termination

## Testing
- focused auto-session-name tests
