### PR TITLE
Metrics extension design — usage counters for registered capabilities

### DIFF
--- a/.psi/extensions.edn
+++ b/.psi/extensions.edn
@@ -5,4 +5,5 @@
   psi/logprobs          {}
   psi/mementum          {}
   psi/munera            {}
-  psi/work-on           {}}}
+  psi/work-on           {}
+  psi/metrics           {}}}

--- a/bases/main/src/psi/launcher/extensions.clj
+++ b/bases/main/src/psi/launcher/extensions.clj
@@ -79,6 +79,13 @@
      :installed   {:local/root "extensions/logprobs"}
      :jar         {:mvn/version :psi/release-version}}}
 
+   'psi/metrics
+   {:psi/init 'psi.metrics.extension/init
+    :source-policies
+    {:development {:local/root "extensions/metrics"}
+     :installed   {:local/root "extensions/metrics"}
+     :jar         {:mvn/version :psi/release-version}}}
+
    'psi/work-on
    {:psi/init 'extensions.work-on/init
     :source-policies

--- a/components/agent-session/src/psi/agent_session/extension_installs.clj
+++ b/components/agent-session/src/psi/agent_session/extension_installs.clj
@@ -97,7 +97,9 @@
    'psi/logprobs {:psi/init 'extensions.logprobs/init
                   :source-policies {:installed {:local/root "extensions/logprobs"}}}
    'psi/work-on {:psi/init 'extensions.work-on/init
-                 :source-policies {:installed {:local/root "extensions/work-on"}}}})
+                 :source-policies {:installed {:local/root "extensions/work-on"}}}
+   'psi/metrics {:psi/init 'psi.metrics.extension/init
+                 :source-policies {:installed {:local/root "extensions/metrics"}}}})
 
 (defn- catalog-entry
   [lib]

--- a/deps.edn
+++ b/deps.edn
@@ -78,7 +78,8 @@
                         "extensions/plan-state-learning/src"
                         "extensions/work-on/src"
                         "extensions/github/src"
-                        "extensions/logprobs/src"]
+                        "extensions/logprobs/src"
+                        "extensions/metrics/src"]
           :extra-deps  {nrepl/nrepl {:mvn/version "1.5.1"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "psi.main"]}
@@ -116,7 +117,8 @@
                         "extensions/plan-state-learning/src"
                         "extensions/work-on/src"
                         "extensions/github/src"
-                        "extensions/logprobs/src"]
+                        "extensions/logprobs/src"
+                        "extensions/metrics/src"]
           :extra-deps  {nrepl/nrepl {:mvn/version "1.5.1"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "psi.main"]}
@@ -153,7 +155,8 @@
                            "extensions/plan-state-learning/src"
                            "extensions/work-on/src"
                            "extensions/github/src"
-                           "extensions/logprobs/src"]
+                           "extensions/logprobs/src"
+                           "extensions/metrics/src"]
              :extra-deps  {nrepl/nrepl {:mvn/version "1.5.1"}}
              :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
              :main-opts   ["-m" "psi.tui.test-harness.tui-demo-main"]}
@@ -228,6 +231,7 @@
                              "extensions/work-on/test"
                              "extensions/github/test"
                              "extensions/logprobs/test"
+                             "extensions/metrics/test"
                              "components/extension-test-helpers/src"]
                :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                              nrepl/nrepl         {:mvn/version "1.5.1"}}
@@ -280,6 +284,7 @@
                         "extensions/work-on/test"
                         "extensions/github/test"
                         "extensions/logprobs/test"
+                        "extensions/metrics/test"
                         "components/ai/src"
                         "components/engine/src"
                         "components/query/src"
@@ -327,6 +332,7 @@
                         "extensions/work-on/src"
                         "extensions/github/src"
                         "extensions/logprobs/src"
+                        "extensions/metrics/src"
                         "components/extension-test-helpers/src"]
           :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                         nrepl/nrepl         {:mvn/version "1.5.1"}}

--- a/extensions/deps.edn
+++ b/extensions/deps.edn
@@ -15,13 +15,15 @@
         psi/mementum                {:local/root "mementum"}
         psi/munera                  {:local/root "munera"}
         psi/plan-state-learning     {:local/root "plan-state-learning"}
-        psi/work-on                 {:local/root "work-on"}}
+        psi/work-on                 {:local/root "work-on"}
+        psi/metrics                 {:local/root "metrics"}}
 
  :aliases
  {:test {:extra-paths ["auto-session-name/test"
                        "commit-checks/test"
                        "hello-ext/test"
                        "mcp-tasks-run/test"
+                       "metrics/test"
                        "plan-state-learning/test"
                        "work-on/test"]
          :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}

--- a/extensions/metrics/deps.edn
+++ b/extensions/metrics/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        metosin/malli       {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {lambdaisland/kaocha         {:mvn/version "1.91.1392"}
+                      psi/extension-test-helpers  {:local/root "../../components/extension-test-helpers"}
+                      psi/agent-session           {:local/root "../../components/agent-session"}}}}}

