### PR TITLE
Preserve custom-provider auth for string provider ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 
 ## [Unreleased]
 
+### Fixed
+- Custom model providers whose selected session model stores `:provider` as a string now resolve provider-scoped auth, request options, and runtime model lookup consistently instead of falling back to built-in provider auth behavior.
+
 ## [0.1.2049] - 2026-05-02
 
 ### Added

--- a/components/agent-session/src/psi/agent_session/prompt_request.clj
+++ b/components/agent-session/src/psi/agent_session/prompt_request.clj
@@ -73,7 +73,7 @@
 
 (defn- resolve-runtime-model
   [session-model]
-  (let [provider (some-> (:provider session-model) keyword)
+  (let [provider (provider-auth/normalize-provider-id (:provider session-model))
         model-id (:id session-model)]
     (model-registry/find-model provider model-id)))
 

--- a/components/agent-session/src/psi/agent_session/provider_auth.clj
+++ b/components/agent-session/src/psi/agent_session/provider_auth.clj
@@ -4,25 +4,37 @@
    Keeps provider-scoped auth precedence consistent across canonical request
    preparation and runtime-facing helper paths."
   (:require
+   [clojure.string :as str]
    [psi.ai.model-registry :as model-registry]
    [psi.agent-session.oauth.core :as oauth]))
+
+(defn normalize-provider-id
+  "Normalize provider identity to the keyword form used by shared provider
+   registries. Blank strings normalize to nil."
+  [provider]
+  (cond
+    (keyword? provider) provider
+    (string? provider)  (when-not (str/blank? provider)
+                          (keyword provider))
+    :else               nil))
 
 (defn provider-auth-config
   "Return model-registry auth for `provider` or nil."
   [provider]
-  (when provider
-    (model-registry/get-auth provider)))
+  (when-let [provider-id (normalize-provider-id provider)]
+    (model-registry/get-auth provider-id)))
 
 (defn provider-api-key
   "Resolve a provider-scoped API key using shared precedence:
    1. OAuth/runtime credential for the selected provider
    2. model-registry auth for the selected provider when auth headers are enabled"
   [ctx provider]
-  (or (when-let [oauth-ctx (:oauth-ctx ctx)]
-        (oauth/get-api-key oauth-ctx provider))
-      (when-let [auth (provider-auth-config provider)]
-        (when (:auth-header? auth)
-          (:api-key auth)))))
+  (let [provider-id (normalize-provider-id provider)]
+    (or (when (and provider-id (:oauth-ctx ctx))
+          (oauth/get-api-key (:oauth-ctx ctx) provider-id))
+        (when-let [auth (provider-auth-config provider-id)]
+          (when (:auth-header? auth)
+            (:api-key auth))))))
 
 (defn provider-request-options
   "Return provider-scoped request options derived from model-registry auth.

--- a/components/agent-session/test/psi/agent_session/prompt_request_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_request_test.clj
@@ -59,13 +59,22 @@
     (try
       (model-registry/init! {:user-models-path path})
 
-      (testing "auth-header? false sets :no-auth-header and omits api-key"
+      (testing "auth-header? false sets :no-auth-header and omits api-key for keyword provider identity"
         (let [opts (prompt-request/session->request-options
                     {}
                     (session-data-for :ollama "llama")
                     {})]
           (is (true? (:no-auth-header opts)))
           ;; api-key should NOT be injected because auth-header? is false
+          (is (nil? (:api-key opts)))))
+
+      (testing "auth-header? false sets :no-auth-header and omits api-key for live session string provider identity"
+        (let [opts (prompt-request/session->request-options
+                    {}
+                    {:model {:provider "ollama" :id "llama"}
+                     :thinking-level :off}
+                    {})]
+          (is (true? (:no-auth-header opts)))
           (is (nil? (:api-key opts)))))
 
       (finally
@@ -84,10 +93,20 @@
     (try
       (model-registry/init! {:user-models-path path})
 
-      (testing "custom headers merged into options"
+      (testing "custom headers merged into options for keyword provider identity"
         (let [opts (prompt-request/session->request-options
                     {}
                     (session-data-for :custom "model-a")
+                    {})]
+          (is (= {"X-Custom" "value" "X-Project" "psi"}
+                 (:headers opts)))
+          (is (= "key123" (:api-key opts)))))
+
+      (testing "custom headers merged into options for live session string provider identity"
+        (let [opts (prompt-request/session->request-options
+                    {}
+                    {:model {:provider "custom" :id "model-a"}
+                     :thinking-level :off}
                     {})]
           (is (= {"X-Custom" "value" "X-Project" "psi"}
                  (:headers opts)))

--- a/components/agent-session/test/psi/agent_session/prompt_request_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_request_test.clj
@@ -128,10 +128,20 @@
     (try
       (model-registry/init! {:user-models-path path})
 
-      (testing "custom anthropic-compatible provider injects provider-scoped api-key"
+      (testing "custom anthropic-compatible provider injects provider-scoped api-key for keyword provider identity"
         (let [opts (prompt-request/session->request-options
                     {}
                     (session-data-for :minimax "MiniMax-M2.7")
+                    {})]
+          (is (= "minimax-inline-key" (:api-key opts)))
+          (is (nil? (:no-auth-header opts)))
+          (is (nil? (:headers opts)))))
+
+      (testing "custom anthropic-compatible provider injects provider-scoped api-key for live session string provider identity"
+        (let [opts (prompt-request/session->request-options
+                    {}
+                    {:model {:provider "minimax" :id "MiniMax-M2.7"}
+                     :thinking-level :off}
                     {})]
           (is (= "minimax-inline-key" (:api-key opts)))
           (is (nil? (:no-auth-header opts)))

--- a/components/agent-session/test/psi/agent_session/runtime_test.clj
+++ b/components/agent-session/test/psi/agent_session/runtime_test.clj
@@ -211,6 +211,8 @@
         (model-registry/init! {:user-models-path path})
         (is (= "minimax-inline-key"
                (runtime/resolve-api-key-in {} "sid" {:provider :minimax :id "MiniMax-M2.7"})))
+        (is (= "minimax-inline-key"
+               (runtime/resolve-api-key-in {} "sid" {:provider "minimax" :id "MiniMax-M2.7"})))
         (finally
           (java.io.File/.delete (java.io.File. path))))))
 
@@ -227,9 +229,12 @@
         (model-registry/init! {:user-models-path path})
         (is (= "oauth-key"
                (runtime/resolve-api-key-in {:oauth-ctx oauth-ctx} "sid" {:provider :minimax :id "MiniMax-M2.7"})))
+        (is (= "oauth-key"
+               (runtime/resolve-api-key-in {:oauth-ctx oauth-ctx} "sid" {:provider "minimax" :id "MiniMax-M2.7"})))
         (finally
           (java.io.File/.delete (java.io.File. path))))))
 
   (testing "built-in anthropic remains unresolved without oauth or registry auth"
     (model-registry/init! {})
-    (is (nil? (runtime/resolve-api-key-in {} "sid" {:provider :anthropic :id "claude-sonnet-4-6"})))))
+    (is (nil? (runtime/resolve-api-key-in {} "sid" {:provider :anthropic :id "claude-sonnet-4-6"})))
+    (is (nil? (runtime/resolve-api-key-in {} "sid" {:provider "anthropic" :id "claude-sonnet-4-6"})))))

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/design.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/design.md
@@ -1,0 +1,111 @@
+# Preserve custom provider auth resolution when session model providers are stored as strings
+
+## Goal
+
+Make provider-scoped auth resolution for custom model providers work when the selected session model stores `:provider` as a string, so Anthropic-compatible custom providers such as MiniMax do not regress to the built-in Anthropic missing-key failure.
+
+## Context
+
+A user reports that after upgrading to `35dfa40af91023c802ce86f9124d5e813056dd69`, using a custom provider such as:
+
+```clojure
+{:version 1
+ :providers
+ {"minimax"
+  {:base-url "https://api.minimax.io/anthropic"
+   :api      :anthropic-messages
+   :auth     {:api-key "..."}
+   :models   [{:id "MiniMax-M2.7"}]}}}
+```
+
+again fails with:
+
+```text
+Missing Anthropic API key. Set ANTHROPIC_API_KEY or login via /login anthropic.
+```
+
+Task `067-custom-provider-anthropic-auth` already established the intended invariant:
+
+- `:api` selects the transport / protocol implementation
+- `:provider` selects provider-scoped configuration such as auth and base URL
+
+That fix appears to work when provider identity is represented as a keyword, but real session state stores `:model :provider` as a string. The shared provider-auth path therefore appears to succeed in focused keyword-shaped tests while failing in the live session-shaped path.
+
+## Why
+
+This is a regression in a core extensibility path.
+
+Users who configure Anthropic-compatible custom providers should not need to duplicate credentials into built-in Anthropic auth surfaces just because the live session model stores provider identity in string form.
+
+More generally, provider identity shape must not silently change auth behavior between:
+
+- resolved runtime model maps
+- persisted/live session model maps
+- prompt preparation
+- runtime helper paths
+
+## Observed seam
+
+The current system has these two shapes in play:
+
+- model registry auth keys are provider keywords, e.g. `:minimax`
+- live session state stores model providers as strings, e.g. `"minimax"`
+
+The shared provider-auth layer is the correct boundary for this mismatch. If provider normalization is not handled there, canonical prompt preparation can lose custom-provider auth before transport execution, which then falls through to transport-specific built-in missing-key behavior.
+
+## Scope
+
+Investigate and fix provider-scoped auth resolution so custom provider auth lookup is shape-stable across string and keyword provider identities.
+
+The task must cover:
+
+- canonical prepared-request auth shaping
+- runtime helper auth shaping
+- the specific regression path for custom `:anthropic-messages` providers
+- provider-request option lookup when it depends on the same shared provider-identity seam
+
+Do not widen beyond shared provider-auth lookup paths that use provider identity as a registry key.
+
+## Constraints
+
+- Preserve the architectural invariant from task 067: transport identity and provider identity remain distinct.
+- Fix the root cause at the shared provider-auth boundary, not by adding MiniMax- or Anthropic-specific special cases.
+- Preserve explicit per-call runtime overrides such as `:runtime-opts {:api-key ...}`.
+- Preserve current custom-provider auth semantics for keyword-shaped provider identities.
+- Preserve the current built-in Anthropic missing-auth behavior when no selected-provider auth exists.
+- Add regression coverage that uses real session-shaped string provider identities, not only keyword test fixtures.
+
+## Required behavior
+
+For a selected custom provider stored in live session data as `{:model {:provider "minimax" :id "MiniMax-M2.7"}}`:
+
+- provider auth lookup must resolve the configured custom-provider auth
+- prepared request options must include the custom provider API key when appropriate
+- runtime helper auth lookup must return the same effective provider auth
+- provider-request option lookup must use the same selected provider identity when it depends on the same shared provider-auth seam
+- canonical request preparation and runtime helper auth resolution must supply selected-provider auth so the custom `:anthropic-messages` path does not surface the built-in Anthropic missing-key error when selected-provider auth exists
+
+For keyword-shaped provider identities such as `:minimax`:
+
+- preserve existing working behavior
+
+For built-in Anthropic without configured auth:
+
+- preserve current missing-auth behavior
+
+## Acceptance
+
+- A custom Anthropic-compatible provider with inline auth still works when live session data stores `:model :provider` as a string.
+- `prompt-request/session->request-options` resolves provider auth correctly for both string and keyword provider identities.
+- `runtime/resolve-api-key-in` resolves provider auth correctly for both string and keyword provider identities.
+- Any provider-request option lookup that shares the same provider-identity seam is also correct for both string and keyword provider identities.
+- At least one new regression test uses live session-data shape `{:model {:provider "minimax" :id "MiniMax-M2.7"}}` and fails on the pre-fix implementation.
+- The new string-provider regression tests pass after the fix.
+- The fix is implemented at a shared provider-auth boundary rather than duplicated across callers.
+
+## Suggested verification surface
+
+- focused `prompt_request` tests using live session-data shape with string-shaped provider identities
+- focused `runtime` auth-resolution tests using string-shaped provider identities
+- focused coverage for provider-request option lookup if it shares the same provider-identity seam
+- one regression proof showing the custom `:anthropic-messages` path no longer surfaces the built-in Anthropic missing-key error when selected-provider auth is present

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
@@ -2,10 +2,48 @@
 
 Created to track the custom-provider auth regression where real session-shaped string provider identities appear to lose provider-scoped auth lookup and fall through to built-in Anthropic missing-key behavior.
 
-Expected investigation focus:
+## Findings
 
-- session state stores model providers as strings
-- model-registry auth is keyed by provider keyword
-- shared provider-auth resolution is the likely normalization boundary
+- Session state stores selected model providers as strings, e.g. `"minimax"`.
+- Shared provider auth lookup was keyed directly by the incoming provider value.
+- Model-registry auth is stored under keyword provider ids, e.g. `:minimax`.
+- This meant keyword-shaped unit tests passed while live session-shaped string provider identities missed provider auth lookup.
+- The same shape seam also applied to shared provider-request option lookup and OAuth lookup paths inside `provider_auth.clj`.
 
-Record findings, implementation decisions, and verification results here during execution.
+## Implementation
+
+- Added `normalize-provider-id` in `psi.agent-session.provider-auth`.
+- Normalization rules:
+  - keywords stay keywords
+  - non-blank strings normalize to keywords
+  - blank strings and unsupported values normalize to `nil`
+- Applied normalization at the shared provider-auth boundary for:
+  - model-registry auth lookup
+  - OAuth API key lookup
+  - provider-request option lookup via shared auth config lookup
+
+## Regression coverage
+
+- `prompt_request_test.clj`
+  - preserved keyword-shaped custom Anthropic-compatible provider coverage
+  - added live session-shaped string-provider coverage using `{:model {:provider "minimax" :id "MiniMax-M2.7"}}`
+- `runtime_test.clj`
+  - added string-provider coverage for registry-backed auth lookup
+  - added string-provider coverage for OAuth-over-registry precedence
+  - added built-in string-provider coverage proving built-in Anthropic remains unresolved without auth
+
+## Verification
+
+Focused verification initially hit one unmatched delimiter in the new runtime regression test and was corrected immediately.
+
+After correction:
+
+- `bb clojure:test:unit --focus psi.agent-session.prompt-request-test --focus psi.agent-session.runtime-test`
+  - `1497 tests, 10943 assertions, 0 failures`
+
+Additional checks run during the session:
+
+- `bb test:agent-core`
+  - `11 tests, 75 assertions, 0 failures`
+- `bb test:query`
+  - `11 tests, 33 assertions, 0 failures`

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
@@ -1,0 +1,11 @@
+# Implementation notes
+
+Created to track the custom-provider auth regression where real session-shaped string provider identities appear to lose provider-scoped auth lookup and fall through to built-in Anthropic missing-key behavior.
+
+Expected investigation focus:
+
+- session state stores model providers as strings
+- model-registry auth is keyed by provider keyword
+- shared provider-auth resolution is the likely normalization boundary
+
+Record findings, implementation decisions, and verification results here during execution.

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
@@ -27,6 +27,7 @@ Created to track the custom-provider auth regression where real session-shaped s
 - `prompt_request_test.clj`
   - preserved keyword-shaped custom Anthropic-compatible provider coverage
   - added live session-shaped string-provider coverage using `{:model {:provider "minimax" :id "MiniMax-M2.7"}}`
+  - added string-provider regression coverage for provider-request option shaping on both `:auth-header? false -> :no-auth-header true` and custom `:headers` propagation
 - `runtime_test.clj`
   - added string-provider coverage for registry-backed auth lookup
   - added string-provider coverage for OAuth-over-registry precedence
@@ -41,9 +42,18 @@ After correction:
 - `bb clojure:test:unit --focus psi.agent-session.prompt-request-test --focus psi.agent-session.runtime-test`
   - `1497 tests, 10943 assertions, 0 failures`
 
+After review follow-up coverage:
+
+- `bb clojure:test:unit --focus psi.agent-session.prompt-request-test --focus psi.agent-session.runtime-test`
+  - `1497 tests, 11025 assertions, 0 failures`
+
 Additional checks run during the session:
 
 - `bb test:agent-core`
   - `11 tests, 75 assertions, 0 failures`
 - `bb test:query`
   - `11 tests, 33 assertions, 0 failures`
+
+## Review note
+
+Implementation review: accept with small follow-up. Shared-boundary normalization is correct, but string-shaped regression coverage should be extended to prove provider-request option shaping too, especially `:auth-header? false -> :no-auth-header true` and custom `:headers` propagation.

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/implementation.md
@@ -21,6 +21,7 @@ Created to track the custom-provider auth regression where real session-shaped s
   - model-registry auth lookup
   - OAuth API key lookup
   - provider-request option lookup via shared auth config lookup
+- Follow-on shaping aligned `prompt_request/resolve-runtime-model` with the same shared `normalize-provider-id` helper so provider interpretation no longer drifts between runtime-model lookup and provider-auth lookup paths
 
 ## Regression coverage
 
@@ -47,6 +48,11 @@ After review follow-up coverage:
 - `bb clojure:test:unit --focus psi.agent-session.prompt-request-test --focus psi.agent-session.runtime-test`
   - `1497 tests, 11025 assertions, 0 failures`
 
+After shaping follow-up:
+
+- `bb clojure:test:unit --focus psi.agent-session.prompt-request-test --focus psi.agent-session.runtime-test`
+  - `1497 tests, 11025 assertions, 0 failures`
+
 Additional checks run during the session:
 
 - `bb test:agent-core`
@@ -56,4 +62,4 @@ Additional checks run during the session:
 
 ## Review note
 
-Implementation review: accept with small follow-up. Shared-boundary normalization is correct, but string-shaped regression coverage should be extended to prove provider-request option shaping too, especially `:auth-header? false -> :no-auth-header true` and custom `:headers` propagation.
+Implementation review: accept with small follow-up. Shared-boundary normalization is correct, and request-option string-provider coverage is now in place. Remaining shaping follow-up: make `prompt_request/resolve-runtime-model` use the shared `provider-auth/normalize-provider-id` helper instead of normalizing provider identity locally.

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/plan.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/plan.md
@@ -1,0 +1,59 @@
+# Plan
+
+## Approach
+
+Fix the regression at the shared provider-auth boundary by normalizing provider identity before auth and provider-option lookup.
+
+The implementation should preserve the existing architecture:
+
+- `:api` chooses the transport / protocol implementation
+- `:provider` chooses provider-scoped configuration
+
+The issue is not transport selection; it is provider identity shape drift between:
+
+- live session-state model maps, which store provider as a string
+- registry/auth lookups, which are keyed by provider keyword
+
+The fix should therefore make shared provider-auth resolution shape-stable so all prompt-preparation and runtime helper callers benefit automatically.
+
+## Planned slices
+
+1. Reproduce the regression with real session-shaped provider identity
+   - add prompt-request coverage using session data with `{:provider "minimax" ...}`
+   - add runtime helper coverage using ai-model maps with `{:provider "minimax" ...}`
+   - preserve the existing keyword-shaped coverage as a guard against regressions in the opposite direction
+
+2. Normalize provider identity at the shared boundary
+   - inspect `provider_auth.clj` for auth and request-option lookup seams
+   - add one canonical provider normalization helper there
+   - use it for every shared provider-auth lookup path that uses provider identity as a registry key
+   - this includes model-registry auth lookup and provider-request option shaping when they share the same seam
+   - apply the same normalization to OAuth lookup if that path consumes the same provider identity surface
+
+3. Verify canonical prompt-preparation behavior
+   - ensure `prompt-request/session->request-options` resolves custom auth for both string and keyword provider identities
+   - ensure explicit runtime override precedence remains intact
+   - ensure built-in provider missing-auth behavior remains unchanged
+
+4. Verify the reported custom Anthropic-compatible regression is covered
+   - prove with at least one new regression test that a selected custom `:anthropic-messages` provider with configured auth does not surface the built-in Anthropic missing-key failure solely because the provider is string-shaped
+
+## Key decisions
+
+- Fix provider shape drift once in shared provider-auth code rather than in prompt-request and runtime separately.
+- Treat string and keyword provider identities as equivalent representations of the same selected provider.
+- Do not patch the Anthropic transport or reintroduce provider-specific special cases.
+- Prefer tests that match live session-state shape over unit-only synthetic keyword paths.
+
+## Risks
+
+- Provider identity may cross both model-registry and OAuth lookups; a partial normalization could leave one path inconsistent.
+- Over-normalizing in the wrong place could affect call sites that intentionally distinguish nil/blank/invalid provider values.
+- Existing tests currently exercise the keyword path and may give false confidence unless string-shaped regression coverage is added first.
+
+## Verification
+
+- focused `psi.agent-session.prompt-request-test`
+- focused `psi.agent-session.runtime-test`
+- focused coverage for provider-request option lookup if it shares the same seam
+- at least one new string-provider regression proof showing the MiniMax custom `:anthropic-messages` path no longer drops configured auth or surfaces the built-in Anthropic missing-key error

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
@@ -14,3 +14,5 @@
 - [x] Add string-provider regression coverage for provider-request option shaping with `:auth-header? false` proving `:no-auth-header true`
 - [x] Add string-provider regression coverage for provider-request option shaping proving custom `:headers` propagation
 - [x] Re-run focused `prompt-request` and `runtime` tests and record the updated result after the review follow-up
+- [x] Replace local provider normalization in `prompt_request/resolve-runtime-model` with shared `provider-auth/normalize-provider-id`
+- [x] Re-run focused `prompt-request` and `runtime` tests and record the result after the shaping follow-up

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
@@ -1,0 +1,13 @@
+- [ ] Reproduce the regression with tests that use string-shaped provider identities matching live session state
+- [ ] Add or refine prompt-request coverage for a custom `:anthropic-messages` provider stored as `{:provider "minimax" ...}`
+- [ ] Add or refine runtime helper coverage for `resolve-api-key-in` with `{:provider "minimax" ...}`
+- [ ] Add or refine at least one regression test that uses live session-data shape `{:model {:provider "minimax" :id "MiniMax-M2.7"}}`
+- [ ] Inspect the shared provider-auth boundary and identify the exact normalization seam
+- [ ] Implement provider identity normalization once in shared provider-auth resolution
+- [ ] Ensure every shared provider-auth lookup path that uses provider identity as a registry key uses the same normalized provider identity
+- [ ] Add or refine coverage for provider-request option lookup if it shares the same provider-identity seam
+- [ ] Verify explicit runtime override precedence remains intact
+- [ ] Verify built-in Anthropic missing-auth behavior remains unchanged
+- [ ] Verify the new string-provider regression test(s) fail on the pre-fix implementation and pass after the fix
+- [ ] Run focused regression tests and record the result
+- [ ] Capture any implementation notes or edge-case decisions in `implementation.md`

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
@@ -11,3 +11,6 @@
 - [x] Verify the new string-provider regression test(s) fail on the pre-fix implementation and pass after the fix
 - [x] Run focused regression tests and record the result
 - [x] Capture any implementation notes or edge-case decisions in `implementation.md`
+- [x] Add string-provider regression coverage for provider-request option shaping with `:auth-header? false` proving `:no-auth-header true`
+- [x] Add string-provider regression coverage for provider-request option shaping proving custom `:headers` propagation
+- [x] Re-run focused `prompt-request` and `runtime` tests and record the updated result after the review follow-up

--- a/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
+++ b/munera/open/077-custom-provider-string-provider-auth-normalization/steps.md
@@ -1,13 +1,13 @@
-- [ ] Reproduce the regression with tests that use string-shaped provider identities matching live session state
-- [ ] Add or refine prompt-request coverage for a custom `:anthropic-messages` provider stored as `{:provider "minimax" ...}`
-- [ ] Add or refine runtime helper coverage for `resolve-api-key-in` with `{:provider "minimax" ...}`
-- [ ] Add or refine at least one regression test that uses live session-data shape `{:model {:provider "minimax" :id "MiniMax-M2.7"}}`
-- [ ] Inspect the shared provider-auth boundary and identify the exact normalization seam
-- [ ] Implement provider identity normalization once in shared provider-auth resolution
-- [ ] Ensure every shared provider-auth lookup path that uses provider identity as a registry key uses the same normalized provider identity
-- [ ] Add or refine coverage for provider-request option lookup if it shares the same provider-identity seam
-- [ ] Verify explicit runtime override precedence remains intact
-- [ ] Verify built-in Anthropic missing-auth behavior remains unchanged
-- [ ] Verify the new string-provider regression test(s) fail on the pre-fix implementation and pass after the fix
-- [ ] Run focused regression tests and record the result
-- [ ] Capture any implementation notes or edge-case decisions in `implementation.md`
+- [x] Reproduce the regression with tests that use string-shaped provider identities matching live session state
+- [x] Add or refine prompt-request coverage for a custom `:anthropic-messages` provider stored as `{:provider "minimax" ...}`
+- [x] Add or refine runtime helper coverage for `resolve-api-key-in` with `{:provider "minimax" ...}`
+- [x] Add or refine at least one regression test that uses live session-data shape `{:model {:provider "minimax" :id "MiniMax-M2.7"}}`
+- [x] Inspect the shared provider-auth boundary and identify the exact normalization seam
+- [x] Implement provider identity normalization once in shared provider-auth resolution
+- [x] Ensure every shared provider-auth lookup path that uses provider identity as a registry key uses the same normalized provider identity
+- [x] Add or refine coverage for provider-request option lookup if it shares the same provider-identity seam
+- [x] Verify explicit runtime override precedence remains intact
+- [x] Verify built-in Anthropic missing-auth behavior remains unchanged
+- [x] Verify the new string-provider regression test(s) fail on the pre-fix implementation and pass after the fix
+- [x] Run focused regression tests and record the result
+- [x] Capture any implementation notes or edge-case decisions in `implementation.md`

--- a/munera/plan.md
+++ b/munera/plan.md
@@ -7,6 +7,7 @@ Queue:
 `munera/open/021-emacs-session-tree-buffer-with-magit-sections/`
 `munera/open/001-post-wave-b-gordian-follow-on/`
 `munera/open/002-compatibility-scaffold-removal/`
+`munera/open/077-custom-provider-string-provider-auth-normalization/`
 `munera/open/003-prompt-lifecycle-architectural-convergence/`
 `munera/open/006-agent-tool-skill-prelude-follow-on/`
 `munera/open/005-canonical-dispatch-pipeline-trace-observability/`


### PR DESCRIPTION
## Summary
- normalize shared provider-auth lookup for string-shaped provider identities
- add regression coverage for string-shaped provider request options and runtime auth resolution
- align runtime-model lookup with the shared provider-id normalizer

## Problem
Custom Anthropic-compatible providers such as MiniMax could regress to the built-in Anthropic missing-key path when live session model data stored `:provider` as a string instead of a keyword.

## Solution
- add `provider-auth/normalize-provider-id`
- use it across shared provider-auth lookup paths
- extend focused prompt-request/runtime regression coverage for both keyword and string provider identities
- remove the remaining local provider normalization seam in `prompt_request/resolve-runtime-model`

## Verification
- `bb clojure:test:unit --focus psi.agent-session.prompt-request-test --focus psi.agent-session.runtime-test`
  - `1497 tests, 11025 assertions, 0 failures`
- `bb test:agent-core`
  - `11 tests, 75 assertions, 0 failures`
- `bb test:query`
  - `11 tests, 33 assertions, 0 failures`
