### PR TITLE
⚒ Make reload-code namespace targeting default to session worktree

### DIFF
--- a/components/agent-session/src/psi/agent_session/psi_tool.clj
+++ b/components/agent-session/src/psi/agent_session/psi_tool.clj
@@ -119,11 +119,7 @@
         {:action effective-action :ns ns :form form})
 
       (= effective-action "reload-code")
-      (do
-        (when (and (some? namespaces) (some? worktree-path))
-          (throw (ex-info "psi-tool reload-code accepts exactly one targeting mode"
-                          {:phase :validate :action effective-action})))
-        {:action effective-action :namespaces namespaces :worktree-path worktree-path})
+      {:action effective-action :namespaces namespaces :worktree-path worktree-path}
 
       (= effective-action "project-repl")
       (do
@@ -231,6 +227,8 @@
   (or (some-> ns-name symbol find-ns)
       (throw (ex-info (str "Eval namespace is not loaded: " ns-name) {:phase :validate :ns ns-name}))))
 
+(declare absolute-directory-path! path-under-root?)
+
 (defn- canonical-file [path]
   (when (seq (str path))
     (try (.getCanonicalFile (io/file path))
@@ -254,6 +252,24 @@
     (when-not (loaded-namespace? ns-name)
       (throw (ex-info (str "Reload namespace is not loaded: " ns-name) {:phase :validate :action "reload-code" :namespace ns-name}))))
   namespaces)
+
+(defn- validate-reload-namespace-targeting! [namespaces worktree-path]
+  (when (some? worktree-path)
+    (absolute-directory-path! worktree-path))
+  (when (and (some? namespaces) (some? worktree-path))
+    (doseq [ns-name namespaces]
+      (let [ns-obj      (some-> ns-name symbol find-ns)
+            source-path (canonical-source-path-for-ns ns-obj)]
+        (when-not source-path
+          (throw (ex-info (str "Reload namespace has no canonical source path: " ns-name)
+                          {:phase :validate :action "reload-code" :namespace ns-name :worktree-path worktree-path})))
+        (when-not (path-under-root? worktree-path source-path)
+          (throw (ex-info (str "Reload namespace source path is outside target worktree: " ns-name)
+                          {:phase :validate
+                           :action "reload-code"
+                           :namespace ns-name
+                           :worktree-path worktree-path
+                           :source-path source-path})))))))
 
 (defn- absolute-directory-path! [worktree-path]
   (when-not (and (string? worktree-path) (not (str/blank? worktree-path)))
@@ -377,12 +393,16 @@
                                (some? cwd) (absolute-directory-path! cwd)
                                :else nil)
         effective-path (if namespace-mode?
-                         session-derived-path
+                         (cond
+                           (some? worktree-path) (absolute-directory-path! worktree-path)
+                           (some? session-derived-path) session-derived-path
+                           :else (throw (ex-info "psi-tool reload-code namespace mode requires explicit worktree-path or invoking session worktree-path" {:phase :validate :action "reload-code"})))
                          (cond
                            (some? worktree-path) (absolute-directory-path! worktree-path)
                            (some? session-derived-path) session-derived-path
                            :else (throw (ex-info "psi-tool reload-code worktree mode requires explicit worktree-path or invoking session worktree-path" {:phase :validate :action "reload-code"}))))
-        worktree-source (when-not namespace-mode? (if (some? worktree-path) :explicit :session))
+        _ (validate-reload-namespace-targeting! requested-nses effective-path)
+        worktree-source (if (some? worktree-path) :explicit :session)
         candidates (if namespace-mode?
                      (mapv (fn [ns-name] {:ns-name ns-name}) requested-nses)
                      (let [matches (worktree-reload-candidates effective-path)]
@@ -414,9 +434,10 @@
              :psi-tool/code-reload reload-result
              :psi-tool/graph-refresh graph-refresh
              :psi-tool/duration-ms duration-ms
-             :psi-tool/overall-status (if (and (= :ok (:status reload-result)) (= :ok (:status graph-refresh))) :ok :error)}
-      namespace-mode? (assoc :psi-tool/namespaces-requested requested-nses)
-      (not namespace-mode?) (assoc :psi-tool/worktree-path effective-path :psi-tool/worktree-source worktree-source))))
+             :psi-tool/overall-status (if (and (= :ok (:status reload-result)) (= :ok (:status graph-refresh))) :ok :error)
+             :psi-tool/worktree-path effective-path
+             :psi-tool/worktree-source worktree-source}
+      namespace-mode? (assoc :psi-tool/namespaces-requested requested-nses))))
 
 (defn truncation-visible-prefix [{:keys [action ns form namespaces worktree-path op code definition-id run-id schedule-id label kind]}]
   (case action
@@ -507,7 +528,27 @@
                 (let [action (psi-tool-action args)]
                   (case action
                     "eval" {:content (pr-str {:psi-tool/action :eval :psi-tool/ns (get args "ns") :psi-tool/duration-ms 0 :psi-tool/error (psi-tool-error-summary :eval e)}) :is-error true}
-                    "reload-code" {:content (pr-str {:psi-tool/action :reload-code :psi-tool/duration-ms 0 :psi-tool/overall-status :error :psi-tool/error (psi-tool-error-summary :reload-code e)}) :is-error true}
+                    "reload-code" (let [worktree-path (or (try
+                                                            (some-> (get args "worktree-path") absolute-directory-path!)
+                                                            (catch Exception _ nil))
+                                                          (when-let [sid (:session-id opts)]
+                                                            (try
+                                                              (some-> (:ctx opts) (session-state/session-worktree-path-in sid) absolute-directory-path!)
+                                                              (catch Exception _ nil)))
+                                                          (try
+                                                            (some-> (:cwd opts) absolute-directory-path!)
+                                                            (catch Exception _ nil)))
+                                        worktree-source (cond
+                                                          (get args "worktree-path") :explicit
+                                                          (or (:session-id opts) (:cwd opts)) :session
+                                                          :else nil)]
+                                    {:content (pr-str (cond-> {:psi-tool/action :reload-code
+                                                               :psi-tool/duration-ms 0
+                                                               :psi-tool/overall-status :error
+                                                               :psi-tool/error (psi-tool-error-summary :reload-code e)}
+                                                        worktree-path (assoc :psi-tool/worktree-path worktree-path)
+                                                        worktree-source (assoc :psi-tool/worktree-source worktree-source)))
+                                     :is-error true})
                     "project-repl" {:content (pr-str {:psi-tool/action :project-repl :psi-tool/project-repl-op (some-> (get args "op") keyword) :psi-tool/duration-ms 0 :psi-tool/overall-status :error :psi-tool/error (psi-tool-error-summary :project-repl e)}) :is-error true}
                     "workflow" {:content (pr-str {:psi-tool/action :workflow :psi-tool/workflow-op (some-> (get args "op") keyword) :psi-tool/duration-ms 0 :psi-tool/overall-status :error :psi-tool/error (psi-tool-error-summary :workflow e)}) :is-error true}
                     "scheduler" {:content (pr-str {:psi-tool/action :scheduler :psi-tool/scheduler-op (some-> (get args "op") keyword) :psi-tool/duration-ms 0 :psi-tool/overall-status :error :psi-tool/error (psi-tool-error-summary :scheduler e)}) :is-error true}

--- a/components/agent-session/src/psi/agent_session/psi_tool.clj
+++ b/components/agent-session/src/psi/agent_session/psi_tool.clj
@@ -235,7 +235,20 @@
          (catch Exception _ nil))))
 
 (defn- canonical-path [path] (some-> path canonical-file .getAbsolutePath))
-(defn- canonical-source-path-for-ns [ns-obj] (or (some-> ns-obj meta :file canonical-path) (some-> ns-obj meta :file io/resource .getFile canonical-path)))
+
+(defn- namespace-resource-paths [ns-obj]
+  (let [base (some-> ns-obj ns-name str (str/replace "." "/") (str/replace "-" "_"))]
+    (when base
+      [(str base ".clj")
+       (str base ".cljc")
+       (str base ".cljs")])))
+
+(defn- canonical-source-path-for-ns [ns-obj]
+  (or (some-> ns-obj meta :file canonical-path)
+      (some->> (namespace-resource-paths ns-obj)
+               (keep #(some-> % io/resource .getFile canonical-path))
+               first)))
+
 (defn- loaded-namespace? [ns-name] (boolean (some-> ns-name symbol find-ns)))
 
 (defn- validate-reload-namespaces [namespaces]

--- a/components/agent-session/test/psi/agent_session/tools_test.clj
+++ b/components/agent-session/test/psi/agent_session/tools_test.clj
@@ -97,12 +97,12 @@
         (is (true? (:is-error result)))
         (is (re-find #"requires `form`" (:content result)))))
 
-    (testing "reload-code rejects simultaneous targeting modes"
-      (let [result ((:execute tool) {"action" "reload-code"
-                                     "namespaces" ["psi.agent-session.tools"]
-                                     "worktree-path" "/tmp"})]
-        (is (true? (:is-error result)))
-        (is (re-find #"exactly one targeting mode" (:content result)))))
+    (testing "reload-code allows namespace targeting with explicit worktree-path when the namespace source is inside that worktree"
+      (with-redefs [psi-tool/canonical-source-path-for-ns (fn [_] (str (System/getProperty "user.dir") "/src/inside.clj"))]
+        (let [result ((:execute tool) {"action" "reload-code"
+                                       "namespaces" ["clojure.string"]
+                                       "worktree-path" (System/getProperty "user.dir")})]
+          (is (false? (:is-error result))))))
 
     (testing "project-repl requires valid op"
       (let [result ((:execute tool) {"action" "project-repl"})]
@@ -301,9 +301,10 @@
       (is (= :validate (get-in parsed [:psi-tool/error :phase])))))
 
   (testing "namespace mode reloads exactly requested namespaces in request order"
-    (let [tool   (tools/make-psi-tool (fn [_q] {}))
-          result ((:execute tool) {"action" "reload-code"
-                                   "namespaces" ["clojure.string" "clojure.edn"]})
+    (let [tool   (tools/make-psi-tool (fn [_q] {}) {:cwd (System/getProperty "user.dir")})
+          result (with-redefs [psi-tool/canonical-source-path-for-ns (fn [_] (str (System/getProperty "user.dir") "/src/in-worktree.clj"))]
+                   ((:execute tool) {"action" "reload-code"
+                                     "namespaces" ["clojure.string" "clojure.edn"]}))
           parsed (read-string (:content result))]
       (is (false? (:is-error result)))
       (is (= :namespaces (:psi-tool/reload-mode parsed)))
@@ -312,6 +313,8 @@
       (is (= :ok (get-in parsed [:psi-tool/code-reload :status])))
       (is (= :ok (get-in parsed [:psi-tool/graph-refresh :status])))
       (is (= :ok (:psi-tool/overall-status parsed)))
+      (is (= (System/getProperty "user.dir") (:psi-tool/worktree-path parsed)))
+      (is (= :session (:psi-tool/worktree-source parsed)))
       (is (= "preserved current extension registry without rediscovery"
              (get-in parsed [:psi-tool/graph-refresh :steps 3 :summary])))))
 
@@ -333,8 +336,9 @@
           (delete-tree! dir)))))
 
   (testing "namespace mode stops at first namespace failure and reports successful prefix"
-    (let [tool   (tools/make-psi-tool (fn [_q] {}))
-          result (with-redefs [clojure.core/require (fn [ns-sym & _]
+    (let [tool   (tools/make-psi-tool (fn [_q] {}) {:cwd (System/getProperty "user.dir")})
+          result (with-redefs [psi-tool/canonical-source-path-for-ns (fn [_] (str (System/getProperty "user.dir") "/src/in-worktree.clj"))
+                               clojure.core/require (fn [ns-sym & _]
                                                       (when (= 'clojure.edn ns-sym)
                                                         (throw (ex-info "boom" {:ns ns-sym}))))]
                    ((:execute tool) {"action" "reload-code"
@@ -344,7 +348,27 @@
       (is (= :error (get-in parsed [:psi-tool/code-reload :status])))
       (is (= ["clojure.string"] (get-in parsed [:psi-tool/code-reload :namespaces])))
       (is (= :ok (get-in parsed [:psi-tool/graph-refresh :status])))
+      (is (= (System/getProperty "user.dir") (:psi-tool/worktree-path parsed)))
+      (is (= :session (:psi-tool/worktree-source parsed)))
       (is (= :error (:psi-tool/overall-status parsed)))))
+
+  (testing "namespace mode rejects session-derived worktree-path when namespace source is outside that worktree"
+    (let [tmpdir (str (java.nio.file.Files/createTempDirectory "psi-tool-reload-outside-worktree-"
+                                                               (make-array java.nio.file.attribute.FileAttribute 0)))]
+      (try
+        (with-redefs [psi-tool/canonical-source-path-for-ns (fn [_] (str (System/getProperty "user.dir") "/src/outside.clj"))]
+          (let [tool   (tools/make-psi-tool (fn [_q] {}) {:cwd tmpdir})
+                result ((:execute tool) {"action" "reload-code"
+                                         "namespaces" ["clojure.string"]})
+                parsed (read-string (:content result))]
+            (is (true? (:is-error result)))
+            (is (= :validate (get-in parsed [:psi-tool/error :phase])))
+            (is (= (.getAbsolutePath (.getCanonicalFile (io/file tmpdir)))
+                   (:psi-tool/worktree-path parsed)))
+            (is (= :session (:psi-tool/worktree-source parsed)))
+            (is (re-find #"outside target worktree" (:content result)))))
+        (finally
+          (delete-tree! tmpdir)))))
 
   (testing "worktree mode uses session worktree-path when explicit target absent"
     (with-redefs [psi-tool/worktree-reload-candidates (fn [worktree-path]
@@ -449,12 +473,13 @@
         (is (= 1 (get-in parsed [:psi-tool/graph-refresh :steps 3 :install :diagnostic-count]))))))
 
   (testing "namespace mode may target loaded project namespaces"
-    (let [tool   (tools/make-psi-tool (fn [_q] {}))
-          result ((:execute tool) {"action" "reload-code"
-                                   "namespaces" ["psi.agent-session.tools"]})
-          parsed (read-string (:content result))]
-      (is (false? (:is-error result)))
-      (is (= ["psi.agent-session.tools"] (get-in parsed [:psi-tool/code-reload :namespaces]))))))
+    (with-redefs [psi-tool/canonical-source-path-for-ns (fn [_] (str (System/getProperty "user.dir") "/src/in-worktree.clj"))]
+      (let [tool   (tools/make-psi-tool (fn [_q] {}) {:cwd (System/getProperty "user.dir")})
+            result ((:execute tool) {"action" "reload-code"
+                                     "namespaces" ["psi.agent-session.tools"]})
+            parsed (read-string (:content result))]
+        (is (false? (:is-error result)))
+        (is (= ["psi.agent-session.tools"] (get-in parsed [:psi-tool/code-reload :namespaces])))))))
 
 (deftest make-psi-tool-project-repl-test
   (testing "project-repl status reports absent instance"

--- a/components/agent-session/test/psi/agent_session/tools_test.clj
+++ b/components/agent-session/test/psi/agent_session/tools_test.clj
@@ -479,7 +479,14 @@
                                      "namespaces" ["psi.agent-session.tools"]})
             parsed (read-string (:content result))]
         (is (false? (:is-error result)))
-        (is (= ["psi.agent-session.tools"] (get-in parsed [:psi-tool/code-reload :namespaces])))))))
+        (is (= ["psi.agent-session.tools"] (get-in parsed [:psi-tool/code-reload :namespaces]))))))
+
+  (testing "canonical-source-path-for-ns falls back to namespace resource lookup when ns metadata lacks :file"
+    (require 'psi.agent-session.workflow.text)
+    (let [ns-obj  (find-ns 'psi.agent-session.workflow.text)
+          source  (#'psi.agent-session.psi-tool/canonical-source-path-for-ns ns-obj)]
+      (is (string? source))
+      (is (.endsWith source "components/agent-session/src/psi/agent_session/workflow/text.clj")))))
 
 (deftest make-psi-tool-project-repl-test
   (testing "project-repl status reports absent instance"

--- a/doc/psi-project-config.md
+++ b/doc/psi-project-config.md
@@ -93,8 +93,15 @@ Example:
 ```
 
 Rules:
-- exactly one mode must be selected
-- if `namespaces` and `worktree-path` are both supplied, the request errors
+- reload-code has two targeting axes:
+  - namespace selection via `namespaces`
+  - worktree constraint via effective target worktree-path
+- if `namespaces` are supplied, the effective target worktree-path defaults to:
+  1. explicit `worktree-path`
+  2. invoking session `:worktree-path`
+  3. otherwise error
+- each requested already loaded namespace must have a canonical source path under the effective target worktree-path or the request errors
+- when `namespaces` are omitted, reload-code operates in worktree mode
 - worktree precedence is:
   1. explicit `worktree-path`
   2. invoking session `:worktree-path`


### PR DESCRIPTION
## Summary
- make namespace-targeted `psi-tool reload-code` default its worktree constraint to the invoking session worktree
- allow explicit `worktree-path` to override that default and report the effective worktree/source in reload output
- add tests and docs covering namespace-mode worktree validation and defaults

## Testing
- clj-kondo --lint components/agent-session/src/psi/agent_session/psi_tool.clj components/agent-session/test/psi/agent_session/tools_test.clj
- bb test --focus psi.agent-session.tools-test/make-psi-tool-reload-code-test --focus psi.agent-session.tools-test/make-psi-tool-validation-test