--- a/extensions/metrics/src/psi/metrics/counters.clj
+++ b/extensions/metrics/src/psi/metrics/counters.clj
@@ -1,0 +1,103 @@
+(ns psi.metrics.counters
+  "Pure counter update functions for the metrics extension.
+   All functions take and return plain maps — no atoms, no I/O.")
+
+;;; Helpers
+
+(defn- now-str
+  "Return the current instant as an ISO-8601 string."
+  []
+  (str (java.time.Instant/now)))
+
+(defn empty-metrics
+  "Return a fresh, schema-conforming empty metrics map."
+  []
+  {:tools      {}
+   :workflows  {}
+   :commands   {}
+   :operations {}
+   :tokens     {}
+   :updated-at nil})
+
+;;; Tool counters
+
+(defn inc-tool-invocation
+  "Increment the invocation counter for tool-name."
+  [metrics tool-name]
+  (-> metrics
+      (update-in [:tools tool-name :invocations] (fnil inc 0))
+      (update-in [:tools tool-name :errors] (fnil identity 0))
+      (update-in [:tools tool-name :error-reasons] (fnil identity {}))
+      (assoc :updated-at (now-str))))
+
+(defn inc-tool-error
+  "Increment the error counter for tool-name and record the error reason."
+  [metrics tool-name reason]
+  (-> metrics
+      (update-in [:tools tool-name :errors] (fnil inc 0))
+      (update-in [:tools tool-name :error-reasons reason] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+;;; Workflow / command / operation counters
+
+(defn inc-workflow-invocation
+  "Increment the invocation counter for workflow-id."
+  [metrics workflow-id]
+  (-> metrics
+      (update-in [:workflows workflow-id :invocations] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+(defn inc-command-invocation
+  "Increment the invocation counter for command-name."
+  [metrics command-name]
+  (-> metrics
+      (update-in [:commands command-name :invocations] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+(defn inc-operation-invocation
+  "Increment the invocation counter for operation-id."
+  [metrics operation-id]
+  (-> metrics
+      (update-in [:operations operation-id :invocations] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+;;; Token counters
+
+(defn add-token-delta
+  "Add a per-model token delta to the metrics token counters.
+   delta is a map with :input :output :cache-read :cache-write keys (all ints).
+   model-id is a string; uses \"unknown\" when nil."
+  [metrics model-id delta]
+  (let [mid (or model-id "unknown")]
+    (-> metrics
+        (update-in [:tokens mid :input]       (fnil + 0) (or (:input delta) 0))
+        (update-in [:tokens mid :output]      (fnil + 0) (or (:output delta) 0))
+        (update-in [:tokens mid :cache-read]  (fnil + 0) (or (:cache-read delta) 0))
+        (update-in [:tokens mid :cache-write] (fnil + 0) (or (:cache-write delta) 0))
+        (assoc :updated-at (now-str)))))
+
+(defn compute-token-delta
+  "Compute the incremental token delta for a session turn.
+
+   current-totals is the map of usage attrs returned by EQL for this turn:
+     {:psi.agent-session/usage-input N
+      :psi.agent-session/usage-output N
+      :psi.agent-session/usage-cache-read N
+      :psi.agent-session/usage-cache-write N}
+
+   prev-totals is the last-seen totals map for this session (nil on first turn).
+
+   Returns a delta map {:input N :output N :cache-read N :cache-write N}."
+  [current-totals prev-totals]
+  (let [cur-in    (or (:psi.agent-session/usage-input current-totals) 0)
+        cur-out   (or (:psi.agent-session/usage-output current-totals) 0)
+        cur-cr    (or (:psi.agent-session/usage-cache-read current-totals) 0)
+        cur-cw    (or (:psi.agent-session/usage-cache-write current-totals) 0)
+        prev-in   (or (:psi.agent-session/usage-input prev-totals) 0)
+        prev-out  (or (:psi.agent-session/usage-output prev-totals) 0)
+        prev-cr   (or (:psi.agent-session/usage-cache-read prev-totals) 0)
+        prev-cw   (or (:psi.agent-session/usage-cache-write prev-totals) 0)]
+    {:input       (max 0 (- cur-in prev-in))
+     :output      (max 0 (- cur-out prev-out))
+     :cache-read  (max 0 (- cur-cr prev-cr))
+     :cache-write (max 0 (- cur-cw prev-cw))}))

--- a/extensions/metrics/src/psi/metrics/extension.clj
+++ b/extensions/metrics/src/psi/metrics/extension.clj
@@ -1,0 +1,208 @@
+(ns psi.metrics.extension
+  "psi/metrics extension entry point.
+
+   Subscribes to tool_call, tool_result, and session_turn_finished events
+   and maintains persistent per-capability usage counters.
+
+   Registers:
+   - deterministic operation  metrics/summary
+   - slash command            /metrics"
+  (:require
+   [clojure.string :as str]
+   [psi.metrics.counters :as counters]
+   [psi.metrics.persistence :as persist]
+   [psi.metrics.schema :as schema]))
+
+;;; State
+
+(defonce store
+  (atom nil))
+
+(defonce writing?
+  (atom false))
+
+;;; Internal accessors
+
+(defn- get-metrics
+  "Return the current metrics map from the store."
+  []
+  (:metrics @store))
+
+(defn- update-metrics!
+  "Apply f to the current metrics map inside the store and mark dirty."
+  [f & args]
+  (swap! store update :metrics #(apply f % args))
+  (persist/mark-dirty-and-persist! store writing?))
+
+;;; Event handlers
+
+(defn- on-tool-call
+  "Increment the invocation counter for the named tool."
+  [payload]
+  (when-let [tool-name (:tool-name payload)]
+    (update-metrics! counters/inc-tool-invocation tool-name))
+  nil)
+
+(defn- on-tool-result
+  "Increment error counters when the tool result is an error."
+  [payload]
+  (when (and (:tool-name payload) (:is-error payload))
+    (let [tool-name (:tool-name payload)
+          content   (str (:content payload))
+          reason    (-> content
+                        (str/split-lines)
+                        first
+                        (or "")
+                        (str/trim)
+                        (subs 0 (min 80 (count (str/trim (first (str/split-lines content)))))))]
+      (update-metrics! counters/inc-tool-error tool-name reason)))
+  nil)
+
+(defn- make-turn-finished-handler
+  "Return a session_turn_finished handler closed over api for EQL queries."
+  [api]
+  (fn [payload]
+    (when-let [session-id (:session-id payload)]
+      (try
+        (let [result    ((:query-session api)
+                         session-id
+                         [:psi.agent-session/usage-input
+                          :psi.agent-session/usage-output
+                          :psi.agent-session/usage-cache-read
+                          :psi.agent-session/usage-cache-write
+                          :psi.agent-session/model-id])
+              model-id  (:psi.agent-session/model-id result)
+              cur-usage (select-keys result [:psi.agent-session/usage-input
+                                             :psi.agent-session/usage-output
+                                             :psi.agent-session/usage-cache-read
+                                             :psi.agent-session/usage-cache-write])
+              prev-usage (get-in @store [:session-usage-cache session-id])
+              delta      (counters/compute-token-delta cur-usage prev-usage)]
+          ;; Update the per-session usage cache (transient, not persisted).
+          (swap! store assoc-in [:session-usage-cache session-id] cur-usage)
+          (update-metrics! counters/add-token-delta model-id delta))
+        (catch Exception e
+          (println (str "DEBUG [psi/metrics] skipping token tracking for session "
+                        session-id ": " (ex-message e))))))
+    nil))
+
+;;; Formatting
+
+(defn- format-number
+  "Format an integer with thousands separators."
+  [n]
+  (format "%,d" (long n)))
+
+(defn- format-tools-section
+  [tools]
+  (when (seq tools)
+    (let [rows (sort-by key tools)]
+      (str "### Tools (" (count rows) " tracked)\n"
+           "| Tool | Invocations | Errors |\n"
+           "|------|-------------|--------|\n"
+           (str/join "\n"
+                     (map (fn [[name {:keys [invocations errors]}]]
+                            (str "| " name " | " (format-number invocations)
+                                 " | " (format-number (or errors 0)) " |"))
+                          rows))
+           "\n"))))
+
+(defn- format-tokens-section
+  [tokens]
+  (when (seq tokens)
+    (let [rows (sort-by key tokens)]
+      (str "### Token Usage (by model)\n"
+           "| Model | Input | Output | Cache Read | Cache Write |\n"
+           "|-------|-------|--------|------------|-------------|\n"
+           (str/join "\n"
+                     (map (fn [[model {:keys [input output cache-read cache-write]}]]
+                            (str "| " model
+                                 " | " (format-number (or input 0))
+                                 " | " (format-number (or output 0))
+                                 " | " (format-number (or cache-read 0))
+                                 " | " (format-number (or cache-write 0)) " |"))
+                          rows))
+           "\n"))))
+
+(defn- format-simple-section
+  [title items]
+  (when (seq items)
+    (let [rows (sort-by key items)]
+      (str "### " title " (" (count rows) " tracked)\n"
+           "| Name | Invocations |\n"
+           "|------|-------------|\n"
+           (str/join "\n"
+                     (map (fn [[name {:keys [invocations]}]]
+                            (str "| " name " | " (format-number invocations) " |"))
+                          rows))
+           "\n"))))
+
+(defn- format-metrics-summary
+  "Render the metrics map as a markdown string for the /metrics command."
+  [metrics]
+  (let [{:keys [tools workflows commands operations tokens updated-at]} metrics
+        sections (keep identity
+                       [(format-tools-section tools)
+                        (format-tokens-section tokens)
+                        (format-simple-section "Workflows" workflows)
+                        (format-simple-section "Commands" commands)
+                        (format-simple-section "Operations" operations)])]
+    (str "## Usage Metrics\n\n"
+         (if (seq sections)
+           (str/join "\n" sections)
+           "_No metrics recorded yet._\n")
+         (when updated-at
+           (str "\n_Updated: " updated-at "_\n")))))
+
+;;; Operation handler
+
+(defn- invoke-summary
+  "Deterministic operation handler for metrics/summary."
+  [{:keys [_args]}]
+  (update-metrics! counters/inc-operation-invocation "metrics/summary")
+  {:status :ok
+   :data   (get-metrics)})
+
+;;; Command handler
+
+(defn- metrics-command-handler
+  "Slash command handler for /metrics."
+  [_args api]
+  (update-metrics! counters/inc-command-invocation "metrics")
+  (persist/maybe-persist! store writing?)
+  ((:notify api)
+   (format-metrics-summary (get-metrics))
+   {:role "assistant" :custom-type :metrics-summary}))
+
+;;; Init
+
+(defn init
+  "Extension entry point. Called by the psi runtime on load and reload.
+
+   On first init: loads persisted metrics from disk, initialises the store atom.
+   On reload: preserves accumulated counters; updates worktree-path only."
+  [api]
+  (let [worktree-path (get ((:query api) [:psi.agent-session/worktree-path])
+                           :psi.agent-session/worktree-path)]
+    (if @store
+      ;; Reload: preserve counters, update worktree-path in case it changed.
+      (swap! store assoc :worktree-path worktree-path)
+      ;; First init: load persisted metrics (or start empty).
+      (let [initial (persist/load-metrics worktree-path)]
+        (reset! store (persist/empty-store worktree-path initial))))
+    ((:on api) "tool_call"             on-tool-call)
+    ((:on api) "tool_result"           on-tool-result)
+    ((:on api) "session_turn_finished" (make-turn-finished-handler api))
+    ((:register-operation api)
+     {:id          "metrics/summary"
+      :description "Return current usage metrics for all tracked capabilities"
+      :handler     invoke-summary})
+    (when-let [register-command (:register-command api)]
+      (register-command "metrics"
+                        {:description "Display usage metrics summary"
+                         :handler     (fn [args] (metrics-command-handler args api))}))
+    nil))
+
+;;; Schema re-export for consumers
+
+(def metrics-schema schema/metrics-schema)

--- a/extensions/metrics/src/psi/metrics/persistence.clj
+++ b/extensions/metrics/src/psi/metrics/persistence.clj
@@ -1,0 +1,114 @@
+(ns psi.metrics.persistence
+  "Load/save metrics EDN with atomic writes and write-coalescing.
+
+   Atomic writes: spit to a .tmp file then java.nio.file.Files/move with
+   ATOMIC_MOVE + REPLACE_EXISTING to prevent partial-read corruption.
+
+   Write-coalescing: a dirty-flag + CAS gate ensures at most one thread
+   writes at a time, and re-dirtied state triggers a follow-up write."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [psi.metrics.counters :as counters]
+   [psi.metrics.schema :as schema])
+  (:import
+   (java.nio.file Files StandardCopyOption)))
+
+;;; File paths
+
+(defn metrics-file
+  "Return a java.io.File for the metrics EDN file under worktree-path."
+  [worktree-path]
+  (io/file worktree-path ".psi" "metrics.edn"))
+
+(defn- tmp-file
+  "Return the temp file used for atomic writes."
+  [worktree-path]
+  (io/file worktree-path ".psi" ".metrics.edn.tmp"))
+
+;;; Load
+
+(defn load-metrics
+  "Load metrics from worktree-path/.psi/metrics.edn.
+   Returns empty metrics when:
+   - worktree-path is nil (no worktree)
+   - the file does not exist
+   - the file contains invalid EDN
+   - the file does not conform to metrics-schema (logs warning)"
+  [worktree-path]
+  (when worktree-path
+    (let [f (metrics-file worktree-path)]
+      (if (.exists f)
+        (try
+          (let [data (edn/read-string (slurp f))]
+            (if (schema/valid? data)
+              data
+              (do
+                (println (str "WARN [psi/metrics] metrics.edn failed schema validation — "
+                              "starting with empty counters. File preserved at: " (.getAbsolutePath f)))
+                nil)))
+          (catch Exception e
+            (println (str "WARN [psi/metrics] failed to read metrics.edn: "
+                          (ex-message e) " — starting with empty counters"))
+            nil))
+        nil))))
+
+;;; Save
+
+(defn save-metrics!
+  "Atomically write metrics-map to worktree-path/.psi/metrics.edn.
+   Creates the .psi/ directory if absent.
+   No-ops when worktree-path is nil."
+  [worktree-path metrics-map]
+  (when worktree-path
+    (let [f   (metrics-file worktree-path)
+          tmp (tmp-file worktree-path)]
+      (io/make-parents f)
+      (spit tmp (pr-str metrics-map))
+      (Files/move
+       (.toPath ^java.io.File tmp)
+       (.toPath ^java.io.File f)
+       (into-array StandardCopyOption
+                   [StandardCopyOption/ATOMIC_MOVE
+                    StandardCopyOption/REPLACE_EXISTING])))))
+
+;;; Write-coalescing gate
+
+(defn maybe-persist!
+  "Persist the current metrics snapshot if dirty, using a CAS gate to
+   ensure at most one thread writes at a time.
+
+   store-atom shape:
+     {:metrics {...} :worktree-path \"...\" :dirty? true/false ...}
+
+   writing?-atom is a separate boolean atom used as the CAS gate.
+
+   After each write the writer re-checks :dirty? and loops if re-dirtied
+   by concurrent events, coalescing rapid-fire mutations into minimal I/O."
+  [store-atom writing?-atom]
+  (when (compare-and-set! writing?-atom false true)
+    (try
+      (loop []
+        (let [{:keys [metrics worktree-path dirty?]} @store-atom]
+          (when dirty?
+            ;; Clear dirty flag atomically before writing — any concurrent
+            ;; mutation after this swap! will re-set :dirty? to true.
+            (swap! store-atom assoc :dirty? false)
+            (save-metrics! worktree-path metrics)
+            (recur))))
+      (finally
+        (reset! writing?-atom false)))))
+
+(defn mark-dirty-and-persist!
+  "Mark the store as dirty and trigger a coalesced persist."
+  [store-atom writing?-atom]
+  (swap! store-atom assoc :dirty? true)
+  (maybe-persist! store-atom writing?-atom))
+
+(defn empty-store
+  "Return the initial store map for a given worktree-path."
+  [worktree-path initial-metrics]
+  {:metrics          (or initial-metrics (counters/empty-metrics))
+   :worktree-path    worktree-path
+   :session-usage-cache {}
+   :dirty?           false})

--- a/extensions/metrics/src/psi/metrics/schema.clj
+++ b/extensions/metrics/src/psi/metrics/schema.clj
@@ -1,0 +1,46 @@
+(ns psi.metrics.schema
+  "Malli schemas for the metrics extension data shape."
+  (:require
+   [malli.core :as m]))
+
+;;; Schemas
+
+(def counter-schema
+  "Invocation counter for workflows, commands, and operations."
+  [:map
+   [:invocations :int]])
+
+(def tool-counter-schema
+  "Invocation + error counter for tool calls."
+  [:map
+   [:invocations :int]
+   [:errors :int]
+   [:error-reasons [:map-of :string :int]]])
+
+(def token-totals-schema
+  "Cumulative token usage totals for a single model."
+  [:map
+   [:input :int]
+   [:output :int]
+   [:cache-read :int]
+   [:cache-write :int]])
+
+(def metrics-schema
+  "Top-level metrics map persisted to disk and returned by metrics/summary."
+  [:map
+   [:tools [:map-of :string tool-counter-schema]]
+   [:workflows [:map-of :string counter-schema]]
+   [:commands [:map-of :string counter-schema]]
+   [:operations [:map-of :string counter-schema]]
+   [:tokens [:map-of :string token-totals-schema]]
+   [:updated-at [:maybe :string]]])
+
+(defn valid?
+  "Return true when metrics-map conforms to metrics-schema."
+  [metrics-map]
+  (m/validate metrics-schema metrics-map))
+
+(defn explain
+  "Return malli explain output for a metrics-map that fails validation."
+  [metrics-map]
+  (m/explain metrics-schema metrics-map))

--- a/extensions/metrics/test/psi/metrics/counters_test.clj
+++ b/extensions/metrics/test/psi/metrics/counters_test.clj
@@ -1,0 +1,153 @@
+(ns psi.metrics.counters-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [psi.metrics.counters :as counters]))
+
+;;; empty-metrics
+
+(deftest empty-metrics-has-expected-shape-test
+  ;; empty-metrics returns a map with all required keys set to empty collections.
+  (let [m (counters/empty-metrics)]
+    (is (= {} (:tools m)))
+    (is (= {} (:workflows m)))
+    (is (= {} (:commands m)))
+    (is (= {} (:operations m)))
+    (is (= {} (:tokens m)))
+    (is (nil? (:updated-at m)))))
+
+;;; inc-tool-invocation
+
+(deftest inc-tool-invocation-increments-counter-test
+  ;; Each call to inc-tool-invocation adds 1 to :invocations for the named tool.
+  (let [m0 (counters/empty-metrics)
+        m1 (counters/inc-tool-invocation m0 "bash")
+        m2 (counters/inc-tool-invocation m1 "bash")]
+    (is (= 1 (get-in m1 [:tools "bash" :invocations])))
+    (is (= 2 (get-in m2 [:tools "bash" :invocations])))))
+
+(deftest inc-tool-invocation-initialises-error-fields-test
+  ;; A new tool entry gets :errors 0 and :error-reasons {} on first invocation.
+  (let [m (counters/inc-tool-invocation (counters/empty-metrics) "read")]
+    (is (= 0 (get-in m [:tools "read" :errors])))
+    (is (= {} (get-in m [:tools "read" :error-reasons])))))
+
+(deftest inc-tool-invocation-sets-updated-at-test
+  ;; updated-at is set after incrementing.
+  (let [m (counters/inc-tool-invocation (counters/empty-metrics) "write")]
+    (is (string? (:updated-at m)))))
+
+(deftest inc-tool-invocation-tracks-multiple-tools-independently-test
+  ;; Incrementing one tool does not affect another.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-tool-invocation "read")
+              (counters/inc-tool-invocation "read")
+              (counters/inc-tool-invocation "bash"))]
+    (is (= 2 (get-in m [:tools "read" :invocations])))
+    (is (= 1 (get-in m [:tools "bash" :invocations])))))
+
+;;; inc-tool-error
+
+(deftest inc-tool-error-increments-error-counter-test
+  ;; inc-tool-error increments :errors for the named tool.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-tool-invocation "bash")
+              (counters/inc-tool-error "bash" "timeout"))]
+    (is (= 1 (get-in m [:tools "bash" :errors])))
+    (is (= 1 (get-in m [:tools "bash" :error-reasons "timeout"])))))
+
+(deftest inc-tool-error-accumulates-multiple-reasons-test
+  ;; Different error reasons are tracked independently under :error-reasons.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-tool-error "bash" "timeout")
+              (counters/inc-tool-error "bash" "timeout")
+              (counters/inc-tool-error "bash" "parse-error"))]
+    (is (= 2 (get-in m [:tools "bash" :error-reasons "timeout"])))
+    (is (= 1 (get-in m [:tools "bash" :error-reasons "parse-error"])))))
+
+;;; inc-workflow/command/operation-invocation
+
+(deftest inc-workflow-invocation-test
+  ;; Workflow invocations are counted under :workflows.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-workflow-invocation "builder")
+              (counters/inc-workflow-invocation "builder"))]
+    (is (= 2 (get-in m [:workflows "builder" :invocations])))))
+
+(deftest inc-command-invocation-test
+  ;; Command invocations are counted under :commands.
+  (let [m (counters/inc-command-invocation (counters/empty-metrics) "metrics")]
+    (is (= 1 (get-in m [:commands "metrics" :invocations])))))
+
+(deftest inc-operation-invocation-test
+  ;; Operation invocations are counted under :operations.
+  (let [m (counters/inc-operation-invocation (counters/empty-metrics) "metrics/summary")]
+    (is (= 1 (get-in m [:operations "metrics/summary" :invocations])))))
+
+;;; add-token-delta
+
+(deftest add-token-delta-accumulates-per-model-test
+  ;; Token deltas accumulate under the model-id key.
+  (let [m (-> (counters/empty-metrics)
+              (counters/add-token-delta "claude-3" {:input 100 :output 50 :cache-read 200 :cache-write 10})
+              (counters/add-token-delta "claude-3" {:input 50  :output 20 :cache-read 0   :cache-write 5}))]
+    (is (= 150 (get-in m [:tokens "claude-3" :input])))
+    (is (= 70  (get-in m [:tokens "claude-3" :output])))
+    (is (= 200 (get-in m [:tokens "claude-3" :cache-read])))
+    (is (= 15  (get-in m [:tokens "claude-3" :cache-write])))))
+
+(deftest add-token-delta-uses-unknown-for-nil-model-test
+  ;; A nil model-id falls back to the "unknown" key.
+  (let [m (counters/add-token-delta (counters/empty-metrics) nil {:input 10 :output 5 :cache-read 0 :cache-write 0})]
+    (is (= 10 (get-in m [:tokens "unknown" :input])))))
+
+(deftest add-token-delta-tracks-multiple-models-independently-test
+  ;; Different model-ids accumulate in separate map entries.
+  (let [m (-> (counters/empty-metrics)
+              (counters/add-token-delta "gpt-4o" {:input 500 :output 100 :cache-read 0 :cache-write 0})
+              (counters/add-token-delta "claude-3" {:input 300 :output 80 :cache-read 0 :cache-write 0}))]
+    (is (= 500 (get-in m [:tokens "gpt-4o" :input])))
+    (is (= 300 (get-in m [:tokens "claude-3" :input])))))
+
+;;; compute-token-delta
+
+(deftest compute-token-delta-first-turn-is-full-value-test
+  ;; When prev-totals is nil (first turn), the full current value is the delta.
+  (let [cur {:psi.agent-session/usage-input 100
+             :psi.agent-session/usage-output 50
+             :psi.agent-session/usage-cache-read 20
+             :psi.agent-session/usage-cache-write 5}
+        delta (counters/compute-token-delta cur nil)]
+    (is (= 100 (:input delta)))
+    (is (= 50  (:output delta)))
+    (is (= 20  (:cache-read delta)))
+    (is (= 5   (:cache-write delta)))))
+
+(deftest compute-token-delta-subsequent-turn-is-incremental-test
+  ;; When prev-totals is known, the delta is the difference.
+  (let [prev {:psi.agent-session/usage-input 100
+              :psi.agent-session/usage-output 50
+              :psi.agent-session/usage-cache-read 20
+              :psi.agent-session/usage-cache-write 5}
+        cur  {:psi.agent-session/usage-input 150
+              :psi.agent-session/usage-output 70
+              :psi.agent-session/usage-cache-read 20
+              :psi.agent-session/usage-cache-write 5}
+        delta (counters/compute-token-delta cur prev)]
+    (is (= 50 (:input delta)))
+    (is (= 20 (:output delta)))
+    (is (= 0  (:cache-read delta)))
+    (is (= 0  (:cache-write delta)))))
+
+(deftest compute-token-delta-clamps-to-zero-test
+  ;; Negative deltas (e.g., counter reset) are clamped to 0.
+  (let [prev {:psi.agent-session/usage-input 200
+              :psi.agent-session/usage-output 100
+              :psi.agent-session/usage-cache-read 0
+              :psi.agent-session/usage-cache-write 0}
+        cur  {:psi.agent-session/usage-input 50
+              :psi.agent-session/usage-output 30
+              :psi.agent-session/usage-cache-read 0
+              :psi.agent-session/usage-cache-write 0}
+        delta (counters/compute-token-delta cur prev)]
+    (is (= 0 (:input delta)))
+    (is (= 0 (:output delta)))))

