### PR TITLE
Fix interrupted tool-call runtime recovery and Anthropic transcript validity

### DIFF
--- a/components/agent-core/src/psi/agent_core/core.clj
+++ b/components/agent-core/src/psi/agent_core/core.clj
@@ -396,9 +396,15 @@
     data))
 
 (defn record-tool-result-in!
-  "Append a tool result message and emit message_start / message_end."
+  "Append a tool result message, clear its pending tool-call id, and emit
+   message_start / message_end."
   [ctx tool-result-msg]
-  (let [data (swap-data! ctx update :messages conj tool-result-msg)]
+  (let [tool-call-id (:tool-call-id tool-result-msg)
+        data         (swap-data! ctx
+                                 (fn [d]
+                                   (cond-> (update d :messages conj tool-result-msg)
+                                     tool-call-id
+                                     (update :pending-tool-calls disj tool-call-id))))]
     (emit-in! ctx {:type :message-start :message tool-result-msg})
     (emit-in! ctx {:type :message-end   :message tool-result-msg})
     data))
@@ -412,16 +418,19 @@
   (get-data-in ctx))
 
 (defn emit-tool-start-in!
-  "Emit tool_execution_start for `tool-call`."
+  "Emit tool_execution_start for `tool-call` and mark it pending."
   [ctx tool-call]
-  (emit-in! ctx {:type         :tool-execution-start
-                 :tool-call-id (:id tool-call)
-                 :tool-name    (:name tool-call)
-                 :args         (:arguments tool-call)})
-  (get-data-in ctx))
+  (let [tool-call-id (:id tool-call)]
+    (swap-data! ctx update :pending-tool-calls (fnil conj #{}) tool-call-id)
+    (emit-in! ctx {:type         :tool-execution-start
+                   :tool-call-id tool-call-id
+                   :tool-name    (:name tool-call)
+                   :args         (:arguments tool-call)})
+    (get-data-in ctx)))
 
 (defn emit-tool-end-in!
-  "Emit tool_execution_end for `tool-call` with `result` and `is-error?`."
+  "Emit tool_execution_end for `tool-call` with `result` and `is-error?`.
+   Pending state is cleared when the tool result is recorded."
   [ctx tool-call result is-error?]
   (emit-in! ctx {:type         :tool-execution-end
                  :tool-call-id (:id tool-call)

--- a/components/agent-core/test/psi/agent_core/core_test.clj
+++ b/components/agent-core/test/psi/agent_core/core_test.clj
@@ -359,12 +359,13 @@
   (let [call {:id "call-1" :name "bash" :arguments "{}"}
         res  {:content [{:type :text :text "ok"}]}]
 
-    (testing "emit-tool-start-in! emits tool_execution_start event"
+    (testing "emit-tool-start-in! emits tool_execution_start event and marks the call pending"
       (let [ctx (agent/create-context)]
         (agent/create-agent-in! ctx)
         (agent/emit-tool-start-in! ctx call)
         (let [events (agent/drain-events-in! ctx)]
-          (is (some #(= :tool-execution-start (:type %)) events)))))
+          (is (some #(= :tool-execution-start (:type %)) events))
+          (is (= #{"call-1"} (:pending-tool-calls (agent/get-data-in ctx)))))))
 
     (testing "emit-tool-end-in! emits tool_execution_end event"
       (let [ctx (agent/create-context)]
@@ -381,13 +382,15 @@
         (let [events (agent/drain-events-in! ctx)]
           (is (some #(= :turn-end (:type %)) events)))))
 
-    (testing "record-tool-result-in! appends to messages and emits events"
+    (testing "record-tool-result-in! appends to messages, emits events, and clears pending call"
       (let [ctx    (agent/create-context)
             result {:role "tool-result" :tool-call-id "c1" :tool-name "bash"
                     :content [] :is-error false}]
         (agent/create-agent-in! ctx)
+        (swap! (:data-atom ctx) assoc :pending-tool-calls #{"c1"})
         (agent/record-tool-result-in! ctx result)
         (is (= [result] (:messages (agent/get-data-in ctx))))
+        (is (= #{} (:pending-tool-calls (agent/get-data-in ctx))))
         (let [events (agent/drain-events-in! ctx)
               types  (map :type events)]
           (is (some #{:message-start} types))

--- a/components/agent-session/src/psi/agent_session/context.clj
+++ b/components/agent-session/src/psi/agent_session/context.clj
@@ -26,6 +26,7 @@
    [psi.agent-session.tool-plan :as tool-plan]
    [psi.agent-core.core :as agent-core]
    [psi.agent-session.session-runtime :as session-runtime]
+   [psi.agent-session.session-close]
    [psi.agent-session.workflow-execution :as workflow-execution]
    [psi.agent-session.workflow-judge :as workflow-judge]
    [psi.workflow-runtime.child-session-contract :as workflow-child-session-contract]
@@ -314,6 +315,9 @@
 (defn shutdown-context! [ctx]
   (doseq [{:keys [session-id]} (ss/list-context-sessions-in ctx)]
     (dispatch/dispatch! ctx :scheduler/cancel-all {:session-id session-id} {:origin :core}))
+  (doseq [{:keys [session-id]} (ss/list-context-sessions-in ctx)]
+    (when (ss/get-session-data-in ctx session-id)
+      (psi.agent-session.session-close/close-session-in! ctx session-id)))
   (dispatch-effects/cancel-all-scheduler-timers!)
   (when-let [timers* (:scheduler-timers* ctx)]
     (reset! timers* {}))

--- a/components/agent-session/src/psi/agent_session/context.clj
+++ b/components/agent-session/src/psi/agent_session/context.clj
@@ -26,7 +26,7 @@
    [psi.agent-session.tool-plan :as tool-plan]
    [psi.agent-core.core :as agent-core]
    [psi.agent-session.session-runtime :as session-runtime]
-   [psi.agent-session.session-close]
+   [psi.agent-session.tools]
    [psi.agent-session.workflow-execution :as workflow-execution]
    [psi.agent-session.workflow-judge :as workflow-judge]
    [psi.workflow-runtime.child-session-contract :as workflow-child-session-contract]
@@ -316,8 +316,9 @@
   (doseq [{:keys [session-id]} (ss/list-context-sessions-in ctx)]
     (dispatch/dispatch! ctx :scheduler/cancel-all {:session-id session-id} {:origin :core}))
   (doseq [{:keys [session-id]} (ss/list-context-sessions-in ctx)]
-    (when (ss/get-session-data-in ctx session-id)
-      (psi.agent-session.session-close/close-session-in! ctx session-id)))
+    (when-let [agent-ctx (ss/agent-ctx-in ctx session-id)]
+      (agent-core/abort-in! agent-ctx))
+    (psi.agent-session.tools/abort-bash!))
   (dispatch-effects/cancel-all-scheduler-timers!)
   (when-let [timers* (:scheduler-timers* ctx)]
     (reset! timers* {}))

--- a/components/agent-session/src/psi/agent_session/dispatch_effects.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_effects.clj
@@ -117,6 +117,28 @@
 (defmethod execute-effect! :runtime/agent-record-tool-result [ctx effect]
   (when-let [ac (effect-agent-ctx ctx effect)] (agent/record-tool-result-in! ac (:tool-result-msg effect))))
 
+(defmethod execute-effect! :runtime/record-pending-tool-call-interrupts [ctx effect]
+  (let [session-id (:session-id effect)
+        reason     (:reason effect)
+        agent-ctx  (effect-agent-ctx ctx effect)
+        pending    (vec (or (some-> agent-ctx agent/get-data-in :pending-tool-calls) #{}))]
+    (doseq [tool-call-id pending]
+      (dispatch/dispatch! ctx
+                          :session/tool-agent-record-result
+                          {:session-id session-id
+                           :tool-result-msg {:role "toolResult"
+                                             :tool-call-id tool-call-id
+                                             :tool-name "interrupted"
+                                             :content [{:type :text
+                                                        :text (str "Tool execution interrupted before completion."
+                                                                   (when reason
+                                                                     (str " Reason: " (name reason) ".")))}]
+                                             :is-error true
+                                             :details {:interruption {:reason reason}}
+                                             :timestamp (java.time.Instant/now)}}
+                          {:origin :core}))
+    {:recorded-count (count pending) :reason reason}))
+
 (defmethod execute-effect! :runtime/tool-execute [ctx effect]
   (try
     (try ((:execute-tool-runtime-fn ctx) ctx (:session-id effect) (:tool-name effect) (:args effect) (:opts effect))

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_lifecycle.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_lifecycle.clj
@@ -5,6 +5,7 @@
    `psi.agent-session.turn.handlers`; this namespace only registers dispatch handlers."
   (:require
    [psi.agent-session.journal-append-effect :as journal-append-effect]
+   [psi.agent-session.prompt-request :as prompt-request]
    [psi.session-persistence.core :as persist]
    [psi.session-state.state :as ss]
    [psi.state-kernel.dispatch :as kernel]
@@ -28,11 +29,23 @@
 
   (register-core-handler!
    :session/prompt-submit
-   (fn [_ctx {:keys [session-id user-msg]}]
-     {:effects [(journal-append-effect/append-message-effect session-id user-msg)]
-      :return {:submitted? true
-               :turn-id (str (java.util.UUID/randomUUID))
-               :user-msg user-msg}}))
+   (fn [ctx {:keys [session-id user-msg]}]
+     (let [journal  (persist/all-entries-in ctx session-id)
+           messages (into []
+                          (keep (fn [entry]
+                                  (when (= :message (:kind entry))
+                                    (get-in entry [:data :message]))))
+                          journal)
+           repairs  (prompt-request/tail-dangling-tool-result-repairs messages)
+           effects  (into []
+                          (concat
+                           (map #(journal-append-effect/append-message-effect session-id %) repairs)
+                           [(journal-append-effect/append-message-effect session-id user-msg)]))]
+       {:effects effects
+        :return {:submitted? true
+                 :turn-id (str (java.util.UUID/randomUUID))
+                 :user-msg user-msg
+                 :repaired-tool-result-count (count repairs)}})))
 
   (register-core-handler!
    :session/submit-synthetic-user-prompt

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj
@@ -449,13 +449,14 @@
 
   (register-core-handler!
    :session/request-interrupt
-   (fn [ctx {:keys [session-id already-pending? requested-at]}]
+   (fn [ctx {:keys [session-id already-pending? requested-at reason]}]
      (let [sd (session/get-session-data-in ctx session-id)]
        {:root-state-update
         (session/session-update session-id
                                 (fn [_]
                                   (cond-> (assoc sd
                                                  :interrupt-pending true
+                                                 :interrupt-reason (or reason :deferred-interrupt)
                                                  :steering-messages [])
                                     (not already-pending?)
                                     (assoc :interrupt-requested-at requested-at))))

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/statechart_actions.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/statechart_actions.clj
@@ -74,21 +74,29 @@
 
   (kernel/register-handler!
    :on-agent-done
-   (fn [_ctx {:keys [session-id]}]
-     {:root-state-update (session/session-update session-id #(assoc % :is-streaming false
-                                                                    :retry-attempt 0
-                                                                    :interrupt-pending false
-                                                                    :interrupt-requested-at nil))
-      :effects [{:effect/type :runtime/mark-workflow-jobs-terminal}
-                {:effect/type :runtime/emit-background-job-terminal-messages}
-                {:effect/type :scheduler/drain-queue}]}))
+   (fn [ctx {:keys [session-id]}]
+     (let [sd                 (session/get-session-data-in ctx session-id)
+           interruption-reason (:interrupt-reason sd)]
+       {:root-state-update (session/session-update session-id #(assoc % :is-streaming false
+                                                                      :retry-attempt 0
+                                                                      :interrupt-pending false
+                                                                      :interrupt-requested-at nil
+                                                                      :interrupt-reason nil))
+        :effects (cond-> [{:effect/type :runtime/mark-workflow-jobs-terminal}
+                          {:effect/type :runtime/emit-background-job-terminal-messages}
+                          {:effect/type :scheduler/drain-queue}]
+                   interruption-reason
+                   (into [{:effect/type :runtime/record-pending-tool-call-interrupts
+                           :session-id session-id
+                           :reason interruption-reason}]))})))
 
   (kernel/register-handler!
    :on-abort
    (fn [_ctx {:keys [session-id]}]
      {:root-state-update (session/session-update session-id #(assoc % :is-streaming false
                                                                     :interrupt-pending false
-                                                                    :interrupt-requested-at nil))
+                                                                    :interrupt-requested-at nil
+                                                                    :interrupt-reason nil))
       :effects [{:effect/type :runtime/agent-abort}
                 {:effect/type :scheduler/drain-queue}]}))
 

--- a/components/agent-session/src/psi/agent_session/dispatch_schema.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_schema.clj
@@ -58,6 +58,10 @@
      [:tool-call :map] [:result :any] [:is-error? :boolean]]]
    [:runtime/agent-record-tool-result
     [:map [:effect/type [:= :runtime/agent-record-tool-result]] [:tool-result-msg :map]]]
+   [:runtime/record-pending-tool-call-interrupts
+    [:map [:effect/type [:= :runtime/record-pending-tool-call-interrupts]]
+     [:session-id :string]
+     [:reason :keyword]]]
    [:runtime/tool-execute
     [:map [:effect/type [:= :runtime/tool-execute]]
      [:tool-name :string] [:args :map] [:opts {:optional true} [:maybe :map]]]]

--- a/components/agent-session/src/psi/agent_session/introspection.clj
+++ b/components/agent-session/src/psi/agent_session/introspection.clj
@@ -7,6 +7,7 @@
    [psi.agent-session.resolvers :as resolvers]
    [psi.session-state.model :as session]
    [psi.session-state.state :as ss]
+   [psi.turn-runtime.stream]
    [psi.agent-session.extension-workflow-runtime :as extension-workflow-runtime]))
 
 (defn replay-dispatch-event-log-in!
@@ -26,8 +27,12 @@
 (defn diagnostics-in
   "Return a diagnostic snapshot map."
   [ctx session-id]
-  (let [sd    (ss/get-session-data-in ctx session-id)
-        phase (ss/sc-phase-in ctx session-id)]
+  (let [sd          (ss/get-session-data-in ctx session-id)
+        phase       (ss/sc-phase-in ctx session-id)
+        turn-ctx    (ss/get-state-value-in ctx (ss/state-path :turn-ctx session-id))
+        stream-live? (boolean
+                      (when-let [stream-handle (some-> turn-ctx :turn-data deref :stream-handle)]
+                        (not (psi.turn-runtime.stream/cancelled-stream-handle? stream-handle))))]
     {:phase                   phase
      :session-id              session-id
      :is-idle                 (= phase :idle)
@@ -45,6 +50,7 @@
      :workflow-count          (extension-workflow-runtime/workflow-count-in (:workflow-registry ctx))
      :workflow-running-count  (extension-workflow-runtime/running-count-in (:workflow-registry ctx))
      :journal-entries         (count (ss/get-state-value-in ctx (ss/state-path :journal session-id)))
+     :turn-stream-live?       stream-live?
      :agent-diagnostics       (agent/diagnostics-in (ss/agent-ctx-in ctx session-id))}))
 
 (defn query-in

--- a/components/agent-session/src/psi/agent_session/prompt_request.clj
+++ b/components/agent-session/src/psi/agent_session/prompt_request.clj
@@ -13,16 +13,67 @@
    [psi.prompt-assets.skills :as skills]
    [psi.prompt-assets.system-prompt :as system-prompt]))
 
+(defn- assistant-tool-call-ids
+  [message]
+  (into []
+        (comp (filter #(= :tool-call (:type %)))
+              (map :id)
+              (filter string?))
+        (:content message)))
+
+(defn- tool-result-message?
+  [message]
+  (= "toolResult" (:role message)))
+
+(defn- tool-result-id
+  [message]
+  (:tool-call-id message))
+
+(defn- interrupted-tool-result
+  [tool-call-id timestamp]
+  {:role "toolResult"
+   :tool-call-id tool-call-id
+   :tool-name "interrupted"
+   :content [{:type :text
+              :text "Tool execution interrupted before completion."}]
+   :is-error true
+   :timestamp (or timestamp (java.time.Instant/now))})
+
+(defn- repair-dangling-tool-uses
+  "Ensure every assistant tool-call block is followed by corresponding
+   contiguous toolResult messages before any later non-toolResult message.
+
+   When a session was interrupted after journaling an assistant tool-use but
+   before journaling its matching toolResult, synthesize an error toolResult in
+   the provider-facing projection so follow-on prompts remain valid."
+  [messages]
+  (loop [remaining (seq messages)
+         repaired  []]
+    (if-let [message (first remaining)]
+      (let [tool-call-ids (seq (assistant-tool-call-ids message))]
+        (if (and (= "assistant" (:role message)) tool-call-ids)
+          (let [[tool-results tail] (split-with tool-result-message? (rest remaining))
+                present-ids         (into #{} (keep tool-result-id) tool-results)
+                missing-results     (->> tool-call-ids
+                                         (remove present-ids)
+                                         (mapv #(interrupted-tool-result % (:timestamp message))))]
+            (recur tail (into repaired (concat [message] tool-results missing-results))))
+          (recur (next remaining) (conj repaired message))))
+      repaired)))
+
 (defn journal->provider-messages
   "Project persisted journal entries into agent/provider message maps.
    :message entries become provider messages directly.
-   :logprobs entries are persisted but not projected into provider messages."
+   :logprobs entries are persisted but not projected into provider messages.
+   Dangling assistant tool uses are repaired with synthetic error tool results
+   in the provider-facing projection so interrupted sessions remain usable."
   [journal]
-  (into []
-        (keep (fn [entry]
-                (when (= :message (:kind entry))
-                  (get-in entry [:data :message]))))
-        journal))
+  (repair-dangling-tool-uses
+   (into []
+         (keep (fn [entry]
+                 (when (= :message (:kind entry))
+                   (get-in entry [:data :message]))))
+         journal)))
 
 (defn session->provider-messages
   "Project the persisted journal for `session-id` into provider-visible messages."

--- a/components/agent-session/src/psi/agent_session/prompt_request.clj
+++ b/components/agent-session/src/psi/agent_session/prompt_request.clj
@@ -39,6 +39,45 @@
    :is-error true
    :timestamp (or timestamp (java.time.Instant/now))})
 
+(defn dangling-tool-result-repairs
+  "Return synthetic error toolResult messages needed to repair dangling
+   assistant tool-call blocks.
+
+   A dangling block is an assistant message with one or more tool calls not
+   fully covered by the immediately following contiguous toolResult messages."
+  [messages]
+  (loop [remaining (seq messages)
+         repairs   []]
+    (if-let [message (first remaining)]
+      (let [tool-call-ids (seq (assistant-tool-call-ids message))]
+        (if (and (= "assistant" (:role message)) tool-call-ids)
+          (let [[tool-results tail] (split-with tool-result-message? (rest remaining))
+                present-ids         (into #{} (keep tool-result-id) tool-results)
+                missing-results     (->> tool-call-ids
+                                         (remove present-ids)
+                                         (mapv #(interrupted-tool-result % (:timestamp message))))]
+            (recur tail (into repairs missing-results)))
+          (recur (next remaining) repairs)))
+      repairs)))
+
+(defn tail-dangling-tool-result-repairs
+  "Return synthetic error toolResult messages needed to repair a dangling tail
+   tool-use before appending a later user message to the journal.
+
+   This only repairs the final assistant tool-use segment at the end of the
+   current history, preserving immediate adjacency in the persisted journal."
+  [messages]
+  (let [[trailing-tool-results reversed-prefix] (split-with tool-result-message? (rseq (vec messages)))
+        assistant-msg                           (first reversed-prefix)]
+    (if (and assistant-msg
+             (= "assistant" (:role assistant-msg))
+             (seq (assistant-tool-call-ids assistant-msg)))
+      (let [present-ids (into #{} (keep tool-result-id) trailing-tool-results)]
+        (->> (assistant-tool-call-ids assistant-msg)
+             (remove present-ids)
+             (mapv #(interrupted-tool-result % (:timestamp assistant-msg)))))
+      [])))
+
 (defn- repair-dangling-tool-uses
   "Ensure every assistant tool-call block is followed by corresponding
    contiguous toolResult messages before any later non-toolResult message.

--- a/components/agent-session/src/psi/agent_session/session_close.clj
+++ b/components/agent-session/src/psi/agent_session/session_close.clj
@@ -8,7 +8,9 @@
   (:require
    [com.fulcrologic.statecharts :as sc]
    [com.fulcrologic.statecharts.protocols :as sp]
+   [psi.agent-core.core :as agent]
    [psi.agent-session.dispatch :as dispatch]
+   [psi.agent-session.tools :as tools]
    [psi.session-state.state :as ss]))
 
 (defn- next-active-session-id
@@ -38,6 +40,35 @@
                           {:session-id session-id
                            :schedule-id schedule-id}
                           {:origin :core})))
+  true)
+
+(defn- interrupted-tool-result-message
+  [tool-call-id]
+  {:role "toolResult"
+   :tool-call-id tool-call-id
+   :tool-name "interrupted"
+   :content [{:type :text
+              :text "Tool execution interrupted before completion."}]
+   :is-error true
+   :timestamp (java.time.Instant/now)})
+
+(defn- repair-pending-tool-calls-before-close!
+  [ctx session-id]
+  (when-let [agent-ctx (ss/agent-ctx-in ctx session-id)]
+    (doseq [tool-call-id (:pending-tool-calls (agent/get-data-in agent-ctx))]
+      (let [message (interrupted-tool-result-message tool-call-id)]
+        (dispatch/dispatch! ctx
+                            :session/tool-agent-record-result
+                            {:session-id session-id
+                             :tool-result-msg message}
+                            {:origin :core}))))
+  true)
+
+(defn- abort-session-runtime!
+  [ctx session-id]
+  (when-let [agent-ctx (ss/agent-ctx-in ctx session-id)]
+    (agent/abort-in! agent-ctx))
+  (tools/abort-bash!)
   true)
 
 (defn- remove-session-state!
@@ -71,6 +102,8 @@
                                   keys
                                   vec)
           _                  (cancel-owned-schedules! ctx session-id sd)
+          _                  (abort-session-runtime! ctx session-id)
+          _                  (repair-pending-tool-calls-before-close! ctx session-id)
           _                  (doseq [schedule-id owned-schedule-ids]
                                (interrupt-scheduler-timer! ctx schedule-id))
           _                  (when sc-session-id

--- a/components/agent-session/src/psi/agent_session/turn.clj
+++ b/components/agent-session/src/psi/agent_session/turn.clj
@@ -198,10 +198,36 @@
        :pending? (boolean (:interrupt-pending sd))
        :dropped-steering-text ""})))
 
+(defn- interrupted-tool-result-message
+  [tool-call-id reason]
+  {:role "toolResult"
+   :tool-call-id tool-call-id
+   :tool-name "interrupted"
+   :content [{:type :text
+              :text (str "Tool execution interrupted before completion."
+                         (when reason
+                           (str " Reason: " (name reason) ".")))}]
+   :is-error true
+   :details {:interruption {:reason reason}}
+   :timestamp (java.time.Instant/now)})
+
+(defn- record-pending-tool-call-interrupts!
+  [ctx session-id reason]
+  (let [agent-ctx (ss/agent-ctx-in ctx session-id)
+        pending   (vec (or (some-> agent-ctx agent/get-data-in :pending-tool-calls) #{}))]
+    (doseq [tool-call-id pending]
+      (dispatch/dispatch! ctx
+                          :session/tool-agent-record-result
+                          {:session-id session-id
+                           :tool-result-msg (interrupted-tool-result-message tool-call-id reason)}
+                          {:origin :core}))
+    pending))
+
 (defn abort-in!
   "Abort the current agent run immediately for `session-id`. Prefer
    `request-interrupt-in!` for deferred semantics."
   [ctx session-id]
+  (record-pending-tool-call-interrupts! ctx session-id :user-abort)
   (turn-runtime/abort-active-turn-in! ctx session-id)
   (dispatch/dispatch! ctx :session/abort {:session-id session-id} {:origin :core}))
 

--- a/components/agent-session/src/psi/agent_session/turn.clj
+++ b/components/agent-session/src/psi/agent_session/turn.clj
@@ -189,13 +189,16 @@
                             :session/request-interrupt
                             {:session-id       session-id
                              :already-pending? already-pending?
-                             :requested-at     (java.time.Instant/now)}
+                             :requested-at     (java.time.Instant/now)
+                             :reason           :deferred-interrupt}
                             {:origin :core})
         {:accepted? (not already-pending?)
          :pending? true
+         :reason :deferred-interrupt
          :dropped-steering-text dropped-text})
       {:accepted? false
        :pending? (boolean (:interrupt-pending sd))
+       :reason (:interrupt-reason sd)
        :dropped-steering-text ""})))
 
 (defn- interrupted-tool-result-message

--- a/components/agent-session/src/psi/agent_session/turn.clj
+++ b/components/agent-session/src/psi/agent_session/turn.clj
@@ -10,8 +10,10 @@
    [psi.agent-session.dispatch :as dispatch]
    [psi.session-persistence.core :as persist]
    [psi.agent-session.runtime :as runtime]
+   [psi.agent-session.statechart :as session-sc]
    [psi.session-state.state :as ss]
-   [psi.turn-runtime.core :as turn-runtime]))
+   [psi.turn-runtime.core :as turn-runtime]
+   [psi.turn-runtime.stream :as turn-stream]))
 
 (defn execute-prepared-request!
   [ai-ctx ctx session-id prepared-request progress-queue]
@@ -48,10 +50,40 @@
        distinct
        (str/join "\n")))
 
+(defn- active-stream-handle?
+  [turn-ctx]
+  (boolean
+   (when-let [stream-handle (some-> turn-ctx :turn-data deref :stream-handle)]
+     (not (turn-stream/cancelled-stream-handle? stream-handle)))))
+
+(defn- stranded-streaming-session?
+  [ctx session-id]
+  (let [phase    (ss/sc-phase-in ctx session-id)
+        turn-ctx (ss/get-state-value-in ctx (ss/state-path :turn-ctx session-id))
+        agent-ctx (ss/agent-ctx-in ctx session-id)
+        pending  (or (some-> agent-ctx agent/get-data-in :pending-tool-calls) #{})]
+    (and (= :streaming phase)
+         (not (active-stream-handle? turn-ctx))
+         (empty? pending))))
+
+(defn- recover-stranded-streaming-session!
+  [ctx session-id]
+  (when (stranded-streaming-session? ctx session-id)
+    (when-let [sc-env (:sc-env ctx)]
+      (when-let [sc-session-id (ss/sc-session-id-in ctx session-id)]
+        ;; Recover via the explicit streaming -> idle abort transition rather
+        ;; than synthesizing an :agent-end event through guards that expect a
+        ;; fully populated live turn context.
+        (session-sc/send-event! sc-env sc-session-id :session/abort nil)))
+    (dispatch/dispatch! ctx :on-abort {:session-id session-id} {:origin :core})
+    true))
+
 (defn prompt-dispatch!
   [ctx session-id text images opts]
+  (recover-stranded-streaming-session! ctx session-id)
   (when-not (ss/idle-in? ctx session-id)
-    (throw (ex-info "Session is not idle" {:phase (ss/sc-phase-in ctx session-id)})))
+    (throw (ex-info "Session is not idle" {:phase (ss/sc-phase-in ctx session-id)
+                                           :recovered-stranded-streaming? false})))
   (let [user-msg {:role      "user"
                   :content   (cond-> [{:type :text :text text}]
                                images (into images))
@@ -113,26 +145,38 @@
   (dispatch/dispatch! ctx :session/enqueue-follow-up-message {:session-id session-id :text text} {:origin :core}))
 
 (defn queue-while-streaming-in!
-  "Queue prompt text while streaming for `session-id`."
+  "Queue prompt text while streaming for `session-id`.
+   If the session is stranded in :streaming with no live turn and no pending
+   tool calls, recover it first and treat the input as a normal prompt-ready
+   session."
   [ctx session-id text behavior]
-  (let [sd                 (ss/get-session-data-in ctx session-id)
-        interrupt-pending? (boolean (:interrupt-pending sd))
-        mode               (cond
-                             interrupt-pending? :coerced-follow-up
-                             (= behavior :steer) :steer
-                             :else :queue)]
-    (case mode
-      :steer
-      (do (steer-in! ctx session-id text)
-          {:accepted? true :behavior :steer})
+  (let [recovered?          (boolean (recover-stranded-streaming-session! ctx session-id))
+        phase               (ss/sc-phase-in ctx session-id)
+        sd                  (ss/get-session-data-in ctx session-id)
+        interrupt-pending?  (boolean (:interrupt-pending sd))]
+    (if (= :streaming phase)
+      (let [mode (cond
+                   interrupt-pending? :coerced-follow-up
+                   (= behavior :steer) :steer
+                   :else :queue)]
+        (case mode
+          :steer
+          (do (steer-in! ctx session-id text)
+              {:accepted? true :behavior :steer :recovered? recovered?})
 
-      (:queue :coerced-follow-up)
-      (do (follow-up-in! ctx session-id text)
-          {:accepted? true :behavior (if interrupt-pending? :coerced-follow-up :queue)}))))
+          (:queue :coerced-follow-up)
+          (do (follow-up-in! ctx session-id text)
+              {:accepted? true
+               :behavior (if interrupt-pending? :coerced-follow-up :queue)
+               :recovered? recovered?})))
+      {:accepted? false
+       :behavior :not-streaming
+       :recovered? recovered?})))
 
 (defn request-interrupt-in!
   "Request a deferred interrupt at the next turn boundary for `session-id`."
   [ctx session-id]
+  (recover-stranded-streaming-session! ctx session-id)
   (let [phase (ss/sc-phase-in ctx session-id)
         sd    (ss/get-session-data-in ctx session-id)]
     (if (= :streaming phase)

--- a/components/agent-session/test/psi/agent_session/model_dispatch_test.clj
+++ b/components/agent-session/test/psi/agent_session/model_dispatch_test.clj
@@ -332,6 +332,7 @@
       (test-support/update-state! ctx :session-data assoc
                                   :interrupt-pending false
                                   :steering-messages ["queued steer"])
+      (swap! (:data-atom (ss/agent-ctx-in ctx session-id)) assoc :pending-tool-calls #{"tc-interrupt-test"})
       ;; Force streaming deterministically so interrupt behavior does not depend
       ;; on prompt runtime timing.
       (sc/send-event! (:sc-env ctx)
@@ -342,6 +343,7 @@
       (let [sd    (ss/get-session-data-in ctx session-id)
             entry (last (kernel/event-log-entries))]
         (is (true? (:interrupt-pending sd)))
+        (is (= :deferred-interrupt (:interrupt-reason sd)))
         (is (= [] (:steering-messages sd)))
         (is (instance? java.time.Instant (:interrupt-requested-at sd)))
         (is (= :session/request-interrupt (:event-type entry)))

--- a/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
@@ -226,6 +226,39 @@
       (is (= [session-id] @sync-calls)
           "prompt-in! should run git-head sync after a normal prompt turn"))))
 
+(deftest stranded-streaming-session-recovers-on-next-prompt-test
+  (let [[ctx session-id] (create-session-context {:persist? false})]
+    (session/dispatch-in! ctx :session/prompt {:session-id session-id} {:origin :core})
+    (session/dispatch-in! ctx :on-streaming-entered {:session-id session-id} {:origin :statechart})
+    (is (= :streaming (ss/sc-phase-in ctx session-id)))
+    (is (true? (:is-streaming (ss/get-session-data-in ctx session-id))))
+    (with-redefs [psi.turn-runtime.core/execute-prepared-request!
+                  (fn [_ai-ctx _ctx sid prepared _pq]
+                    {:execution-result/turn-id (:prepared-request/id prepared)
+                     :execution-result/session-id sid
+                     :execution-result/assistant-message {:role "assistant"
+                                                          :content [{:type :text :text "recovered"}]
+                                                          :stop-reason :stop
+                                                          :timestamp (java.time.Instant/now)}
+                     :execution-result/turn-outcome :turn.outcome/stop
+                     :execution-result/tool-calls []
+                     :execution-result/stop-reason :stop})]
+      (session/prompt-in! ctx session-id "hello after stall"))
+    (is (= :idle (ss/sc-phase-in ctx session-id)))
+    (is (false? (:is-streaming (ss/get-session-data-in ctx session-id))))
+    (is (= ["user" "assistant"] (mapv :role (journal-messages ctx session-id))))))
+
+(deftest queue-while-streaming-recovers-stranded-session-test
+  (let [[ctx session-id] (create-session-context {:persist? false})]
+    (session/dispatch-in! ctx :session/prompt {:session-id session-id} {:origin :core})
+    (session/dispatch-in! ctx :on-streaming-entered {:session-id session-id} {:origin :statechart})
+    (let [result (session/queue-while-streaming-in! ctx session-id "nudge" :steer)]
+      (is (= false (:accepted? result)))
+      (is (= :not-streaming (:behavior result)))
+      (is (true? (:recovered? result)))
+      (is (= :idle (ss/sc-phase-in ctx session-id)))
+      (is (= [] (:steering-messages (ss/get-session-data-in ctx session-id)))))))
+
 (deftest abort-cancels-active-prompt-runtime-test
   (let [[ctx session-id] (create-session-context {:persist? false})
         started (promise)

--- a/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
@@ -10,6 +10,7 @@
    [psi.agent-session.runtime :as runtime]
    [psi.agent-session.turn]
    [psi.state-kernel.dispatch :as kernel]
+   [psi.session-persistence.core]
    [psi.session-state.state :as ss]
    [psi.agent-session.test-support :as test-support]
    [clojure.java.io :as io]
@@ -67,6 +68,32 @@
       (is (= 3 (count effects)))
       (is (= [:session/prompt-submit :session/prompt :session/prompt-prepare-request]
              (mapv :event-type effects))))))
+
+(deftest prompt-submit-handler-adds-tail-repair-effect-before-user-message-test
+  (let [[ctx session-id] (create-session-context {:persist? false})
+        assistant-msg {:role "assistant"
+                       :content [{:type :tool-call :id "tc-tail" :name "bash" :arguments "{}"}]
+                       :stop-reason :tool_use
+                       :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+        user-msg {:role "user"
+                  :content [{:type :text :text "status?"}]
+                  :timestamp (java.time.Instant/now)}]
+    (session/dispatch-in! ctx :session/append-journal-entry
+                          {:session-id session-id
+                           :entry (psi.session-persistence.core/message-entry assistant-msg)}
+                          {:origin :core})
+    (let [handler-result ((:fn (kernel/handler-entry :session/prompt-submit))
+                          ctx
+                          {:session-id session-id
+                           :user-msg user-msg})
+          effects (:effects handler-result)]
+      (is (= 2 (count effects)))
+      (is (= :runtime/dispatch-event (-> effects first :effect/type)))
+      (is (= "toolResult" (get-in (first effects) [:event-data :entry :data :message :role])))
+      (is (= "tc-tail" (get-in (first effects) [:event-data :entry :data :message :tool-call-id])))
+      (is (= :runtime/dispatch-event (-> effects second :effect/type)))
+      (is (= "user" (get-in (second effects) [:event-data :entry :data :message :role])))
+      (is (= 1 (get-in handler-result [:return :repaired-tool-result-count]))))))
 
 (deftest prompt-record-response-appends-assistant-once-test
   (let [[ctx session-id] (create-session-context {:persist? false})
@@ -350,41 +377,27 @@
 
 (deftest queued-steering-is-injected-into-continuation-prepared-request-test
   (let [[ctx session-id] (create-session-context {:persist? false})
-        assistant-msg    {:role "assistant"
-                          :content [{:type :tool-call :id "tc-1" :name "read" :arguments "{}"}]
-                          :stop-reason :stop
-                          :timestamp (java.time.Instant/now)}
-        execution-result {:execution-result/turn-id "turn-1"
-                          :execution-result/session-id session-id
-                          :execution-result/assistant-message assistant-msg
-                          :execution-result/turn-outcome :turn.outcome/tool-use
-                          :execution-result/tool-calls [{:id "tc-1" :name "read" :arguments "{}"}]
-                          :execution-result/stop-reason :stop}
-        tool-result-msg  {:role "toolResult"
-                          :tool-call-id "tc-1"
-                          :tool-name "read"
-                          :content [{:type :text :text "file body"}]
-                          :timestamp (java.time.Instant/now)}]
+        user-msg        {:role "user"
+                         :content [{:type :text :text "hi"}]
+                         :timestamp (java.time.Instant/now)}
+        assistant-msg   {:role "assistant"
+                         :content [{:type :tool-call :id "tc-1" :name "read" :arguments "{}"}]
+                         :stop-reason :stop
+                         :timestamp (java.time.Instant/now)}
+        tool-result-msg {:role "toolResult"
+                         :tool-call-id "tc-1"
+                         :tool-name "read"
+                         :content [{:type :text :text "file body"}]
+                         :timestamp (java.time.Instant/now)}]
     (session/dispatch-in! ctx :session/bootstrap-prompt-state
                           {:session-id session-id
                            :system-prompt "sys"}
                           {:origin :core})
-    (session/dispatch-in! ctx :session/prompt-submit
-                          {:session-id session-id
-                           :user-msg {:role "user"
-                                      :content [{:type :text :text "hi"}]
-                                      :timestamp (java.time.Instant/now)}}
-                          {:origin :core})
-    (with-redefs [psi.agent-session.prompt-chain/run-prompt-tools! (fn [_ctx _sid _res _pq]
-                                                                     {:continued? true :tool-call-count 1})]
-      (session/dispatch-in! ctx :session/prompt-record-response
+    (doseq [message [user-msg assistant-msg tool-result-msg]]
+      (session/dispatch-in! ctx :session/append-journal-entry
                             {:session-id session-id
-                             :execution-result execution-result}
+                             :entry (psi.session-persistence.core/message-entry message)}
                             {:origin :core}))
-    (session/dispatch-in! ctx :session/tool-record-result
-                          {:session-id session-id
-                           :shaped-result {:result-message tool-result-msg}}
-                          {:origin :core})
     (session/dispatch-in! ctx :session/enqueue-steering-message
                           {:session-id session-id
                            :text "Please be brief."}

--- a/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
+   [psi.agent-session.dispatch]
    [psi.agent-session.extensions]
    [psi.agent-session.prompt-chain]
    [psi.agent-session.prompt-request]
@@ -258,6 +259,24 @@
       (is (true? (:recovered? result)))
       (is (= :idle (ss/sc-phase-in ctx session-id)))
       (is (= [] (:steering-messages (ss/get-session-data-in ctx session-id)))))))
+
+(deftest abort-records-interrupted-tool-results-with-reason-test
+  (let [[ctx session-id] (create-session-context {:persist? false})
+        agent-ctx        (ss/agent-ctx-in ctx session-id)
+        appended*        (atom [])]
+    (swap! (:data-atom agent-ctx) assoc :pending-tool-calls #{"tc-abort"})
+    (with-redefs [psi.agent-session.dispatch/dispatch!
+                  (let [orig psi.agent-session.dispatch/dispatch!]
+                    (fn [ctx event-type event-data opts]
+                      (when (= :session/tool-agent-record-result event-type)
+                        (swap! appended* conj (:tool-result-msg event-data)))
+                      (orig ctx event-type event-data opts)))]
+      (session/abort-in! ctx session-id))
+    (is (= 1 (count @appended*)))
+    (is (= "tc-abort" (:tool-call-id (first @appended*))))
+    (is (true? (:is-error (first @appended*))))
+    (is (= :user-abort (get-in (first @appended*) [:details :interruption :reason])))
+    (is (str/includes? (get-in (first @appended*) [:content 0 :text]) "Reason: user-abort."))))
 
 (deftest abort-cancels-active-prompt-runtime-test
   (let [[ctx session-id] (create-session-context {:persist? false})

--- a/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
@@ -278,6 +278,27 @@
     (is (= :user-abort (get-in (first @appended*) [:details :interruption :reason])))
     (is (str/includes? (get-in (first @appended*) [:content 0 :text]) "Reason: user-abort."))))
 
+(deftest deferred-interrupt-records-interrupted-tool-results-with-reason-test
+  (let [[ctx session-id] (create-session-context {:persist? false})
+        agent-ctx        (ss/agent-ctx-in ctx session-id)
+        appended*        (atom [])]
+    (session/dispatch-in! ctx :session/prompt {:session-id session-id} {:origin :core})
+    (session/dispatch-in! ctx :on-streaming-entered {:session-id session-id} {:origin :statechart})
+    (swap! (:data-atom agent-ctx) assoc :pending-tool-calls #{"tc-interrupt"})
+    (session/request-interrupt-in! ctx session-id)
+    (with-redefs [psi.agent-session.dispatch/dispatch!
+                  (let [orig psi.agent-session.dispatch/dispatch!]
+                    (fn [ctx event-type event-data opts]
+                      (when (= :session/tool-agent-record-result event-type)
+                        (swap! appended* conj (:tool-result-msg event-data)))
+                      (orig ctx event-type event-data opts)))]
+      (session/dispatch-in! ctx :on-agent-done {:session-id session-id} {:origin :statechart}))
+    (is (= 1 (count @appended*)))
+    (is (= "tc-interrupt" (:tool-call-id (first @appended*))))
+    (is (true? (:is-error (first @appended*))))
+    (is (= :deferred-interrupt (get-in (first @appended*) [:details :interruption :reason])))
+    (is (str/includes? (get-in (first @appended*) [:content 0 :text]) "Reason: deferred-interrupt."))))
+
 (deftest abort-cancels-active-prompt-runtime-test
   (let [[ctx session-id] (create-session-context {:persist? false})
         started (promise)

--- a/components/agent-session/test/psi/agent_session/prompt_request_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_request_test.clj
@@ -216,3 +216,24 @@
                       (persist/message-entry later-user)])]
       (is (= ["assistant" "toolResult" "user"] (mapv :role messages)))
       (is (= "done" (get-in (second messages) [:content 0 :text]))))))
+
+(deftest tail-dangling-tool-result-repairs-test
+  (testing "returns repair for dangling trailing assistant tool call"
+    (let [assistant {:role "assistant"
+                     :content [{:type :tool-call :id "call-tail" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          repairs   (prompt-request/tail-dangling-tool-result-repairs [assistant])]
+      (is (= 1 (count repairs)))
+      (is (= "call-tail" (:tool-call-id (first repairs))))
+      (is (true? (:is-error (first repairs))))))
+
+  (testing "returns no repair when trailing tool result already exists"
+    (let [assistant {:role "assistant"
+                     :content [{:type :tool-call :id "call-tail" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          result    {:role "toolResult"
+                     :tool-call-id "call-tail"
+                     :tool-name "bash"
+                     :content [{:type :text :text "done"}]}
+          repairs   (prompt-request/tail-dangling-tool-result-repairs [assistant result])]
+      (is (= [] repairs)))))

--- a/components/agent-session/test/psi/agent_session/prompt_request_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_request_test.clj
@@ -3,7 +3,8 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [psi.ai.model-registry :as model-registry]
-   [psi.agent-session.prompt-request :as prompt-request]))
+   [psi.agent-session.prompt-request :as prompt-request]
+   [psi.session-persistence.core :as persist]))
 
 ;; ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -181,3 +182,37 @@
       (is (nil? (:api-key opts)))
       (is (nil? (:no-auth-header opts)))
       (is (nil? (:headers opts))))))
+
+(deftest journal->provider-messages-repairs-dangling-tool-use-test
+  (testing "missing tool result is repaired with synthetic error toolResult before later messages"
+    (let [assistant {:role "assistant"
+                     :content [{:type :text :text "working"}
+                               {:type :tool-call :id "call-1" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          later-user {:role "user"
+                      :content [{:type :text :text "status?"}]}
+          messages (prompt-request/journal->provider-messages
+                    [(persist/message-entry assistant)
+                     (persist/message-entry later-user)])]
+      (is (= ["assistant" "toolResult" "user"] (mapv :role messages)))
+      (is (= "call-1" (:tool-call-id (second messages))))
+      (is (true? (:is-error (second messages))))
+      (is (= "Tool execution interrupted before completion."
+             (get-in (second messages) [:content 0 :text])))))
+
+  (testing "existing contiguous tool result is preserved and no synthetic repair is added"
+    (let [assistant {:role "assistant"
+                     :content [{:type :tool-call :id "call-1" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          result    {:role "toolResult"
+                     :tool-call-id "call-1"
+                     :tool-name "bash"
+                     :content [{:type :text :text "done"}]}
+          later-user {:role "user"
+                      :content [{:type :text :text "status?"}]}
+          messages  (prompt-request/journal->provider-messages
+                     [(persist/message-entry assistant)
+                      (persist/message-entry result)
+                      (persist/message-entry later-user)])]
+      (is (= ["assistant" "toolResult" "user"] (mapv :role messages)))
+      (is (= "done" (get-in (second messages) [:content 0 :text]))))))

--- a/components/agent-session/test/psi/agent_session/session_close_test.clj
+++ b/components/agent-session/test/psi/agent_session/session_close_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
+   [psi.agent-session.dispatch :as dispatch]
    [psi.agent-session.statechart :as sc]
    [psi.agent-session.test-support :as test-support]
    [psi.session-state.state :as ss]))
@@ -81,6 +82,23 @@
       (session/close-session-in! ctx session-id)
       ;; After close: working memory is gone, sc-phase returns nil
       (is (nil? (sc/sc-phase (:sc-env ctx) sc-session-id))))))
+
+(deftest close-session-records-interrupted-tool-results-for-pending-calls-test
+  (testing "close-session-in! appends interrupted tool results before session removal side effects complete"
+    (let [[ctx session-id] (create-session-context {:persist? false})
+          agent-ctx        (ss/agent-ctx-in ctx session-id)
+          appended*        (atom [])]
+      (swap! (:data-atom agent-ctx) assoc :pending-tool-calls #{"tc-pending"})
+      (with-redefs [dispatch/dispatch!
+                    (let [orig dispatch/dispatch!]
+                      (fn [ctx event-type event-data opts]
+                        (when (= :session/tool-agent-record-result event-type)
+                          (swap! appended* conj (:tool-result-msg event-data)))
+                        (orig ctx event-type event-data opts)))]
+        (session/close-session-in! ctx session-id))
+      (is (= 1 (count @appended*)))
+      (is (= "tc-pending" (:tool-call-id (first @appended*))))
+      (is (true? (:is-error (first @appended*)))))))
 
 (deftest close-session-tree-closes-all-descendants-test
   (testing "close-session-tree-in! closes all descendants then the root"

--- a/components/agent-session/test/psi/agent_session/statechart_actions_test.clj
+++ b/components/agent-session/test/psi/agent_session/statechart_actions_test.clj
@@ -71,6 +71,7 @@
   (let [[ctx session-id] (test-support/make-session-ctx {:session-data {:is-streaming false
                                                                         :retry-attempt 3
                                                                         :interrupt-pending true
+                                                                        :interrupt-reason :deferred-interrupt
                                                                         :interrupt-requested-at #inst "2026-01-01T00:00:00.000Z"}})]
     (with-registered-handlers
       ctx
@@ -86,12 +87,16 @@
              (is (= {:is-streaming false
                      :retry-attempt 0
                      :interrupt-pending false
-                     :interrupt-requested-at nil}
+                     :interrupt-requested-at nil
+                     :interrupt-reason nil}
                     (select-keys (session-state/get-session-data-in ctx session-id)
-                                 [:is-streaming :retry-attempt :interrupt-pending :interrupt-requested-at])))
+                                 [:is-streaming :retry-attempt :interrupt-pending :interrupt-requested-at :interrupt-reason])))
              (is (= [{:effect/type :runtime/mark-workflow-jobs-terminal}
                      {:effect/type :runtime/emit-background-job-terminal-messages}
-                     {:effect/type :scheduler/drain-queue}]
+                     {:effect/type :scheduler/drain-queue}
+                     {:effect/type :runtime/record-pending-tool-call-interrupts
+                      :session-id session-id
+                      :reason :deferred-interrupt}]
                     (:effects result)))))
 
          (testing "on-abort clears interrupt state and emits agent-abort effect"

--- a/components/session-state/src/psi/session_state/model.clj
+++ b/components/session-state/src/psi/session_state/model.clj
@@ -82,6 +82,9 @@
 (def response-mode-schema
   [:enum :streaming :non-streaming])
 
+(def interruption-reason-schema
+  [:enum :user-abort :deferred-interrupt :session-close :context-shutdown])
+
 (def prompt-component-schema
   [:enum :preamble :context-files :skills :runtime-metadata])
 
@@ -148,6 +151,7 @@
    [:is-compacting :boolean]
    [:interrupt-pending :boolean]
    [:interrupt-requested-at {:optional true} [:maybe inst?]]
+   [:interrupt-reason {:optional true} [:maybe interruption-reason-schema]]
    [:base-system-prompt :string]
    [:system-prompt :string]
    [:prompt-mode {:optional true} prompt-mode-schema]
@@ -237,6 +241,7 @@
      :is-streaming            false
      :is-compacting           false
      :interrupt-pending       false
+     :interrupt-reason        nil
      :interrupt-requested-at  nil
      :base-system-prompt      ""
      :system-prompt           ""


### PR DESCRIPTION
## Summary
- repair interrupted tool-call history for Anthropic transcript validity
- close pending tool calls during runtime teardown and explicit aborts
- recover stranded streaming sessions before prompt dispatch
- preserve interruption reasons across deferred interrupts

## Problem
Long-running or interrupted tool calls could leave the session in an inconsistent state:
- Anthropic would reject history with `tool_use` blocks not followed by `tool_result`
- sessions could become stranded in `:streaming`, causing `Session is not idle`
- explicit/deferred interruption paths lost the reason for interruption

## Changes
### Transcript/runtime recovery
- repair dangling assistant tool-use blocks in provider-facing message projection
- repair dangling tail tool-use before appending later user prompts

### Runtime lifecycle hardening
- track pending tool-call ids in agent-core
- clear pending tool-call ids when tool results are recorded
- close pending tool calls before session teardown/shutdown
- record pending tool-call interruption results immediately on explicit abort

### Stranded session recovery
- detect `:streaming` sessions with no live stream handle and no pending tool calls
- recover them before prompt dispatch / queue-while-streaming / interrupt request handling

### Interruption reason propagation
- persist `:interrupt-reason` in session state
- carry `:deferred-interrupt` through request-interrupt
- emit compensating tool results with structured interruption details and user-visible reason text

## Verification
- focused tests for prompt lifecycle, model dispatch, statechart actions, session close, and agent-core tool lifecycle
- clj-kondo clean on touched files
