### PR TITLE
Fix worktree-path threading through review delegation chain

### DIFF
--- a/.psi/workflows/gh-issue-implement.md
+++ b/.psi/workflows/gh-issue-implement.md
@@ -66,9 +66,8 @@ description: Find an implement-labeled PR, prepare its branch worktree, design a
          {:name "review"
           :type :delegate
           :target "review-implementation"
-          :prompt-string {:type :template
-                          :text "Improve the implemented Munera task described by {{implementation_report}} by running the review-implementation workflow in the same PR worktree. Work independently. Use the preloaded design handoff so the review can compare implementation against the intended design. Use the `clojure-coding-standards` and `testing-without-mocks` skills while carrying out review follow-up work. Execute the review workflow until it converges, update the task artifacts as it goes, preserve any meaningful deviations from the initial design in `implementation.md` so they can be summarized back onto the PR, and commit the review/task-artifact updates at the end of the review pass if there are changes to record."
-                          :vars {"implementation_report" {:from {:step "implement" :yield :text}}}}
+          :prompt-string {:type :map
+                          :fields {:input {:from {:step "implement" :yield :text}}}}
           :context [{:type :source
                      :from :workflow-original}
                     {:type :source

--- a/.psi/workflows/review-implementation.md
+++ b/.psi/workflows/review-implementation.md
@@ -52,7 +52,7 @@ description: Review a Munera task implementation, record terse notes, execute ad
                      :from {:step "review-test-shape" :yield :text}}]}
          {:name "final-summary"
           :type :session
-          :tools ["read" "bash"]
+          :tools ["read" "bash" "work-on"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :source
@@ -64,7 +64,7 @@ description: Review a Munera task implementation, record terse notes, execute ad
                           {:type :source
                            :from {:step "review-code-shape" :yield :text}}
                           {:type :template
-                           :text "Produce the user-facing final result for the Munera task identified by {{input}}. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether all four review passes completed cleanly\n- the key issues found and resolved across the four passes (task-implementation-review, task-test-review, test-shaper, code-shaper)\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior."
+                           :text "Produce the user-facing final result for the Munera task identified by {{input}}. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether all four review passes completed cleanly\n- the key issues found and resolved across the four passes (task-implementation-review, task-test-review, test-shaper, code-shaper)\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior."
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}}}]}]}
 