--- a/extensions/metrics/test/psi/metrics/extension_test.clj
+++ b/extensions/metrics/test/psi/metrics/extension_test.clj
@@ -1,0 +1,251 @@
+(ns psi.metrics.extension-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is use-fixtures]]
+   [psi.extension-test-helpers.nullable-api :as nullable]
+   [psi.metrics.extension :as ext]
+   [psi.metrics.schema :as schema]))
+
+;;; Fixtures
+
+(use-fixtures :each
+  (fn [f]
+    ;; Reset the defonce atoms between tests so each test starts clean.
+    (reset! ext/store nil)
+    (reset! ext/writing? false)
+    (f)
+    (reset! ext/store nil)
+    (reset! ext/writing? false)))
+
+;;; Helpers
+
+(defn- make-api
+  "Create a nullable extension API augmented with :register-operation support.
+   opts are forwarded to create-nullable-extension-api.
+   Returns {:api ... :state atom :ops atom}."
+  ([] (make-api {}))
+  ([opts]
+   (let [{:keys [api state]} (nullable/create-nullable-extension-api opts)
+         ops (atom [])
+         api* (assoc api
+                     :register-operation
+                     (fn [op-spec]
+                       (swap! ops conj op-spec)
+                       nil))]
+     {:api api* :state state :ops ops})))
+
+(defn- fire-event
+  "Fire all registered handlers for event-name with payload."
+  [state event-name payload]
+  (doseq [h (get-in @state [:handlers event-name])]
+    (h payload)))
+
+;;; init registration
+
+(deftest init-registers-three-event-handlers-test
+  ;; init subscribes to tool_call, tool_result, and session_turn_finished.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (is (seq (get-in @state [:handlers "tool_call"])))
+    (is (seq (get-in @state [:handlers "tool_result"])))
+    (is (seq (get-in @state [:handlers "session_turn_finished"])))))
+
+(deftest init-registers-metrics-summary-operation-test
+  ;; init registers the metrics/summary deterministic operation via :register-operation.
+  (let [{:keys [api ops]} (make-api)]
+    (ext/init api)
+    (let [registered (filter #(= "metrics/summary" (:id %)) @ops)]
+      (is (= 1 (count registered)))
+      (is (fn? (:handler (first registered)))))))
+
+(deftest init-registers-metrics-command-test
+  ;; init registers the /metrics slash command when :register-command is available.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (is (contains? (:commands @state) "metrics"))))
+
+(deftest init-returns-nil-test
+  ;; init must return nil.
+  (let [{:keys [api]} (make-api)]
+    (is (nil? (ext/init api)))))
+
+;;; tool_call event
+
+(deftest tool-call-increments-invocation-counter-test
+  ;; tool_call events increment the invocation counter for the named tool.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c2" :input {}})
+    (fire-event state "tool_call" {:tool-name "read" :tool-call-id "c3" :input {}})
+    (let [metrics (:metrics @ext/store)]
+      (is (= 2 (get-in metrics [:tools "bash" :invocations])))
+      (is (= 1 (get-in metrics [:tools "read" :invocations]))))))
+
+(deftest tool-call-without-tool-name-is-ignored-test
+  ;; tool_call events with no :tool-name are silently ignored.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-call-id "c1" :input {}})
+    (is (= {} (get-in @ext/store [:metrics :tools])))))
+
+;;; tool_result event
+
+(deftest tool-result-error-increments-error-counter-test
+  ;; tool_result with :is-error true increments the error counter.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_result"
+                {:tool-name "bash" :tool-call-id "c1" :is-error true :content "Command not found"})
+    (let [metrics (:metrics @ext/store)]
+      (is (= 1 (get-in metrics [:tools "bash" :errors])))
+      (is (= 1 (get-in metrics [:tools "bash" :error-reasons "Command not found"]))))))
+
+(deftest tool-result-success-does-not-increment-error-counter-test
+  ;; tool_result with :is-error false does not touch error counters.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_result"
+                {:tool-name "bash" :tool-call-id "c1" :is-error false :content "ok"})
+    (let [metrics (:metrics @ext/store)]
+      (is (nil? (get-in metrics [:tools "bash" :errors]))))))
+
+(deftest tool-result-error-reason-truncated-to-80-chars-test
+  ;; The error reason key is derived from the first line, max 80 chars.
+  (let [{:keys [api state]} (make-api)
+        long-message (apply str (repeat 100 "x"))]
+    (ext/init api)
+    (fire-event state "tool_result"
+                {:tool-name "read" :tool-call-id "c1" :is-error true :content long-message})
+    (let [reasons (get-in @ext/store [:metrics :tools "read" :error-reasons])]
+      (is (= 1 (count reasons)))
+      (is (<= (count (first (keys reasons))) 80)))))
+
+;;; session_turn_finished event — token accumulation
+
+(deftest turn-finished-accumulates-token-delta-per-model-test
+  ;; session_turn_finished queries usage and accumulates delta under the model-id key.
+  (let [query-session-fn (fn [_session-id _eql]
+                           {:psi.agent-session/usage-input 100
+                            :psi.agent-session/usage-output 50
+                            :psi.agent-session/usage-cache-read 0
+                            :psi.agent-session/usage-cache-write 0
+                            :psi.agent-session/model-id "claude-3"})
+        {:keys [api state]} (make-api {:query-fn (fn [_q] {})})
+        api* (assoc api :query-session query-session-fn)]
+    (ext/init api*)
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t1"})
+    (let [metrics (:metrics @ext/store)]
+      (is (= 100 (get-in metrics [:tokens "claude-3" :input])))
+      (is (= 50  (get-in metrics [:tokens "claude-3" :output]))))))
+
+(deftest turn-finished-computes-delta-on-second-turn-test
+  ;; The second turn for a session contributes only the incremental delta.
+  (let [call-count (atom 0)
+        responses  [{:psi.agent-session/usage-input 100
+                     :psi.agent-session/usage-output 50
+                     :psi.agent-session/usage-cache-read 0
+                     :psi.agent-session/usage-cache-write 0
+                     :psi.agent-session/model-id "claude-3"}
+                    {:psi.agent-session/usage-input 160
+                     :psi.agent-session/usage-output 80
+                     :psi.agent-session/usage-cache-read 0
+                     :psi.agent-session/usage-cache-write 0
+                     :psi.agent-session/model-id "claude-3"}]
+        query-session-fn (fn [_session-id _eql]
+                           (let [idx @call-count]
+                             (swap! call-count inc)
+                             (nth responses idx nil)))
+        {:keys [api state]} (make-api {:query-fn (fn [_q] {})})
+        api* (assoc api :query-session query-session-fn)]
+    (ext/init api*)
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t1"})
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t2"})
+    (let [metrics (:metrics @ext/store)]
+      ;; Total input: 100 (turn1) + 60 (turn2 delta: 160-100) = 160.
+      (is (= 160 (get-in metrics [:tokens "claude-3" :input])))
+      ;; Total output: 50 + 30 = 80.
+      (is (= 80  (get-in metrics [:tokens "claude-3" :output]))))))
+
+(deftest turn-finished-uses-unknown-when-model-id-nil-test
+  ;; When model-id is nil, token delta is accumulated under "unknown".
+  (let [query-session-fn (fn [_session-id _eql]
+                           {:psi.agent-session/usage-input 10
+                            :psi.agent-session/usage-output 5
+                            :psi.agent-session/usage-cache-read 0
+                            :psi.agent-session/usage-cache-write 0
+                            :psi.agent-session/model-id nil})
+        {:keys [api state]} (make-api {:query-fn (fn [_q] {})})
+        api* (assoc api :query-session query-session-fn)]
+    (ext/init api*)
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t1"})
+    (is (= 10 (get-in @ext/store [:metrics :tokens "unknown" :input])))))
+
+;;; metrics/summary operation
+
+(deftest invoke-summary-returns-ok-with-schema-conforming-data-test
+  ;; metrics/summary returns {:status :ok :data <metrics-map>} conforming to schema.
+  (let [{:keys [api ops state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "read" :tool-call-id "c1" :input {}})
+    (let [op-handler (:handler (first (filter #(= "metrics/summary" (:id %)) @ops)))
+          result (op-handler {:args {}})]
+      (is (= :ok (:status result)))
+      (is (schema/valid? (:data result))))))
+
+;;; /metrics command
+
+(deftest metrics-command-calls-notify-with-markdown-test
+  ;; The /metrics command calls (:notify api) with a markdown-formatted string.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    (let [cmd-handler (get-in @state [:commands "metrics" :handler])]
+      (cmd-handler {})
+      (let [msgs (:messages @state)]
+        (is (seq msgs))
+        (is (str/includes? (:content (last msgs)) "## Usage Metrics"))))))
+
+(deftest metrics-command-includes-tool-section-when-tools-tracked-test
+  ;; The /metrics output includes a Tools section when tool invocations exist.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "edit" :tool-call-id "c1" :input {}})
+    (let [cmd-handler (get-in @state [:commands "metrics" :handler])]
+      (cmd-handler {})
+      (is (str/includes? (:content (last (:messages @state))) "### Tools")))))
+
+(deftest metrics-command-shows-commands-section-when-invoked-test
+  ;; Invoking /metrics self-tracks the invocation under :commands.
+  ;; Even with no other events, the commands section appears.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (let [cmd-handler (get-in @state [:commands "metrics" :handler])]
+      (cmd-handler {})
+      (let [content (:content (last (:messages @state)))]
+        (is (str/includes? content "## Usage Metrics"))
+        (is (str/includes? content "metrics"))))))
+
+;;; Reload behaviour
+
+(deftest reload-preserves-counters-test
+  ;; A second call to init (simulating reload) preserves existing counters.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    ;; Simulate reload: call init again.
+    (ext/init api)
+    (is (= 1 (get-in @ext/store [:metrics :tools "bash" :invocations])))))
+
+;;; Schema conformance of returned data
+
+(deftest summary-data-conforms-to-schema-after-events-test
+  ;; After processing several events the metrics map still conforms to schema.
+  (let [{:keys [api ops state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    (fire-event state "tool_result" {:tool-name "bash" :tool-call-id "c1"
+                                     :is-error true :content "fail"})
+    (let [op-handler (:handler (first (filter #(= "metrics/summary" (:id %)) @ops)))
+          result (op-handler {:args {}})]
+      (is (schema/valid? (:data result))))))

--- a/extensions/metrics/test/psi/metrics/persistence_test.clj
+++ b/extensions/metrics/test/psi/metrics/persistence_test.clj
@@ -1,0 +1,119 @@
+(ns psi.metrics.persistence-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is]]
+   [psi.metrics.counters :as counters]
+   [psi.metrics.persistence :as persist]))
+
+;;; Helpers
+
+(defn- with-tmp-dir
+  "Call f with a path string pointing to a fresh temp directory.
+   Cleans up afterwards."
+  [f]
+  (let [dir (java.nio.file.Files/createTempDirectory
+             "psi-metrics-test"
+             (into-array java.nio.file.attribute.FileAttribute []))]
+    (try
+      (f (str dir))
+      (finally
+        ;; Best-effort cleanup.
+        (doseq [file (reverse (file-seq (.toFile dir)))]
+          (.delete file))))))
+
+(defn- sample-metrics []
+  {:tools      {"read" {:invocations 5 :errors 1 :error-reasons {"timeout" 1}}}
+   :workflows  {}
+   :commands   {}
+   :operations {}
+   :tokens     {"claude-3" {:input 1000 :output 200 :cache-read 500 :cache-write 50}}
+   :updated-at "2026-05-14T10:00:00Z"})
+
+;;; load-metrics
+
+(deftest load-metrics-returns-nil-for-nil-worktree-test
+  ;; No worktree → no persistence → nil returned.
+  (is (nil? (persist/load-metrics nil))))
+
+(deftest load-metrics-returns-nil-for-missing-file-test
+  ;; File does not exist → nil (caller uses empty-metrics).
+  (with-tmp-dir
+    (fn [dir]
+      (is (nil? (persist/load-metrics dir))))))
+
+(deftest load-metrics-round-trips-valid-data-test
+  ;; save-metrics! followed by load-metrics returns the original map.
+  (with-tmp-dir
+    (fn [dir]
+      (let [m (sample-metrics)]
+        (persist/save-metrics! dir m)
+        (is (= m (persist/load-metrics dir)))))))
+
+(deftest load-metrics-returns-nil-for-corrupt-edn-test
+  ;; A file with invalid EDN is treated as corrupt → nil returned.
+  (with-tmp-dir
+    (fn [dir]
+      (let [f (persist/metrics-file dir)]
+        (io/make-parents f)
+        (spit f "{{not valid edn")
+        (is (nil? (persist/load-metrics dir)))))))
+
+(deftest load-metrics-returns-nil-for-schema-invalid-data-test
+  ;; Valid EDN that does not conform to metrics-schema → nil returned.
+  (with-tmp-dir
+    (fn [dir]
+      (let [f (persist/metrics-file dir)]
+        (io/make-parents f)
+        (spit f (pr-str {:unexpected "shape"}))
+        (is (nil? (persist/load-metrics dir)))))))
+
+;;; save-metrics!
+
+(deftest save-metrics-creates-psi-directory-test
+  ;; save-metrics! creates the .psi/ directory if absent.
+  (with-tmp-dir
+    (fn [dir]
+      (let [psi-dir (io/file dir ".psi")]
+        (is (not (.exists psi-dir)))
+        (persist/save-metrics! dir (sample-metrics))
+        (is (.exists psi-dir))))))
+
+(deftest save-metrics-no-op-for-nil-worktree-test
+  ;; save-metrics! is a no-op when worktree-path is nil (no exception).
+  (is (nil? (persist/save-metrics! nil (sample-metrics)))))
+
+;;; maybe-persist! write-coalescing
+
+(deftest maybe-persist-coalesces-concurrent-mutations-test
+  ;; When writing? is true, a second call to maybe-persist! is a no-op (does not
+  ;; attempt a concurrent write). After the writer finishes, writing? is reset.
+  (with-tmp-dir
+    (fn [dir]
+      (let [store    (atom (persist/empty-store dir (counters/empty-metrics)))
+            writing? (atom false)]
+        ;; Mark dirty and persist once.
+        (persist/mark-dirty-and-persist! store writing?)
+        ;; After completion, writing? is false and the file exists.
+        (is (false? @writing?))
+        (is (.exists (persist/metrics-file dir)))))))
+
+(deftest mark-dirty-and-persist-writes-current-state-test
+  ;; After mark-dirty-and-persist!, the file on disk contains the current metrics.
+  (with-tmp-dir
+    (fn [dir]
+      (let [m        (counters/inc-tool-invocation (counters/empty-metrics) "bash")
+            store    (atom (assoc (persist/empty-store dir nil) :metrics m))
+            writing? (atom false)]
+        (persist/mark-dirty-and-persist! store writing?)
+        (let [loaded (persist/load-metrics dir)]
+          (is (= 1 (get-in loaded [:tools "bash" :invocations]))))))))
+
+;;; empty-store
+
+(deftest empty-store-shape-test
+  ;; empty-store returns a map with the expected keys.
+  (let [s (persist/empty-store "/tmp/test" nil)]
+    (is (= "/tmp/test" (:worktree-path s)))
+    (is (map? (:metrics s)))
+    (is (= {} (:session-usage-cache s)))
+    (is (false? (:dirty? s)))))

--- a/extensions/metrics/test/psi/metrics/schema_test.clj
+++ b/extensions/metrics/test/psi/metrics/schema_test.clj
@@ -1,0 +1,55 @@
+(ns psi.metrics.schema-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [psi.metrics.schema :as schema]))
+
+(deftest valid?-accepts-empty-metrics-test
+  ;; A freshly-initialised metrics map with all empty sub-maps is valid.
+  (is (schema/valid? {:tools      {}
+                      :workflows  {}
+                      :commands   {}
+                      :operations {}
+                      :tokens     {}
+                      :updated-at nil})))
+
+(deftest valid?-accepts-populated-metrics-test
+  ;; Fully-populated metrics with realistic data is valid.
+  (is (schema/valid?
+       {:tools      {"read" {:invocations 10 :errors 1 :error-reasons {"timeout" 1}}}
+        :workflows  {"builder" {:invocations 3}}
+        :commands   {"metrics" {:invocations 2}}
+        :operations {"metrics/summary" {:invocations 5}}
+        :tokens     {"claude-sonnet-4" {:input 1000 :output 200 :cache-read 500 :cache-write 100}}
+        :updated-at "2026-05-14T10:00:00Z"})))
+
+(deftest valid?-rejects-missing-required-key-test
+  ;; A map missing :tools fails validation.
+  (is (not (schema/valid? {:workflows  {}
+                           :commands   {}
+                           :operations {}
+                           :tokens     {}
+                           :updated-at nil}))))
+
+(deftest valid?-rejects-wrong-type-for-invocations-test
+  ;; :invocations must be an integer, not a string.
+  (is (not (schema/valid?
+            {:tools      {"bash" {:invocations "not-a-number" :errors 0 :error-reasons {}}}
+             :workflows  {}
+             :commands   {}
+             :operations {}
+             :tokens     {}
+             :updated-at nil}))))
+
+(deftest valid?-rejects-wrong-token-shape-test
+  ;; Token totals must have all four keys as ints.
+  (is (not (schema/valid?
+            {:tools      {}
+             :workflows  {}
+             :commands   {}
+             :operations {}
+             :tokens     {"gpt-4o" {:input 100}}
+             :updated-at nil}))))
+
+(deftest explain-returns-non-nil-for-invalid-test
+  ;; explain provides diagnostic info for invalid maps.
+  (is (some? (schema/explain {:not "valid"}))))

--- a/extensions/metrics/tests.edn
+++ b/extensions/metrics/tests.edn
@@ -1,0 +1,4 @@
+#kaocha/v1
+ {:tests [{:id          :unit
+           :test-paths  ["test"]
+           :ns-patterns [".*-test$"]}]}

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -18,7 +18,7 @@ Psi has no visibility into which capabilities are actually used, how often they 
 - Workflow execution counting (by workflow id)
 - Command invocation counting (by command name)
 - Deterministic operation invocation counting (by operation id)
-- Token usage accumulation (aggregate input/output/cache-read/cache-write across all sessions)
+- Token usage accumulation per model (input/output/cache-read/cache-write keyed by model-id)
 - Project-scoped persistence (EDN file in `.psi/`)
 - Deterministic operation `metrics/summary` returning current counter state
 - Slash command `/metrics` rendering human-readable summary
@@ -28,7 +28,7 @@ Psi has no visibility into which capabilities are actually used, how often they 
 
 - User-global (cross-project) aggregation
 - Skill activation tracking (no existing extension event emitted for skill selection; would require core changes)
-- Per-session token breakdowns (the extension tracks aggregate totals only; per-session detail is already available via the EQL resolver `agent-session-usage`)
+- Per-session token breakdowns (the extension tracks per-model aggregate totals, not per-session; per-session detail is already available via the EQL resolver `agent-session-usage`)
 - Cost tracking (requires model-specific pricing data not available to extensions)
 - Historical time-series or bucketed metrics
 - Metrics export (Prometheus, OpenTelemetry, etc.)
@@ -38,7 +38,7 @@ Psi has no visibility into which capabilities are actually used, how often they 
 - **Extension boundary only** — no behavioral modifications to existing core components. The extension uses only the public extension API (`init` receives the `api` map). The only core file touched is the data-only `psi-owned-extension-catalog` map in `extension_installs.clj` to register the new extension (same pattern as all built-in extensions).
 - **Event-driven** — observes existing extension events: `tool_call`, `tool_result`, `session_turn_finished`. No new hooks in core required.
 - **Project-scoped persistence** — EDN file at `<worktree>/.psi/metrics.edn`. Loaded on init, flushed on mutation.
-- **Minimal overhead** — counter increments are in-memory atom updates; persistence is fire-and-forget I/O after each event batch, not on the critical path of tool execution.
+- **Minimal overhead** — counter increments are in-memory atom updates; persistence is out-of-band with write-coalescing so concurrent events (e.g., parallel tool calls) never serialize on disk I/O.
 - **Schema-first** — malli schema defines the canonical metrics data shape; validated on load and available for consumers.
 
 ## Design
@@ -56,7 +56,7 @@ init(api) →
   register-command("metrics",       metrics-command-handler)
 ```
 
-State is held in a single `(defonce store (atom nil))` containing both the metrics counters and the resolved persistence path.
+State is held in a single `(defonce store (atom nil))` containing both the metrics counters and the resolved persistence path. A separate `(defonce writing? (atom false))` gate serializes disk writes.
 
 ### Implementation Strategy
 
@@ -74,10 +74,14 @@ The metrics atom holds a map with this shape:
  :workflows   {"workflow-id" {:invocations 3}}
  :commands    {"command-name" {:invocations 7}}
  :operations  {"operation-id" {:invocations 2}}
- :tokens      {:input       12500
-               :output      3400
-               :cache-read  8000
-               :cache-write 1200}
+ :tokens      {"claude-sonnet-4-20250514" {:input       12500
+                                            :output      3400
+                                            :cache-read  8000
+                                            :cache-write 1200}
+               "gpt-4o"                  {:input       5000
+                                            :output      1200
+                                            :cache-read  0
+                                            :cache-write 0}}
  :updated-at  "2026-05-14T10:00:00Z"}
 ```
 
@@ -107,7 +111,7 @@ The metrics atom holds a map with this shape:
    [:workflows [:map-of :string counter-schema]]
    [:commands [:map-of :string counter-schema]]
    [:operations [:map-of :string counter-schema]]
-   [:tokens token-totals-schema]
+   [:tokens [:map-of :string token-totals-schema]]
    [:updated-at [:maybe :string]]])
 ```
 
@@ -129,7 +133,9 @@ Action: When `:is-error` is truthy, increment `[:tools tool-name :errors]` and `
 
 Payload: `{:session-id "..." :turn-id "..." ...}`
 
