### PR TITLE
fix: judge-prompt derives from session contributions for llm judge specs

### DIFF
--- a/components/agent-session/src/psi/agent_session/workflow_judge.clj
+++ b/components/agent-session/src/psi/agent_session/workflow_judge.clj
@@ -14,6 +14,20 @@
 
 (def ^:private max-judge-retries 2)
 
+(defn- judge-prompt
+  "Derive the judge prompt string from the compiled judge spec.
+
+   For `:invoke`-style specs the prompt lives at `:prompt` (legacy path).
+   For `:llm`-style specs the prompt comes from the last `:template` contribution
+   in `:session :contributions`. Template vars are not rendered here; all current
+   judge specs use static template text with empty `:vars {}`."
+  [judge-spec]
+  (or (:prompt judge-spec)
+      (some->> (get-in judge-spec [:session :contributions])
+               (filter #(= :template (:type %)))
+               last
+               :text)))
+
 (defn- judge-retry-feedback
   "Build a feedback message for a judge retry when no signal matched."
   [judge-output expected-signals]
@@ -49,7 +63,7 @@
       :preloaded-messages projected
       :workflow-owned?    true})
     ;; First attempt
-    (let [initial-result (turn-execution/execute-judge-turn! ctx judge-sid (:prompt judge-spec))]
+    (let [initial-result (turn-execution/execute-judge-turn! ctx judge-sid (judge-prompt judge-spec))]
       (loop [attempt 0
              last-output (str/trim (:assistant-text initial-result))]
         (let [routing-result (workflow-judge/evaluate-routing last-output routing-table

--- a/components/agent-session/test/psi/agent_session/workflow_judge_test.clj
+++ b/components/agent-session/test/psi/agent_session/workflow_judge_test.clj
@@ -92,6 +92,45 @@
           (is (= {:action :complete} (:routing-result result)))
           (is (= 2 @prompt-count*)))))))
 
+(deftest execute-judge-llm-spec-contributions-test
+  (testing "judge derives prompt from :session :contributions when :prompt key is absent"
+    (let [prompts* (atom [])
+          ctx {workflow-execution-adapter/adapter-key
+               (workflow-execution-adapter/create
+                {:create-child-session! (fn [_ctx _parent _opts] nil)})}
+          ;; Compiled :llm judge spec — no :prompt key, contributions hold the text
+          judge-spec {:type :llm
+                      :session {:contributions [{:type :template
+                                                 :text "Respond with exactly one word: REPEAT or DONE."
+                                                 :vars {}}]}}
+          routing-table {"REPEAT" {:goto "step-1" :max-iterations 3}
+                         "DONE"   {:goto :next}}
+          step-runs {"step-1" {:step-id "step-1" :attempts [] :iteration-count 1}
+                     "step-2" {:step-id "step-2" :attempts [] :iteration-count 1}}]
+      (with-redefs [psi.session-persistence.core/messages-from-entries-in
+                    (fn [_ctx _sid] [])
+                    psi.workflow-runtime.turn-execution-contract/execute-judge-turn!
+                    (fn [_ctx sid text]
+                      (swap! prompts* conj {:session-id sid :text text})
+                      {:status :ok
+                       :session-id sid
+                       :turn-outcome :turn.outcome/stop
+                       :assistant-message {:role "assistant" :content [{:type :text :text "DONE"}]}
+                       :assistant-text "DONE"
+                       :execution-result {:execution-result/session-id sid}})]
+        (let [result (workflow-judge/execute-judge!
+                      ctx "parent-1" "actor-1" judge-spec routing-table
+                      {:current-step-id "step-2"
+                       :step-order ["step-1" "step-2"]
+                       :step-runs step-runs})]
+          (is (= "DONE" (:judge-output result)))
+          (is (= "DONE" (:judge-event result)))
+          (is (= {:action :complete} (:routing-result result)))
+          (is (= 1 (count @prompts*)))
+          ;; Key assertion: the contribution text was used as the prompt, not nil
+          (is (= "Respond with exactly one word: REPEAT or DONE."
+                 (:text (first @prompts*)))))))))
+
 (deftest execute-judge-retry-exhaustion-test
   (testing "judge retries exhausted — returns no-match routing"
     (let [prompt-count* (atom 0)


### PR DESCRIPTION
## Summary
- derive the judge prompt from `:session :contributions` when `:prompt` is absent
- keep explicit `:prompt` support intact for judge specs that provide it directly
- add coverage proving `:llm` judge specs use the expected contribution template text

## Testing
- added `execute-judge-llm-spec-contributions-test`

## Context
Fixes a regression where `:llm` judge specs produced by `compile-judge` have no top-level `:prompt`, causing judged workflow session steps to fail before the final step runs.