--- a/.psi/workflows/review-step.md
+++ b/.psi/workflows/review-step.md
@@ -4,31 +4,31 @@ description: Run a single named review skill against a Munera task, record terse
 ---
 {:steps [{:name "review"
           :type :session
-          :tools ["read" "bash" "edit" "write"]
+          :tools ["read" "bash" "edit" "write" "work-on"]
           :skills ["work-independently"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :template
-                           :text "Review the Munera task identified by {{input}} using the {{skill}} skill. Work independently. First read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. append a terse review note to the task's implementation.md\n2. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n3. avoid duplicating review notes or steps that already exist\n4. commit. if there is no new actionable feedback, say so explicitly\n\nEnd your final response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: NO_ACTIONABLE_FEEDBACK"
+                           :text "Review the Munera task identified by {{input}} using the {{skill}} skill. Work independently. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Then read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. append a terse review note to the task's implementation.md\n2. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n3. avoid duplicating review notes or steps that already exist\n4. commit. if there is no new actionable feedback, say so explicitly\n\nEnd your final response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: NO_ACTIONABLE_FEEDBACK"
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}
                                   "skill" {:from :workflow-input
                                            :path [:skill]}}}]}
          {:name "follow-up"
           :type :session
-          :tools ["read" "bash" "edit" "write"]
+          :tools ["read" "bash" "edit" "write" "work-on"]
           :skills ["work-independently"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :source
                            :from {:step "review" :yield :text}}
                           {:type :template
-                           :text "Execute the newly added actionable follow-up items for the Munera task identified by {{input}}. Work independently. Use the preloaded review result to understand what was added in the preceding review pass. Read the task's steps.md, implementation.md, design.md, and plan.md as needed. Complete the newly added unchecked steps when possible, updating task artifacts as you work. If a step is completed, mark it done in steps.md. If a step cannot yet be completed, leave it unchecked and record the blocking reason tersely in implementation.md. commit."
+                           :text "Execute the newly added actionable follow-up items for the Munera task identified by {{input}}. Work independently. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Use the preloaded review result to understand what was added in the preceding review pass. Read the task's steps.md, implementation.md, design.md, and plan.md as needed. Complete the newly added unchecked steps when possible, updating task artifacts as you work. If a step is completed, mark it done in steps.md. If a step cannot yet be completed, leave it unchecked and record the blocking reason tersely in implementation.md. commit."
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}}}]}
          {:name "review-status"
           :type :session
-          :tools ["read" "bash"]
+          :tools ["read" "bash" "work-on"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :source
@@ -36,7 +36,7 @@ description: Run a single named review skill against a Munera task, record terse
                           {:type :source
                            :from {:step "follow-up" :yield :text}}
                           {:type :template
-                           :text "Review the specific Munera task identified by {{input}} and decide whether the just-completed review cycle surfaced remaining new actionable follow-up work. Independently inspect the task artifacts, especially steps.md, implementation.md, design.md, and plan.md when present. This is an internal control step. Respond with exactly one word: REPEAT or DONE. Return REPEAT if the identified task still has new actionable follow-up work to address. Return DONE only if the identified task has no remaining new actionable feedback from that cycle."
+                           :text "Review the specific Munera task identified by {{input}} and decide whether the just-completed review cycle surfaced remaining new actionable follow-up work. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Independently inspect the task artifacts, especially steps.md, implementation.md, design.md, and plan.md when present. This is an internal control step. Respond with exactly one word: REPEAT or DONE. Return REPEAT if the identified task still has new actionable follow-up work to address. Return DONE only if the identified task has no remaining new actionable feedback from that cycle."
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}}}]
           :judge {:type :llm
@@ -48,7 +48,7 @@ description: Run a single named review skill against a Munera task, record terse
                "DONE"   {:goto "final-summary"}}}
          {:name "final-summary"
           :type :session
-          :tools ["read" "bash"]
+          :tools ["read" "bash" "work-on"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :source
@@ -56,7 +56,7 @@ description: Run a single named review skill against a Munera task, record terse
                           {:type :source
                            :from {:step "follow-up" :yield :text}}
                           {:type :template
-                           :text "Produce the user-facing final result for the Munera task identified by {{input}}. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the review loop completed cleanly\n- the key issues found and resolved in this run using the {{skill}} skill\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior."
+                           :text "Produce the user-facing final result for the Munera task identified by {{input}}. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the review loop completed cleanly\n- the key issues found and resolved in this run using the {{skill}} skill\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior."
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}
                                   "skill" {:from :workflow-input
@@ -64,6 +64,6 @@ description: Run a single named review skill against a Munera task, record terse
 
 Run a single named review skill against a Munera task. The review pass records terse notes in `implementation.md` and adds follow-up checklist items to `steps.md`. The follow-up pass executes the newly added work. A judge step decides REPEAT or DONE; the loop repeats up to 6 times until a full pass produces no new actionable feedback.
 
-Input shape: `{:input "task-id-or-path" :skill "skill-name"}`
+Input shape: `{:input "upstream-handoff-report-containing-worktree_path-and-munera_task_path" :skill "skill-name"}`
 
 The skill is resolved at runtime by reading `.psi/skills/<skill>/SKILL.md`. Any skill available in the project can be named.


### PR DESCRIPTION
## Problem

The `gh-issue-implement` workflow ran its `review` step on the wrong worktree. Two structural breaks in the delegation chain:

1. **Type mismatch**: `review` step passed `:type :template` rendered string to `review-implementation`, which expects `{:input ...}` map. Pathing `[:input]` into a string returns nil — `{{input}}` was nil in all `review-step` sessions.

2. **No worktree switch**: `review-step` sessions never called `work-on` because `worktree_path` was not reachable in their context. Sessions defaulted to CWD (main worktree).

## Fix

- **`gh-issue-implement`** `review` step: `:type :template` → `:type :map {:input implement-yield}`. The implement handoff already carries `worktree_path:` and `munera_task_path:` as prose bullet lines.
- **`review-step`**: add `work-on` to all four session tool lists; instruct each session to extract `worktree_path:` from `{{input}}` and call `work-on` before reading any task artifacts.
- **`review-implementation`** `final-summary`: same tool addition and instruction.

`review-step` input shape updated: `:input` is now the upstream handoff report text rather than a bare task-id-or-path.