-Action: Query session token usage via the extension API's `:query-session` function: `((:query-session api) session-id [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write])`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the aggregate `:tokens` counters.
+Action: Query session token usage and model-id via the extension API's `:query-session` function: `((:query-session api) session-id [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write :psi.agent-session/model-id])`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the `:tokens` counters under the model-id key. If model-id is nil, use `"unknown"` as the key.
+
+**Why per-model:** Different models have different token economics and capabilities. Aggregate-only totals hide which models consume the most tokens. Per-model breakdown enables informed model selection and cost awareness.
 
 **Why delta-based:** The EQL resolver returns cumulative session totals. The extension must track the last-seen totals per session in memory so it can compute the incremental contribution of each turn. The per-session tracking map is transient (not persisted) because it is only needed within a running process — on restart, the first turn for each session will be treated as a full delta, which is acceptable because sessions rarely span process restarts and the aggregate totals are approximate anyway.
 
@@ -159,7 +165,18 @@ Deterministic operations are not currently emitted as extension events either. T
 
 **Load on init:** The extension needs the worktree path to locate the persistence file. It obtains this via `((:query api) [:psi.agent-session/worktree-path])` during init. If the query returns nil (no worktree), persistence is disabled and the extension operates in memory-only mode.
 
-**Write strategy:** After each counter mutation, persist synchronously. Each event handler calls `persist!` after `swap!` returns. `persist!` uses a second `swap!` to atomically read the current metrics and clear the `:dirty?` flag, then writes the snapshot to disk outside the swap. This ensures no lost writes and no double-writes. The write is synchronous but fast (small EDN file). No debounce thread or timer needed — the event rate is low enough (one per tool call, one per turn) that synchronous writes are acceptable. The `/metrics` command also triggers a persist to ensure the displayed data matches what's on disk.
+**Write strategy — out-of-band with write-coalescing:** Parallel tool calls produce concurrent `tool_call` and `tool_result` events, which means multiple threads may mutate the metrics atom concurrently. The atom `swap!` is thread-safe, but synchronous file writes after each `swap!` would serialize all event handlers on disk I/O and risk redundant writes.
+
+Instead, persistence uses a dirty-flag + single-writer loop:
+
+1. Each event handler calls `swap!` to update counters, then sets a `:dirty?` flag in the atom and calls `maybe-persist!`.
+2. `maybe-persist!` uses `compare-and-set!` on a separate `(defonce writing? (atom false))` flag to ensure only one thread enters the write path at a time.
+3. The writer atomically reads the current metrics snapshot and clears `:dirty?`, writes the snapshot to disk, then checks `:dirty?` again — if it was re-dirtied during the write (by another concurrent event), it loops and writes again.
+4. When the writer finds `:dirty?` is false after a write, it resets `writing?` to false and exits.
+
+This ensures: (a) no concurrent file writes, (b) no lost updates — if events arrive during a write, the loop catches them, (c) minimal I/O — rapid-fire events coalesce into a single write of the latest state.
+
+The `/metrics` command also triggers a `maybe-persist!` to ensure the displayed data matches what's on disk.
 
 **Atomic writes:** `spit` to a `.metrics.edn.tmp` file in the same directory, then `java.nio.file.Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`. This prevents partial writes from corrupting the file.
 
@@ -227,13 +244,11 @@ No arguments required. Returns the full metrics map conforming to `metrics-schem
 | write | 12 | 0 |
 | delegate | 8 | 0 |
 
-### Token Usage
-| Category | Tokens |
-|----------|--------|
-| Input | 125,000 |
-| Output | 34,000 |
-| Cache Read | 80,000 |
-| Cache Write | 12,000 |
+### Token Usage (by model)
+| Model | Input | Output | Cache Read | Cache Write |
+|-------|-------|--------|------------|-------------|
+| claude-sonnet-4-20250514 | 125,000 | 34,000 | 80,000 | 12,000 |
+| gpt-4o | 5,000 | 1,200 | 0 | 0 |
 
 _Updated: 2026-05-14T10:00:00Z_
 ```
@@ -282,7 +297,7 @@ extensions/metrics/
 1. **Counter monotonicity:** Counters only increment, never decrement. The `updated-at` timestamp advances on every mutation.
 2. **Schema conformance:** The persisted EDN always conforms to `metrics-schema`. Load rejects non-conforming data.
 3. **Graceful degradation:** If persistence path is unavailable (no worktree), the extension operates in memory-only mode without error.
-4. **Thread safety:** All counter mutations go through `swap!` on the store atom. Persistence writes are serialized.
+4. **Thread safety:** All counter mutations go through `swap!` on the store atom. Persistence writes are serialized via a `writing?` CAS gate — at most one thread writes at a time, and writes coalesce concurrent mutations.
 5. **No behavioral core modifications:** The extension uses only the public extension API surface. The only core file touched is the data-only catalog registration.
 
 ### Edge Cases
@@ -290,7 +305,7 @@ extensions/metrics/
 - **No worktree:** Init succeeds, persistence disabled, counters are in-memory only.
 - **Corrupt EDN file:** Log warning, start with empty counters, do not overwrite the corrupt file until the first successful mutation.
 - **Missing `.psi/` directory:** Create it on first write (using `io/make-parents`).
-- **Concurrent writes:** Atomic file rename prevents partial reads. The atom serializes in-memory mutations.
+- **Concurrent writes from parallel tool calls:** Parallel tool execution produces concurrent `tool_call`/`tool_result` events. The atom serializes in-memory counter updates. The `writing?` CAS gate ensures at most one disk write at a time; the dirty-check loop after each write coalesces rapid-fire mutations into minimal I/O. Atomic file rename prevents partial reads.
 - **Extension reload:** `defonce` on the store atom preserves counters across reloads. The init function re-subscribes to events but does not reset counters.
 - **EQL query failure on turn finished:** If the usage query fails (e.g., session already closed), skip token tracking for that turn and log at debug level.
 
@@ -305,14 +320,17 @@ extensions/metrics/
 7. `load-metrics` returns empty counters for missing or corrupt files.
 8. `save-metrics` writes valid EDN that round-trips through `load-metrics`.
 9. Counter functions are pure and independently testable.
-10. Token delta computation correctly handles first-seen sessions and cumulative totals.
+10. Token delta computation correctly handles first-seen sessions, cumulative totals, and per-model keying.
+11. `maybe-persist!` coalesces concurrent mutations — only one thread writes at a time, and re-dirtied state triggers a follow-up write.
 
 ## Acceptance Criteria
 
 1. Extension subscribes to `tool_call`, `tool_result`, and `session_turn_finished` events and increments appropriate counters.
-2. Counters persist to `<worktree>/.psi/metrics.edn` and restore on init.
-3. `metrics/summary` deterministic operation returns current counter state conforming to malli schema.
-4. `/metrics` slash command renders a human-readable markdown summary.
-5. Metrics data conforms to an explicit malli schema (validated on load, available for consumers).
-6. No behavioral modifications to existing core components (data-only catalog entry is acceptable).
-7. Extension operates gracefully when no worktree path is available (memory-only mode).
+2. Token usage is accumulated per model-id (queried via EQL on each `session_turn_finished`).
+3. Counters persist to `<worktree>/.psi/metrics.edn` and restore on init.
+4. Persistence uses out-of-band write-coalescing so parallel tool call events do not serialize on disk I/O.
+5. `metrics/summary` deterministic operation returns current counter state conforming to malli schema.
+6. `/metrics` slash command renders a human-readable markdown summary with per-model token breakdown.
+7. Metrics data conforms to an explicit malli schema (validated on load, available for consumers).
+8. No behavioral modifications to existing core components (data-only catalog entry is acceptable).
+9. Extension operates gracefully when no worktree path is available (memory-only mode).

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -129,17 +129,23 @@ Action: When `:is-error` is truthy, increment `[:tools tool-name :errors]` and `
 
 Payload: `{:session-id "..." :turn-id "..." ...}`
 
-Action: Query session token usage via the extension API's `:query` function using the EQL path `[{[:psi.agent-session/session-id <sid>] [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write]}]`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the aggregate `:tokens` counters.
+Action: Query session token usage via the extension API's `:query-session` function: `((:query-session api) session-id [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write])`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the aggregate `:tokens` counters.
 
 **Why delta-based:** The EQL resolver returns cumulative session totals. The extension must track the last-seen totals per session in memory so it can compute the incremental contribution of each turn. The per-session tracking map is transient (not persisted) because it is only needed within a running process — on restart, the first turn for each session will be treated as a full delta, which is acceptable because sessions rarely span process restarts and the aggregate totals are approximate anyway.
 
 **Alternative considered — enrich `session_turn_finished` payload:** This would require modifying `prompt-finish-base-result` in `turn/handlers.clj`, violating the "no core modifications" constraint. The EQL query approach is slightly less efficient but respects the extension boundary.
 
+### Workflow Tracking
+
+Workflow start/completion events are not currently emitted to the extension event bus. The workflow runtime uses internal statechart events (`:workflow/start`, `:workflow/complete`) but these are not dispatched through `ext/dispatch-in`.
+
+**Decision:** Workflow tracking is included in the schema and data shape (so the surface is ready) but will not be populated in the initial version. A future core enhancement could emit `workflow_started` and `workflow_completed` extension events; the extension is already shaped to consume them.
+
 ### Command Tracking
 
 Slash commands are not currently emitted as extension events. The extension registers its own `/metrics` command but cannot observe other command invocations without core changes.
 
-**Decision:** Command tracking is included in the schema and data shape (so the surface is ready) but will initially only track commands that extensions themselves register and invoke. The `/metrics` command itself will be self-tracked. A future core enhancement could emit a `command_invoked` event to enable full command tracking; the extension is already wired to consume it.
+**Decision:** Command tracking is included in the schema and data shape (so the surface is ready) but will initially only track the extension's own `/metrics` command via self-tracking. A future core enhancement could emit a `command_invoked` event to enable full command tracking.
 
 ### Deterministic Operation Tracking
 
@@ -153,7 +159,7 @@ Deterministic operations are not currently emitted as extension events either. T
 
 **Load on init:** The extension needs the worktree path to locate the persistence file. It obtains this via `((:query api) [:psi.agent-session/worktree-path])` during init. If the query returns nil (no worktree), persistence is disabled and the extension operates in memory-only mode.
 
-**Write strategy:** After each counter mutation, schedule an async flush. Use a simple debounce: track a `dirty?` flag and flush after a short delay (500ms) or immediately on explicit request (e.g., from the `/metrics` command). The flush writes the full metrics map to the EDN file atomically (write to temp file, rename).
+**Write strategy:** After each counter mutation, write synchronously within the `swap!` callback's aftermath. Specifically: each event handler calls a `persist-if-dirty!` function after `swap!` returns. This function checks a `:dirty?` flag in the atom, and if true, writes the metrics to disk and clears the flag. The write is synchronous but fast (small EDN file). No debounce thread or timer needed — the event rate is low enough (one per tool call, one per turn) that synchronous writes are acceptable. The `/metrics` command also triggers a flush to ensure the displayed data matches what's on disk.
 
 **Atomic writes:** `spit` to a `.metrics.edn.tmp` file in the same directory, then `java.nio.file.Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`. This prevents partial writes from corrupting the file.
 
@@ -165,10 +171,16 @@ Deterministic operations are not currently emitted as extension events either. T
 (defn init [api]
   (let [worktree-path (get ((:query api) [:psi.agent-session/worktree-path])
                            :psi.agent-session/worktree-path)
-        initial-state (load-metrics worktree-path)]
-    (reset! store {:metrics initial-state
-                   :worktree-path worktree-path
-                   :session-usage-cache {}})
+        initial-state (when-not @store
+                        (load-metrics worktree-path))]
+    ;; Only reset store on first init (defonce preserves across reloads).
+    ;; On reload, just update worktree-path in case it changed.
+    (if @store
+      (swap! store assoc :worktree-path worktree-path)
+      (reset! store {:metrics (or initial-state (empty-metrics))
+                     :worktree-path worktree-path
+                     :session-usage-cache {}
+                     :dirty? false}))
     ((:on api) "tool_call" on-tool-call)
     ((:on api) "tool_result" on-tool-result)
     ((:on api) "session_turn_finished" (make-turn-finished-handler api))
@@ -184,6 +196,8 @@ Deterministic operations are not currently emitted as extension events either. T
 ```
 
 The `session_turn_finished` handler is created via `make-turn-finished-handler` which closes over the `api` map to access the `:query` function for EQL usage lookups.
+
+**Reload behavior:** On extension reload, the `defonce` atom is preserved. `init` detects the non-nil store and only updates the `:worktree-path` (in case the session switched worktrees). Accumulated counters and the session-usage-cache survive the reload.
 
 ### Operation Handler
 
@@ -257,7 +271,11 @@ extensions/metrics/
 
 **`extensions/tests.edn`:** Add metrics test paths to the Kaocha test suite if one exists, or rely on the extension-level deps.edn test alias.
 
-**Manifest registration:** The extension must be registered in the project manifest so `bootstrap-manifest-extensions-in!` discovers and activates it. This follows the same pattern as other built-in extensions.
+**Manifest registration (three places):**
+
+1. **Catalog entry:** Add `'psi/metrics {:psi/init 'psi.metrics.extension/init :source-policies {:installed {:local/root "extensions/metrics"}}}` to `psi-owned-extension-catalog` in `components/agent-session/src/psi/agent_session/extension_installs.clj`. This is the same registration pattern used by all built-in extensions (github, logprobs, etc.). While technically touching a core component file, it is a data-only catalog addition — no behavioral changes.
+2. **Project manifest:** Add `psi/metrics {}` to `.psi/extensions.edn` under `:deps` to enable the extension in this project.
+3. **Classpath:** Add `psi/metrics {:local/root "metrics"}` to `extensions/deps.edn` under `:deps` so the classpath can resolve it.
 
 ### Key Invariants
 

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -1,28 +1,300 @@
 # Metrics Extension
 
+**Issue:** [#75 — Add metrics extension](https://github.com/hugoduncan/psi/issues/75)
+
 ## Intent
 
-An extension that observes system activity and maintains usage counters for registered capabilities — tools, skills, commands, workflows, and deterministic operations. Counters persist across sessions so that usage patterns are visible over time.
+A standard extension that observes system activity and maintains persistent usage counters for registered capabilities — tools, skills, commands, workflows, and deterministic operations. Counters survive process restarts so that usage patterns are visible over time.
 
 ## Problem Statement
 
-Psi has no visibility into which capabilities are actually used, how often they succeed or fail, or how much they cost in tokens. This makes it hard to identify unused registrations, error-prone tools, or token-expensive workflows. The information exists transiently in the dispatch event log and extension event bus, but nothing aggregates or persists it.
+Psi has no visibility into which capabilities are actually used, how often they succeed or fail, or how much they cost in tokens. The information exists transiently in the dispatch event log and extension event bus, but nothing aggregates or persists it. This makes it hard to identify unused registrations, error-prone tools, or token-expensive workflows.
+
+## Scope
+
+### In Scope
+
+- Tool invocation counting (by tool name), including error counting (by tool name + error classification)
+- Workflow execution counting (by workflow id)
+- Command invocation counting (by command name)
+- Deterministic operation invocation counting (by operation id)
+- Token usage accumulation (aggregate input/output/cache-read/cache-write across all sessions)
+- Project-scoped persistence (EDN file in `.psi/`)
+- Deterministic operation `metrics/summary` returning current counter state
+- Slash command `/metrics` rendering human-readable summary
+- Malli schema for the metrics data shape
+
+### Out of Scope
+
+- User-global (cross-project) aggregation
+- Skill activation tracking (no existing extension event emitted for skill selection; would require core changes)
+- Per-session token breakdowns (the extension tracks aggregate totals only; per-session detail is already available via the EQL resolver `agent-session-usage`)
+- Cost tracking (requires model-specific pricing data not available to extensions)
+- Historical time-series or bucketed metrics
+- Metrics export (Prometheus, OpenTelemetry, etc.)
 
 ## Constraints
 
-- **Extension boundary**: must be a standard extension (init via `api` map), not a core component modification.
-- **Event-driven**: must observe existing events (`tool_call`, `tool_result`, `session_turn_finished`, dispatch events) — no new hooks required in core.
-- **Persistence**: counters must survive process restarts. Storage mechanism should be simple (EDN file in workspace `.psi/` directory or similar).
-- **Scoping**: metrics should be scoped to a workspace (project). User-global aggregation is out of scope for the initial version.
-- **Read surface**: metrics must be queryable — at minimum via a deterministic operation (`metrics/summary` or similar) and a slash command (`/metrics`).
-- **Minimal overhead**: counting and persistence must not observably slow tool execution or turn completion.
-- **Schema**: the metrics data shape must be explicit (malli schema) so consumers can rely on it.
+- **Extension boundary only** — no modifications to existing core components. The extension uses only the public extension API (`init` receives the `api` map).
+- **Event-driven** — observes existing extension events: `tool_call`, `tool_result`, `session_turn_finished`. No new hooks in core required.
+- **Project-scoped persistence** — EDN file at `<worktree>/.psi/metrics.edn`. Loaded on init, flushed on mutation.
+- **Minimal overhead** — counter increments are in-memory atom updates; persistence is fire-and-forget I/O after each event batch, not on the critical path of tool execution.
+- **Schema-first** — malli schema defines the canonical metrics data shape; validated on load and available for consumers.
 
-## Success Criteria
+## Design
 
-1. Extension subscribes to relevant events and increments counters for: tool invocations (by tool name), tool errors (by tool name and error reason), workflow executions (by workflow id), command invocations (by command name), skill activations (by skill name), and token usage (by session, aggregated input/output/cache tokens).
-2. Counters persist to disk and are restored on extension init.
-3. A deterministic operation (`metrics/summary`) returns the current counter state.
-4. A slash command (`/metrics`) renders a human-readable summary.
-5. Metrics data conforms to an explicit malli schema.
-6. No modifications to existing core components are required.
+### Architecture Overview
+
+The extension follows the standard psi extension pattern (see `extensions/logprobs/`, `extensions/commit-checks/`):
+
+```
+init(api) →
+  subscribe("tool_call",            on-tool-call)
+  subscribe("tool_result",          on-tool-result)
+  subscribe("session_turn_finished", on-turn-finished)
+  register-operation("metrics/summary", invoke-summary)
+  register-command("metrics",       metrics-command-handler)
+```
+
+State is held in a single `(defonce store (atom nil))` containing both the metrics counters and the resolved persistence path.
+
+### Implementation Strategy
+
+**Why this fits the architecture:** The extension API already provides `(:on api)` for event subscription, `(:register-operation api)` for deterministic operations, and `(:register-command api)` for slash commands. The commit-checks extension demonstrates the persistence pattern (EDN file in `.psi/`). The logprobs extension demonstrates the event-subscription + operation + command triple. This design composes both patterns.
+
+### Data Shape
+
+The metrics atom holds a map with this shape:
+
+```clojure
+{:tools       {"tool-name" {:invocations 5
+                             :errors      3
+                             :error-reasons {"parse-error" 2
+                                             "timeout" 1}}}
+ :workflows   {"workflow-id" {:invocations 3}}
+ :commands    {"command-name" {:invocations 7}}
+ :operations  {"operation-id" {:invocations 2}}
+ :tokens      {:input       12500
+               :output      3400
+               :cache-read  8000
+               :cache-write 1200}
+ :updated-at  "2026-05-14T10:00:00Z"}
+```
+
+#### Malli Schema
+
+```clojure
+(def counter-schema
+  [:map
+   [:invocations :int]])
+
+(def tool-counter-schema
+  [:map
+   [:invocations :int]
+   [:errors :int]
+   [:error-reasons [:map-of :string :int]]])
+
+(def token-totals-schema
+  [:map
+   [:input :int]
+   [:output :int]
+   [:cache-read :int]
+   [:cache-write :int]])
+
+(def metrics-schema
+  [:map
+   [:tools [:map-of :string tool-counter-schema]]
+   [:workflows [:map-of :string counter-schema]]
+   [:commands [:map-of :string counter-schema]]
+   [:operations [:map-of :string counter-schema]]
+   [:tokens token-totals-schema]
+   [:updated-at [:maybe :string]]])
+```
+
+### Event Handling
+
+#### `tool_call` event
+
+Payload: `{:type "tool_call" :tool-name "..." :tool-call-id "..." :input {...}}`
+
+Action: Increment `[:tools tool-name :invocations]`.
+
+#### `tool_result` event
+
+Payload: `{:type "tool_result" :tool-name "..." :tool-call-id "..." :input {...} :content "..." :is-error true/false}`
+
+Action: When `:is-error` is truthy, increment `[:tools tool-name :errors]` and `[:tools tool-name :error-reasons reason]`. The error reason is derived from the `:content` string — extract the first line, truncated to 80 chars, as the reason key. This keeps reason keys short and greppable without requiring structured error taxonomies.
+
+#### `session_turn_finished` event
+
+Payload: `{:session-id "..." :turn-id "..." ...}`
+
+Action: Query session token usage via the extension API's `:query` function using the EQL path `[{[:psi.agent-session/session-id <sid>] [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write]}]`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the aggregate `:tokens` counters.
+
+**Why delta-based:** The EQL resolver returns cumulative session totals. The extension must track the last-seen totals per session in memory so it can compute the incremental contribution of each turn. The per-session tracking map is transient (not persisted) because it is only needed within a running process — on restart, the first turn for each session will be treated as a full delta, which is acceptable because sessions rarely span process restarts and the aggregate totals are approximate anyway.
+
+**Alternative considered — enrich `session_turn_finished` payload:** This would require modifying `prompt-finish-base-result` in `turn/handlers.clj`, violating the "no core modifications" constraint. The EQL query approach is slightly less efficient but respects the extension boundary.
+
+### Command Tracking
+
+Slash commands are not currently emitted as extension events. The extension registers its own `/metrics` command but cannot observe other command invocations without core changes.
+
+**Decision:** Command tracking is included in the schema and data shape (so the surface is ready) but will initially only track commands that extensions themselves register and invoke. The `/metrics` command itself will be self-tracked. A future core enhancement could emit a `command_invoked` event to enable full command tracking; the extension is already wired to consume it.
+
+### Deterministic Operation Tracking
+
+Deterministic operations are not currently emitted as extension events either. The same forward-compatible approach applies: the schema includes `:operations`, but initial population is limited to self-tracking of `metrics/summary` invocations.
+
+**Decision:** Track `metrics/summary` self-invocations. Future core event emission for operation invocations would automatically populate this counter category.
+
+### Persistence
+
+**File:** `<worktree>/.psi/metrics.edn`
+
+**Load on init:** The extension needs the worktree path to locate the persistence file. It obtains this via `((:query api) [:psi.agent-session/worktree-path])` during init. If the query returns nil (no worktree), persistence is disabled and the extension operates in memory-only mode.
+
+**Write strategy:** After each counter mutation, schedule an async flush. Use a simple debounce: track a `dirty?` flag and flush after a short delay (500ms) or immediately on explicit request (e.g., from the `/metrics` command). The flush writes the full metrics map to the EDN file atomically (write to temp file, rename).
+
+**Atomic writes:** `spit` to a `.metrics.edn.tmp` file in the same directory, then `java.nio.file.Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`. This prevents partial writes from corrupting the file.
+
+**Load validation:** On load, validate the EDN against the malli schema. If validation fails, log a warning and start with empty counters (the corrupt file is preserved for manual inspection).
+
+### Initialization
+
+```clojure
+(defn init [api]
+  (let [worktree-path (get ((:query api) [:psi.agent-session/worktree-path])
+                           :psi.agent-session/worktree-path)
+        initial-state (load-metrics worktree-path)]
+    (reset! store {:metrics initial-state
+                   :worktree-path worktree-path
+                   :session-usage-cache {}})
+    ((:on api) "tool_call" on-tool-call)
+    ((:on api) "tool_result" on-tool-result)
+    ((:on api) "session_turn_finished" (make-turn-finished-handler api))
+    ((:register-operation api)
+     {:id "metrics/summary"
+      :description "Return current usage metrics for all tracked capabilities"
+      :handler invoke-summary})
+    (when-let [register-command (:register-command api)]
+      (register-command "metrics"
+                        {:description "Display usage metrics summary"
+                         :handler (fn [args] (metrics-command-handler args api))}))
+    nil))
+```
+
+The `session_turn_finished` handler is created via `make-turn-finished-handler` which closes over the `api` map to access the `:query` function for EQL usage lookups.
+
+### Operation Handler
+
+`metrics/summary` returns the full metrics map:
+
+```clojure
+(defn invoke-summary [{:keys [_args]}]
+  {:status :ok
+   :data (get-metrics)})
+```
+
+No arguments required. Returns the full metrics map conforming to `metrics-schema`.
+
+### Slash Command
+
+`/metrics` renders a human-readable summary via `(:notify api)`:
+
+```
+## Usage Metrics
+
+### Tools (5 tracked)
+| Tool | Invocations | Errors |
+|------|-------------|--------|
+| read | 42 | 0 |
+| bash | 38 | 3 |
+| edit | 25 | 1 |
+| write | 12 | 0 |
+| delegate | 8 | 0 |
+
+### Token Usage
+| Category | Tokens |
+|----------|--------|
+| Input | 125,000 |
+| Output | 34,000 |
+| Cache Read | 80,000 |
+| Cache Write | 12,000 |
+
+_Updated: 2026-05-14T10:00:00Z_
+```
+
+Workflow, command, and operation sections are included when non-empty.
+
+### File Layout
+
+```
+extensions/metrics/
+├── deps.edn
+├── src/
+│   └── psi/
+│       └── metrics/
+│           ├── extension.clj      ;; init + event handlers + operation + command
+│           ├── schema.clj         ;; malli schemas
+│           ├── persistence.clj    ;; load/save EDN, atomic write
+│           └── counters.clj       ;; pure counter update functions
+└── test/
+    └── psi/
+        └── metrics/
+            ├── extension_test.clj
+            ├── schema_test.clj
+            ├── persistence_test.clj
+            └── counters_test.clj
+```
+
+**Namespace convention:** Uses `psi.metrics.*` following the `psi.github.*` pattern for extensions that are part of the psi project (not third-party `extensions.*` flat namespaces).
+
+### Wiring
+
+**`extensions/deps.edn`:** Add `psi/metrics {:local/root "metrics"}` to `:deps`.
+
+**`extensions/deps.edn` test alias:** Add `"metrics/test"` to `:extra-paths` under `:test`.
+
+**`extensions/tests.edn`:** Add metrics test paths to the Kaocha test suite if one exists, or rely on the extension-level deps.edn test alias.
+
+**Manifest registration:** The extension must be registered in the project manifest so `bootstrap-manifest-extensions-in!` discovers and activates it. This follows the same pattern as other built-in extensions.
+
+### Key Invariants
+
+1. **Counter monotonicity:** Counters only increment, never decrement. The `updated-at` timestamp advances on every mutation.
+2. **Schema conformance:** The persisted EDN always conforms to `metrics-schema`. Load rejects non-conforming data.
+3. **Graceful degradation:** If persistence path is unavailable (no worktree), the extension operates in memory-only mode without error.
+4. **Thread safety:** All counter mutations go through `swap!` on the store atom. Persistence writes are serialized.
+5. **No core modifications:** The extension uses only the public extension API surface.
+
+### Edge Cases
+
+- **No worktree:** Init succeeds, persistence disabled, counters are in-memory only.
+- **Corrupt EDN file:** Log warning, start with empty counters, do not overwrite the corrupt file until the first successful mutation.
+- **Missing `.psi/` directory:** Create it on first write (using `io/make-parents`).
+- **Concurrent writes:** Atomic file rename prevents partial reads. The atom serializes in-memory mutations.
+- **Extension reload:** `defonce` on the store atom preserves counters across reloads. The init function re-subscribes to events but does not reset counters.
+- **EQL query failure on turn finished:** If the usage query fails (e.g., session already closed), skip token tracking for that turn and log at debug level.
+
+### Verification Expectations
+
+1. `init` subscribes to exactly three events and registers one operation and one command.
+2. `on-tool-call` increments `[:tools name :invocations]` for any tool name.
+3. `on-tool-result` with `:is-error true` increments `[:tools name :errors]` and `[:tools name :error-reasons reason]`.
+4. `on-tool-result` with `:is-error false` does not increment error counters.
+5. `invoke-summary` returns `{:status :ok :data <metrics-map>}` conforming to schema.
+6. `/metrics` command calls `(:notify api)` with a markdown-formatted summary.
+7. `load-metrics` returns empty counters for missing or corrupt files.
+8. `save-metrics` writes valid EDN that round-trips through `load-metrics`.
+9. Counter functions are pure and independently testable.
+10. Token delta computation correctly handles first-seen sessions and cumulative totals.
+
+## Acceptance Criteria
+
+1. Extension subscribes to `tool_call`, `tool_result`, and `session_turn_finished` events and increments appropriate counters.
+2. Counters persist to `<worktree>/.psi/metrics.edn` and restore on init.
+3. `metrics/summary` deterministic operation returns current counter state conforming to malli schema.
+4. `/metrics` slash command renders a human-readable markdown summary.
+5. Metrics data conforms to an explicit malli schema (validated on load, available for consumers).
+6. No modifications to existing core components.
+7. Extension operates gracefully when no worktree path is available (memory-only mode).

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -1,0 +1,28 @@
+# Metrics Extension
+
+## Intent
+
+An extension that observes system activity and maintains usage counters for registered capabilities — tools, skills, commands, workflows, and deterministic operations. Counters persist across sessions so that usage patterns are visible over time.
+
+## Problem Statement
+
+Psi has no visibility into which capabilities are actually used, how often they succeed or fail, or how much they cost in tokens. This makes it hard to identify unused registrations, error-prone tools, or token-expensive workflows. The information exists transiently in the dispatch event log and extension event bus, but nothing aggregates or persists it.
+
+## Constraints
+
+- **Extension boundary**: must be a standard extension (init via `api` map), not a core component modification.
+- **Event-driven**: must observe existing events (`tool_call`, `tool_result`, `session_turn_finished`, dispatch events) — no new hooks required in core.
+- **Persistence**: counters must survive process restarts. Storage mechanism should be simple (EDN file in workspace `.psi/` directory or similar).
+- **Scoping**: metrics should be scoped to a workspace (project). User-global aggregation is out of scope for the initial version.
+- **Read surface**: metrics must be queryable — at minimum via a deterministic operation (`metrics/summary` or similar) and a slash command (`/metrics`).
+- **Minimal overhead**: counting and persistence must not observably slow tool execution or turn completion.
+- **Schema**: the metrics data shape must be explicit (malli schema) so consumers can rely on it.
+
+## Success Criteria
+
+1. Extension subscribes to relevant events and increments counters for: tool invocations (by tool name), tool errors (by tool name and error reason), workflow executions (by workflow id), command invocations (by command name), skill activations (by skill name), and token usage (by session, aggregated input/output/cache tokens).
+2. Counters persist to disk and are restored on extension init.
+3. A deterministic operation (`metrics/summary`) returns the current counter state.
+4. A slash command (`/metrics`) renders a human-readable summary.
+5. Metrics data conforms to an explicit malli schema.
+6. No modifications to existing core components are required.

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -280,17 +280,14 @@ extensions/metrics/
 
 ### Wiring
 
-**`extensions/deps.edn`:** Add `psi/metrics {:local/root "metrics"}` to `:deps`.
+The metrics extension follows the same standalone pattern as `psi/github` and `psi/logprobs` — it is **not** added to the central `extensions/deps.edn` (which only covers the simpler flat-namespace extensions). It has its own `deps.edn` with a `:test` alias and is run independently.
 
-**`extensions/deps.edn` test alias:** Add `"metrics/test"` to `:extra-paths` under `:test`.
-
-**`extensions/tests.edn`:** Add metrics test paths to the Kaocha test suite if one exists, or rely on the extension-level deps.edn test alias.
-
-**Manifest registration (three places):**
+**Manifest registration (two places):**
 
 1. **Catalog entry:** Add `'psi/metrics {:psi/init 'psi.metrics.extension/init :source-policies {:installed {:local/root "extensions/metrics"}}}` to `psi-owned-extension-catalog` in `components/agent-session/src/psi/agent_session/extension_installs.clj`. This is the same registration pattern used by all built-in extensions (github, logprobs, etc.). While technically touching a core component file, it is a data-only catalog addition — no behavioral changes.
 2. **Project manifest:** Add `psi/metrics {}` to `.psi/extensions.edn` under `:deps` to enable the extension in this project.
-3. **Classpath:** Add `psi/metrics {:local/root "metrics"}` to `extensions/deps.edn` under `:deps` so the classpath can resolve it.
+
+**Tests:** Run via `clj -M:test` inside `extensions/metrics/` using the `:test` alias in `extensions/metrics/deps.edn`. No changes to the central `extensions/deps.edn` or `extensions/tests.edn`.
 
 ### Key Invariants
 

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -35,7 +35,7 @@ Psi has no visibility into which capabilities are actually used, how often they 
 
 ## Constraints
 
-- **Extension boundary only** — no modifications to existing core components. The extension uses only the public extension API (`init` receives the `api` map).
+- **Extension boundary only** — no behavioral modifications to existing core components. The extension uses only the public extension API (`init` receives the `api` map). The only core file touched is the data-only `psi-owned-extension-catalog` map in `extension_installs.clj` to register the new extension (same pattern as all built-in extensions).
 - **Event-driven** — observes existing extension events: `tool_call`, `tool_result`, `session_turn_finished`. No new hooks in core required.
 - **Project-scoped persistence** — EDN file at `<worktree>/.psi/metrics.edn`. Loaded on init, flushed on mutation.
 - **Minimal overhead** — counter increments are in-memory atom updates; persistence is fire-and-forget I/O after each event batch, not on the critical path of tool execution.
@@ -159,7 +159,7 @@ Deterministic operations are not currently emitted as extension events either. T
 
 **Load on init:** The extension needs the worktree path to locate the persistence file. It obtains this via `((:query api) [:psi.agent-session/worktree-path])` during init. If the query returns nil (no worktree), persistence is disabled and the extension operates in memory-only mode.
 
-**Write strategy:** After each counter mutation, write synchronously within the `swap!` callback's aftermath. Specifically: each event handler calls a `persist-if-dirty!` function after `swap!` returns. This function checks a `:dirty?` flag in the atom, and if true, writes the metrics to disk and clears the flag. The write is synchronous but fast (small EDN file). No debounce thread or timer needed — the event rate is low enough (one per tool call, one per turn) that synchronous writes are acceptable. The `/metrics` command also triggers a flush to ensure the displayed data matches what's on disk.
+**Write strategy:** After each counter mutation, persist synchronously. Each event handler calls `persist!` after `swap!` returns. `persist!` uses a second `swap!` to atomically read the current metrics and clear the `:dirty?` flag, then writes the snapshot to disk outside the swap. This ensures no lost writes and no double-writes. The write is synchronous but fast (small EDN file). No debounce thread or timer needed — the event rate is low enough (one per tool call, one per turn) that synchronous writes are acceptable. The `/metrics` command also triggers a persist to ensure the displayed data matches what's on disk.
 
 **Atomic writes:** `spit` to a `.metrics.edn.tmp` file in the same directory, then `java.nio.file.Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`. This prevents partial writes from corrupting the file.
 
@@ -283,7 +283,7 @@ extensions/metrics/
 2. **Schema conformance:** The persisted EDN always conforms to `metrics-schema`. Load rejects non-conforming data.
 3. **Graceful degradation:** If persistence path is unavailable (no worktree), the extension operates in memory-only mode without error.
 4. **Thread safety:** All counter mutations go through `swap!` on the store atom. Persistence writes are serialized.
-5. **No core modifications:** The extension uses only the public extension API surface.
+5. **No behavioral core modifications:** The extension uses only the public extension API surface. The only core file touched is the data-only catalog registration.
 
 ### Edge Cases
 
@@ -314,5 +314,5 @@ extensions/metrics/
 3. `metrics/summary` deterministic operation returns current counter state conforming to malli schema.
 4. `/metrics` slash command renders a human-readable markdown summary.
 5. Metrics data conforms to an explicit malli schema (validated on load, available for consumers).
-6. No modifications to existing core components.
+6. No behavioral modifications to existing core components (data-only catalog entry is acceptable).
 7. Extension operates gracefully when no worktree path is available (memory-only mode).

--- a/munera/open/151-metrics-extension/implementation.md
+++ b/munera/open/151-metrics-extension/implementation.md
@@ -23,6 +23,14 @@ Like skill activations, slash command and deterministic operation invocations ar
 
 The extension obtains the worktree path via `((:query api) [:psi.agent-session/worktree-path])` during init. This is the same pattern used by commit-checks (which reads `workspace-dir` from event payloads). If nil, persistence is disabled gracefully.
 
+### Workflow tracking excluded from initial version
+
+No workflow start/completion events are emitted to the extension event bus. The workflow runtime uses internal statechart events but does not dispatch through `ext/dispatch-in`. Schema includes `:workflows` for forward compatibility.
+
+### Catalog registration is data-only
+
+Adding the extension to `psi-owned-extension-catalog` in `extension_installs.clj` is technically touching a core component file, but it's a data-only catalog entry — the same pattern used by all other built-in extensions. No behavioral changes to core code.
+
 ### Namespace convention: `psi.metrics.*`
 
 Follows `psi.github.*` pattern for project-owned extensions rather than the flat `extensions.*` convention used by simpler extensions. This allows clean multi-namespace decomposition.

--- a/munera/open/151-metrics-extension/implementation.md
+++ b/munera/open/151-metrics-extension/implementation.md
@@ -39,6 +39,26 @@ Follows `psi.github.*` pattern for project-owned extensions rather than the flat
 
 Uses write-to-temp + `Files/move` with `ATOMIC_MOVE` to prevent partial-read corruption. Same approach used in session persistence elsewhere in the codebase.
 
+## PR #94 Feedback — 2026-05-14
+
+### Per-model token usage (hugoduncan)
+
+Feedback: "Token-usage metrics should be per model."
+
+Changed `:tokens` from a flat `{:input N :output N ...}` map to `[:map-of :string token-totals-schema]` keyed by model-id. The `session_turn_finished` handler now queries `:psi.agent-session/model-id` alongside usage attrs and accumulates deltas under the model-id key. Falls back to `"unknown"` when model-id is nil.
+
+### Parallel tool call write safety (hugoduncan)
+
+Feedback: "Need to check if parallel tool calling would cause parallel metric file writes."
+
+Confirmed: `tool-runtime/batch.clj` uses `ExecutorService.invokeAll` for multi-tool batches, producing concurrent `tool_call`/`tool_result` extension events. The atom `swap!` is thread-safe for in-memory counters, but synchronous file persist after each event would serialize event handlers on I/O and produce redundant writes.
+
+### Out-of-band write-coalescing persistence (hugoduncan)
+
+Feedback: "If needed we could have metrics written out of band, and check for the need to write again when a write completes."
+
+Replaced synchronous persist with a dirty-flag + `writing?` CAS gate pattern: event handlers set `:dirty?` and call `maybe-persist!`; only one thread enters the write path at a time via `compare-and-set!` on `writing?`; after each write, the writer re-checks `:dirty?` and loops if concurrent events re-dirtied the state. This coalesces rapid-fire events into minimal disk I/O.
+
 ### `defonce` store preservation
 
 The store atom uses `defonce` so extension reloads preserve accumulated counters. Init re-subscribes to events but does not reset the atom.

--- a/munera/open/151-metrics-extension/implementation.md
+++ b/munera/open/151-metrics-extension/implementation.md
@@ -27,6 +27,10 @@ The extension obtains the worktree path via `((:query api) [:psi.agent-session/w
 
 No workflow start/completion events are emitted to the extension event bus. The workflow runtime uses internal statechart events but does not dispatch through `ext/dispatch-in`. Schema includes `:workflows` for forward compatibility.
 
+### Standalone extension — not in central extensions/deps.edn
+
+`psi/github` and `psi/logprobs` are not present in `extensions/deps.edn` (the central file covering simpler flat-namespace extensions). They are standalone with their own `deps.edn` and `:test` alias. `psi/metrics` follows the same pattern: standalone `extensions/metrics/deps.edn`, tests run via `clj -M:test` inside that directory. No changes to `extensions/deps.edn` or `extensions/tests.edn`.
+
 ### Catalog registration is data-only
 
 Adding the extension to `psi-owned-extension-catalog` in `extension_installs.clj` is technically touching a core component file, but it's a data-only catalog entry — the same pattern used by all other built-in extensions. No behavioral changes to core code.
@@ -62,3 +66,26 @@ Replaced synchronous persist with a dirty-flag + `writing?` CAS gate pattern: ev
 ### `defonce` store preservation
 
 The store atom uses `defonce` so extension reloads preserve accumulated counters. Init re-subscribes to events but does not reset the atom.
+
+## Refinement Pass — 2026-05-13
+
+### Wiring correction: standalone extension
+
+Verified against the actual repo: `psi/github` and `psi/logprobs` are absent from `extensions/deps.edn` — they are fully standalone extensions with their own deps.edn and test aliases. The design previously incorrectly specified adding `psi/metrics` to `extensions/deps.edn`. Corrected: metrics is standalone, wiring is catalog entry + project manifest only.
+
+### API surface verified
+
+- `(:query api)` — takes single EQL vector, returns result map. Used during `init` to obtain worktree path.
+- `(:query-session api)` — takes `(session-id eql-query)`, returns result map. Used in `session_turn_finished` handler to obtain per-session usage attrs and model-id.
+- `(:register-operation api)` — takes `{:id :description :handler}` map. Same as logprobs/github.
+- `(:register-command api)` — optional key; takes `(name opts-map)`. Same as logprobs.
+- `(:on api)` — takes `(event-name handler-fn)`. Same as logprobs.
+- `(:notify api)` — takes `(content & [opts])`. Used in command handler.
+
+### Test infrastructure
+
+Tests use `psi.extension-test-helpers.nullable-api/create-nullable-extension-api` (same as work-on, github tests). The nullable API provides `:query-session`, `:on`, `:register-operation`, `:register-command`, `:notify` — all needed by metrics. No mocks required.
+
+### Malli dependency
+
+Malli (`metosin/malli`) is not a transitive dep of the extension API or logprobs. Must be declared explicitly in `extensions/metrics/deps.edn` alongside the extension-test-helpers in the `:test` alias.

--- a/munera/open/151-metrics-extension/implementation.md
+++ b/munera/open/151-metrics-extension/implementation.md
@@ -67,6 +67,24 @@ Replaced synchronous persist with a dirty-flag + `writing?` CAS gate pattern: ev
 
 The store atom uses `defonce` so extension reloads preserve accumulated counters. Init re-subscribes to events but does not reset the atom.
 
+## Implementation Pass — 2026-05-13
+
+### store and writing? atoms made non-private
+
+The design specified `^:private` on the `store` and `writing?` `defonce` atoms. In practice, Clojure 1.12 enforces private var access at compile time even via `#'` in tests from a different namespace. Made both atoms non-private so tests can reset them between runs (same pattern as `auto-session-name` extension which also uses `@#'sut/state` on a private atom — but that works because it's in the same compilation unit). The logprobs extension uses `@#'logprobs/store` which works because the test and source are in the same top-level namespace. For `psi.metrics.*` multi-namespace layout, non-private is cleaner.
+
+### :register-operation not in nullable extension API
+
+The nullable extension API (`create-nullable-extension-api`) does not expose `:register-operation` as a direct key — it routes operations through the `mutate` path. The extension tests augment the nullable API with a local `ops` atom and a direct `:register-operation` fn, consistent with how logprobs tests build inline api maps. This is simpler and avoids coupling tests to the nullable API's internal mutation dispatch.
+
+### /metrics command self-tracking
+
+The command handler increments the command invocation counter for `"metrics"` on every invocation. This means there is no "empty metrics" state after the first `/metrics` call. Tests adjusted to reflect this: the "no events" case still shows the Commands section (with `metrics | 1`).
+
+### tests.edn uses kaocha v1 format
+
+Added `extensions/metrics/tests.edn` with kaocha v1 format, consistent with other extensions. `clj -M:test -m kaocha.runner -c tests.edn` runs the full suite.
+
 ## Refinement Pass — 2026-05-13
 
 ### Wiring correction: standalone extension

--- a/munera/open/151-metrics-extension/implementation.md
+++ b/munera/open/151-metrics-extension/implementation.md
@@ -1,0 +1,36 @@
+# Implementation Notes — 151 Metrics Extension
+
+## Provenance
+
+- **GitHub Issue:** [#75 — Add metrics extension](https://github.com/hugoduncan/psi/issues/75)
+- **Issue comment:** Refined task intent posted by hugoduncan on 2026-05-14
+
+## Design Decisions
+
+### Skill activation tracking excluded
+
+The original issue mentions "skill activations" but no extension event is emitted when a skill is selected/activated. Adding one would require core modifications. Excluded from scope; schema is forward-compatible if the event is added later.
+
+### Command and operation tracking partially deferred
+
+Like skill activations, slash command and deterministic operation invocations are not emitted as extension events. The schema includes `:commands` and `:operations` categories, and the extension self-tracks its own `/metrics` and `metrics/summary` invocations. Full tracking requires future core event emission.
+
+### Token tracking via EQL query delta
+
+`session_turn_finished` does not carry token usage in its payload. Rather than modifying core `prompt-finish-base-result` in `turn/handlers.clj`, the extension queries the EQL surface `[:psi.agent-session/usage-input ...]` after each turn and computes the delta from a transient per-session cache. This respects the extension boundary constraint at the cost of one EQL query per turn completion.
+
+### Persistence path from EQL query
+
+The extension obtains the worktree path via `((:query api) [:psi.agent-session/worktree-path])` during init. This is the same pattern used by commit-checks (which reads `workspace-dir` from event payloads). If nil, persistence is disabled gracefully.
+
+### Namespace convention: `psi.metrics.*`
+
+Follows `psi.github.*` pattern for project-owned extensions rather than the flat `extensions.*` convention used by simpler extensions. This allows clean multi-namespace decomposition.
+
+### Atomic file writes
+
+Uses write-to-temp + `Files/move` with `ATOMIC_MOVE` to prevent partial-read corruption. Same approach used in session persistence elsewhere in the codebase.
+
+### `defonce` store preservation
+
+The store atom uses `defonce` so extension reloads preserve accumulated counters. Init re-subscribes to events but does not reset the atom.

--- a/munera/open/151-metrics-extension/steps.md
+++ b/munera/open/151-metrics-extension/steps.md
@@ -2,23 +2,23 @@
 
 ## Implementation
 
-- [ ] Create `extensions/metrics/deps.edn` with malli dep and test alias
-- [ ] Create `psi.metrics.schema` — malli schemas for metrics data shape
-- [ ] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add per-model token delta)
-- [ ] Create `psi.metrics.persistence` — load/save EDN with atomic writes, write-coalescing via `writing?` CAS gate, schema validation on load
-- [ ] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
-- [ ] Add catalog entry in `extension_installs.clj` (`psi-owned-extension-catalog`)
-- [ ] Add `psi/metrics {}` to `.psi/extensions.edn`
+- [x] Create `extensions/metrics/deps.edn` with malli dep and test alias
+- [x] Create `psi.metrics.schema` — malli schemas for metrics data shape
+- [x] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add per-model token delta)
+- [x] Create `psi.metrics.persistence` — load/save EDN with atomic writes, write-coalescing via `writing?` CAS gate, schema validation on load
+- [x] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
+- [x] Add catalog entry in `extension_installs.clj` (`psi-owned-extension-catalog`)
+- [x] Add `psi/metrics {}` to `.psi/extensions.edn`
 
 ## Tests
 
-- [ ] `psi.metrics.schema-test` — schema validation for valid/invalid metrics maps
-- [ ] `psi.metrics.counters-test` — pure counter increment functions, per-model token delta
-- [ ] `psi.metrics.persistence-test` — round-trip load/save, corrupt file handling, missing directory creation, write-coalescing under concurrent mutations
-- [ ] `psi.metrics.extension-test` — init registration, event handler behavior, per-model token accumulation, operation handler, command rendering
+- [x] `psi.metrics.schema-test` — schema validation for valid/invalid metrics maps
+- [x] `psi.metrics.counters-test` — pure counter increment functions, per-model token delta
+- [x] `psi.metrics.persistence-test` — round-trip load/save, corrupt file handling, missing directory creation, write-coalescing under concurrent mutations
+- [x] `psi.metrics.extension-test` — init registration, event handler behavior, per-model token accumulation, operation handler, command rendering
 
 ## Verification
 
-- [ ] All tests green
-- [ ] Lint clean (`clj-kondo --lint extensions/metrics/src`)
-- [ ] Schema conformance validated on load and in operation response
+- [x] All tests green (50 tests, 87 assertions, 0 failures)
+- [x] Lint clean (`clj-kondo --lint extensions/metrics/src`)
+- [x] Schema conformance validated on load and in operation response

--- a/munera/open/151-metrics-extension/steps.md
+++ b/munera/open/151-metrics-extension/steps.md
@@ -4,8 +4,8 @@
 
 - [ ] Create `extensions/metrics/deps.edn` with malli dep and test alias
 - [ ] Create `psi.metrics.schema` — malli schemas for metrics data shape
-- [ ] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add token delta)
-- [ ] Create `psi.metrics.persistence` — load/save EDN with atomic writes, schema validation on load
+- [ ] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add per-model token delta)
+- [ ] Create `psi.metrics.persistence` — load/save EDN with atomic writes, write-coalescing via `writing?` CAS gate, schema validation on load
 - [ ] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
 - [ ] Wire into `extensions/deps.edn` (add `psi/metrics` dep and test paths)
 - [ ] Add catalog entry in `extension_installs.clj` (`psi-owned-extension-catalog`)
@@ -14,9 +14,9 @@
 ## Tests
 
 - [ ] `psi.metrics.schema-test` — schema validation for valid/invalid metrics maps
-- [ ] `psi.metrics.counters-test` — pure counter increment functions
-- [ ] `psi.metrics.persistence-test` — round-trip load/save, corrupt file handling, missing directory creation
-- [ ] `psi.metrics.extension-test` — init registration, event handler behavior, operation handler, command rendering
+- [ ] `psi.metrics.counters-test` — pure counter increment functions, per-model token delta
+- [ ] `psi.metrics.persistence-test` — round-trip load/save, corrupt file handling, missing directory creation, write-coalescing under concurrent mutations
+- [ ] `psi.metrics.extension-test` — init registration, event handler behavior, per-model token accumulation, operation handler, command rendering
 
 ## Verification
 

--- a/munera/open/151-metrics-extension/steps.md
+++ b/munera/open/151-metrics-extension/steps.md
@@ -8,7 +8,8 @@
 - [ ] Create `psi.metrics.persistence` — load/save EDN with atomic writes, schema validation on load
 - [ ] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
 - [ ] Wire into `extensions/deps.edn` (add `psi/metrics` dep and test paths)
-- [ ] Register in project manifest for bootstrap activation
+- [ ] Add catalog entry in `extension_installs.clj` (`psi-owned-extension-catalog`)
+- [ ] Add `psi/metrics {}` to `.psi/extensions.edn`
 
 ## Tests
 

--- a/munera/open/151-metrics-extension/steps.md
+++ b/munera/open/151-metrics-extension/steps.md
@@ -1,0 +1,24 @@
+# Steps — 151 Metrics Extension
+
+## Implementation
+
+- [ ] Create `extensions/metrics/deps.edn` with malli dep and test alias
+- [ ] Create `psi.metrics.schema` — malli schemas for metrics data shape
+- [ ] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add token delta)
+- [ ] Create `psi.metrics.persistence` — load/save EDN with atomic writes, schema validation on load
+- [ ] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
+- [ ] Wire into `extensions/deps.edn` (add `psi/metrics` dep and test paths)
+- [ ] Register in project manifest for bootstrap activation
+
+## Tests
+
+- [ ] `psi.metrics.schema-test` — schema validation for valid/invalid metrics maps
+- [ ] `psi.metrics.counters-test` — pure counter increment functions
+- [ ] `psi.metrics.persistence-test` — round-trip load/save, corrupt file handling, missing directory creation
+- [ ] `psi.metrics.extension-test` — init registration, event handler behavior, operation handler, command rendering
+
+## Verification
+
+- [ ] All tests green
+- [ ] Lint clean (`clj-kondo --lint extensions/metrics/src`)
+- [ ] Schema conformance validated on load and in operation response

--- a/munera/open/151-metrics-extension/steps.md
+++ b/munera/open/151-metrics-extension/steps.md
@@ -7,7 +7,6 @@
 - [ ] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add per-model token delta)
 - [ ] Create `psi.metrics.persistence` — load/save EDN with atomic writes, write-coalescing via `writing?` CAS gate, schema validation on load
 - [ ] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
-- [ ] Wire into `extensions/deps.edn` (add `psi/metrics` dep and test paths)
 - [ ] Add catalog entry in `extension_installs.clj` (`psi-owned-extension-catalog`)
 - [ ] Add `psi/metrics {}` to `.psi/extensions.edn`
 


### PR DESCRIPTION
# Metrics Extension

**Issue:** [#75 — Add metrics extension](https://github.com/hugoduncan/psi/issues/75)

## Intent

A standard extension that observes system activity and maintains persistent usage counters for registered capabilities — tools, skills, commands, workflows, and deterministic operations. Counters survive process restarts so that usage patterns are visible over time.

## Problem Statement

Psi has no visibility into which capabilities are actually used, how often they succeed or fail, or how much they cost in tokens. The information exists transiently in the dispatch event log and extension event bus, but nothing aggregates or persists it. This makes it hard to identify unused registrations, error-prone tools, or token-expensive workflows.

## Scope

### In Scope

- Tool invocation counting (by tool name), including error counting (by tool name + error classification)
- Workflow execution counting (by workflow id)
- Command invocation counting (by command name)
- Deterministic operation invocation counting (by operation id)
- Token usage accumulation per model (input/output/cache-read/cache-write keyed by model-id)
- Project-scoped persistence (EDN file in `.psi/`)
- Deterministic operation `metrics/summary` returning current counter state
- Slash command `/metrics` rendering human-readable summary
- Malli schema for the metrics data shape

### Out of Scope

- User-global (cross-project) aggregation
- Skill activation tracking (no existing extension event emitted for skill selection; would require core changes)
- Per-session token breakdowns (the extension tracks per-model aggregate totals, not per-session; per-session detail is already available via the EQL resolver `agent-session-usage`)
- Cost tracking (requires model-specific pricing data not available to extensions)
- Historical time-series or bucketed metrics
- Metrics export (Prometheus, OpenTelemetry, etc.)

## Constraints

- **Extension boundary only** — no behavioral modifications to existing core components. The extension uses only the public extension API (`init` receives the `api` map). The only core file touched is the data-only `psi-owned-extension-catalog` map in `extension_installs.clj` to register the new extension (same pattern as all built-in extensions).
- **Event-driven** — observes existing extension events: `tool_call`, `tool_result`, `session_turn_finished`. No new hooks in core required.
- **Project-scoped persistence** — EDN file at `<worktree>/.psi/metrics.edn`. Loaded on init, flushed on mutation.
- **Minimal overhead** — counter increments are in-memory atom updates; persistence is out-of-band with write-coalescing so concurrent events (e.g., parallel tool calls) never serialize on disk I/O.
- **Schema-first** — malli schema defines the canonical metrics data shape; validated on load and available for consumers.

## Design

### Architecture Overview

The extension follows the standard psi extension pattern (see `extensions/logprobs/`, `extensions/commit-checks/`):

```
init(api) →
  subscribe("tool_call",            on-tool-call)
  subscribe("tool_result",          on-tool-result)
  subscribe("session_turn_finished", on-turn-finished)
  register-operation("metrics/summary", invoke-summary)
  register-command("metrics",       metrics-command-handler)
```

State is held in a single `(defonce store (atom nil))` containing both the metrics counters and the resolved persistence path. A separate `(defonce writing? (atom false))` gate serializes disk writes.

### Implementation Strategy

**Why this fits the architecture:** The extension API already provides `(:on api)` for event subscription, `(:register-operation api)` for deterministic operations, and `(:register-command api)` for slash commands. The commit-checks extension demonstrates the persistence pattern (EDN file in `.psi/`). The logprobs extension demonstrates the event-subscription + operation + command triple. This design composes both patterns.

### Data Shape

The metrics atom holds a map with this shape:

```clojure
{:tools       {"tool-name" {:invocations 5
                             :errors      3
                             :error-reasons {"parse-error" 2
                                             "timeout" 1}}}
 :workflows   {"workflow-id" {:invocations 3}}
 :commands    {"command-name" {:invocations 7}}
 :operations  {"operation-id" {:invocations 2}}
 :tokens      {"claude-sonnet-4-20250514" {:input       12500
                                            :output      3400
                                            :cache-read  8000
                                            :cache-write 1200}
               "gpt-4o"                  {:input       5000
                                            :output      1200
                                            :cache-read  0
                                            :cache-write 0}}
 :updated-at  "2026-05-14T10:00:00Z"}
```

#### Malli Schema

```clojure
(def counter-schema
  [:map
   [:invocations :int]])

(def tool-counter-schema
  [:map
   [:invocations :int]
   [:errors :int]
   [:error-reasons [:map-of :string :int]]])

(def token-totals-schema
  [:map
   [:input :int]
   [:output :int]
   [:cache-read :int]
   [:cache-write :int]])

(def metrics-schema
  [:map
   [:tools [:map-of :string tool-counter-schema]]
   [:workflows [:map-of :string counter-schema]]
   [:commands [:map-of :string counter-schema]]
   [:operations [:map-of :string counter-schema]]
   [:tokens [:map-of :string token-totals-schema]]
   [:updated-at [:maybe :string]]])
```

### Event Handling

#### `tool_call` event

Payload: `{:type "tool_call" :tool-name "..." :tool-call-id "..." :input {...}}`

Action: Increment `[:tools tool-name :invocations]`.

#### `tool_result` event

Payload: `{:type "tool_result" :tool-name "..." :tool-call-id "..." :input {...} :content "..." :is-error true/false}`

Action: When `:is-error` is truthy, increment `[:tools tool-name :errors]` and `[:tools tool-name :error-reasons reason]`. The error reason is derived from the `:content` string — extract the first line, truncated to 80 chars, as the reason key. This keeps reason keys short and greppable without requiring structured error taxonomies.

#### `session_turn_finished` event

Payload: `{:session-id "..." :turn-id "..." ...}`

Action: Query session token usage and model-id via the extension API's `:query-session` function: `((:query-session api) session-id [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write :psi.agent-session/model-id])`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the `:tokens` counters under the model-id key. If model-id is nil, use `"unknown"` as the key.

**Why per-model:** Different models have different token economics and capabilities. Aggregate-only totals hide which models consume the most tokens. Per-model breakdown enables informed model selection and cost awareness.

**Why delta-based:** The EQL resolver returns cumulative session totals. The extension must track the last-seen totals per session in memory so it can compute the incremental contribution of each turn. The per-session tracking map is transient (not persisted) because it is only needed within a running process — on restart, the first turn for each session will be treated as a full delta, which is acceptable because sessions rarely span process restarts and the aggregate totals are approximate anyway.

**Alternative considered — enrich `session_turn_finished` payload:** This would require modifying `prompt-finish-base-result` in `turn/handlers.clj`, violating the "no core modifications" constraint. The EQL query approach is slightly less efficient but respects the extension boundary.

### Workflow Tracking

Workflow start/completion events are not currently emitted to the extension event bus. The workflow runtime uses internal statechart events (`:workflow/start`, `:workflow/complete`) but these are not dispatched through `ext/dispatch-in`.

**Decision:** Workflow tracking is included in the schema and data shape (so the surface is ready) but will not be populated in the initial version. A future core enhancement could emit `workflow_started` and `workflow_completed` extension events; the extension is already shaped to consume them.

### Command Tracking

Slash commands are not currently emitted as extension events. The extension registers its own `/metrics` command but cannot observe other command invocations without core changes.

**Decision:** Command tracking is included in the schema and data shape (so the surface is ready) but will initially only track the extension's own `/metrics` command via self-tracking. A future core enhancement could emit a `command_invoked` event to enable full command tracking.

### Deterministic Operation Tracking

Deterministic operations are not currently emitted as extension events either. The same forward-compatible approach applies: the schema includes `:operations`, but initial population is limited to self-tracking of `metrics/summary` invocations.

**Decision:** Track `metrics/summary` self-invocations. Future core event emission for operation invocations would automatically populate this counter category.

### Persistence

**File:** `<worktree>/.psi/metrics.edn`

**Load on init:** The extension needs the worktree path to locate the persistence file. It obtains this via `((:query api) [:psi.agent-session/worktree-path])` during init. If the query returns nil (no worktree), persistence is disabled and the extension operates in memory-only mode.

**Write strategy — out-of-band with write-coalescing:** Parallel tool calls produce concurrent `tool_call` and `tool_result` events, which means multiple threads may mutate the metrics atom concurrently. The atom `swap!` is thread-safe, but synchronous file writes after each `swap!` would serialize all event handlers on disk I/O and risk redundant writes.

Instead, persistence uses a dirty-flag + single-writer loop:

1. Each event handler calls `swap!` to update counters, then sets a `:dirty?` flag in the atom and calls `maybe-persist!`.
2. `maybe-persist!` uses `compare-and-set!` on a separate `(defonce writing? (atom false))` flag to ensure only one thread enters the write path at a time.
3. The writer atomically reads the current metrics snapshot and clears `:dirty?`, writes the snapshot to disk, then checks `:dirty?` again — if it was re-dirtied during the write (by another concurrent event), it loops and writes again.
4. When the writer finds `:dirty?` is false after a write, it resets `writing?` to false and exits.

This ensures: (a) no concurrent file writes, (b) no lost updates — if events arrive during a write, the loop catches them, (c) minimal I/O — rapid-fire events coalesce into a single write of the latest state.

The `/metrics` command also triggers a `maybe-persist!` to ensure the displayed data matches what's on disk.

**Atomic writes:** `spit` to a `.metrics.edn.tmp` file in the same directory, then `java.nio.file.Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`. This prevents partial writes from corrupting the file.

**Load validation:** On load, validate the EDN against the malli schema. If validation fails, log a warning and start with empty counters (the corrupt file is preserved for manual inspection).

### Initialization

```clojure
(defn init [api]
  (let [worktree-path (get ((:query api) [:psi.agent-session/worktree-path])
                           :psi.agent-session/worktree-path)
        initial-state (when-not @store
                        (load-metrics worktree-path))]
    ;; Only reset store on first init (defonce preserves across reloads).
    ;; On reload, just update worktree-path in case it changed.
    (if @store
      (swap! store assoc :worktree-path worktree-path)
      (reset! store {:metrics (or initial-state (empty-metrics))
                     :worktree-path worktree-path
                     :session-usage-cache {}
                     :dirty? false}))
    ((:on api) "tool_call" on-tool-call)
    ((:on api) "tool_result" on-tool-result)
    ((:on api) "session_turn_finished" (make-turn-finished-handler api))
    ((:register-operation api)
     {:id "metrics/summary"
      :description "Return current usage metrics for all tracked capabilities"
      :handler invoke-summary})
    (when-let [register-command (:register-command api)]
      (register-command "metrics"
                        {:description "Display usage metrics summary"
                         :handler (fn [args] (metrics-command-handler args api))}))
    nil))
```

The `session_turn_finished` handler is created via `make-turn-finished-handler` which closes over the `api` map to access the `:query` function for EQL usage lookups.

**Reload behavior:** On extension reload, the `defonce` atom is preserved. `init` detects the non-nil store and only updates the `:worktree-path` (in case the session switched worktrees). Accumulated counters and the session-usage-cache survive the reload.

### Operation Handler

`metrics/summary` returns the full metrics map:

```clojure
(defn invoke-summary [{:keys [_args]}]
  {:status :ok
   :data (get-metrics)})
```

No arguments required. Returns the full metrics map conforming to `metrics-schema`.

### Slash Command

`/metrics` renders a human-readable summary via `(:notify api)`:

```
## Usage Metrics

### Tools (5 tracked)
| Tool | Invocations | Errors |
|------|-------------|--------|
| read | 42 | 0 |
| bash | 38 | 3 |
| edit | 25 | 1 |
| write | 12 | 0 |
| delegate | 8 | 0 |

### Token Usage (by model)
| Model | Input | Output | Cache Read | Cache Write |
|-------|-------|--------|------------|-------------|
| claude-sonnet-4-20250514 | 125,000 | 34,000 | 80,000 | 12,000 |
| gpt-4o | 5,000 | 1,200 | 0 | 0 |

_Updated: 2026-05-14T10:00:00Z_
```

Workflow, command, and operation sections are included when non-empty.

### File Layout

```
extensions/metrics/
├── deps.edn
├── src/
│   └── psi/
│       └── metrics/
│           ├── extension.clj      ;; init + event handlers + operation + command
│           ├── schema.clj         ;; malli schemas
│           ├── persistence.clj    ;; load/save EDN, atomic write
│           └── counters.clj       ;; pure counter update functions
└── test/
    └── psi/
        └── metrics/
            ├── extension_test.clj
            ├── schema_test.clj
            ├── persistence_test.clj
            └── counters_test.clj
```

**Namespace convention:** Uses `psi.metrics.*` following the `psi.github.*` pattern for extensions that are part of the psi project (not third-party `extensions.*` flat namespaces).

### Wiring

**`extensions/deps.edn`:** Add `psi/metrics {:local/root "metrics"}` to `:deps`.

**`extensions/deps.edn` test alias:** Add `"metrics/test"` to `:extra-paths` under `:test`.

**`extensions/tests.edn`:** Add metrics test paths to the Kaocha test suite if one exists, or rely on the extension-level deps.edn test alias.

**Manifest registration (three places):**

1. **Catalog entry:** Add `'psi/metrics {:psi/init 'psi.metrics.extension/init :source-policies {:installed {:local/root "extensions/metrics"}}}` to `psi-owned-extension-catalog` in `components/agent-session/src/psi/agent_session/extension_installs.clj`. This is the same registration pattern used by all built-in extensions (github, logprobs, etc.). While technically touching a core component file, it is a data-only catalog addition — no behavioral changes.
2. **Project manifest:** Add `psi/metrics {}` to `.psi/extensions.edn` under `:deps` to enable the extension in this project.
3. **Classpath:** Add `psi/metrics {:local/root "metrics"}` to `extensions/deps.edn` under `:deps` so the classpath can resolve it.

### Key Invariants

1. **Counter monotonicity:** Counters only increment, never decrement. The `updated-at` timestamp advances on every mutation.
2. **Schema conformance:** The persisted EDN always conforms to `metrics-schema`. Load rejects non-conforming data.
3. **Graceful degradation:** If persistence path is unavailable (no worktree), the extension operates in memory-only mode without error.
4. **Thread safety:** All counter mutations go through `swap!` on the store atom. Persistence writes are serialized via a `writing?` CAS gate — at most one thread writes at a time, and writes coalesce concurrent mutations.
5. **No behavioral core modifications:** The extension uses only the public extension API surface. The only core file touched is the data-only catalog registration.

### Edge Cases

- **No worktree:** Init succeeds, persistence disabled, counters are in-memory only.
- **Corrupt EDN file:** Log warning, start with empty counters, do not overwrite the corrupt file until the first successful mutation.
- **Missing `.psi/` directory:** Create it on first write (using `io/make-parents`).
- **Concurrent writes from parallel tool calls:** Parallel tool execution produces concurrent `tool_call`/`tool_result` events. The atom serializes in-memory counter updates. The `writing?` CAS gate ensures at most one disk write at a time; the dirty-check loop after each write coalesces rapid-fire mutations into minimal I/O. Atomic file rename prevents partial reads.
- **Extension reload:** `defonce` on the store atom preserves counters across reloads. The init function re-subscribes to events but does not reset counters.
- **EQL query failure on turn finished:** If the usage query fails (e.g., session already closed), skip token tracking for that turn and log at debug level.

### Verification Expectations

1. `init` subscribes to exactly three events and registers one operation and one command.
2. `on-tool-call` increments `[:tools name :invocations]` for any tool name.
3. `on-tool-result` with `:is-error true` increments `[:tools name :errors]` and `[:tools name :error-reasons reason]`.
4. `on-tool-result` with `:is-error false` does not increment error counters.
5. `invoke-summary` returns `{:status :ok :data <metrics-map>}` conforming to schema.
6. `/metrics` command calls `(:notify api)` with a markdown-formatted summary.
7. `load-metrics` returns empty counters for missing or corrupt files.
8. `save-metrics` writes valid EDN that round-trips through `load-metrics`.
9. Counter functions are pure and independently testable.
10. Token delta computation correctly handles first-seen sessions, cumulative totals, and per-model keying.
11. `maybe-persist!` coalesces concurrent mutations — only one thread writes at a time, and re-dirtied state triggers a follow-up write.

## Acceptance Criteria

1. Extension subscribes to `tool_call`, `tool_result`, and `session_turn_finished` events and increments appropriate counters.
2. Token usage is accumulated per model-id (queried via EQL on each `session_turn_finished`).
3. Counters persist to `<worktree>/.psi/metrics.edn` and restore on init.
4. Persistence uses out-of-band write-coalescing so parallel tool call events do not serialize on disk I/O.
5. `metrics/summary` deterministic operation returns current counter state conforming to malli schema.
6. `/metrics` slash command renders a human-readable markdown summary with per-model token breakdown.
7. Metrics data conforms to an explicit malli schema (validated on load, available for consumers).
8. No behavioral modifications to existing core components (data-only catalog entry is acceptable).
9. Extension operates gracefully when no worktree path is available (memory-only mode).
