### PR TITLE
Fix local OpenAI-compatible usage capture for streaming and non-streaming

### DIFF
--- a/.psi/extensions.edn
+++ b/.psi/extensions.edn
@@ -1,6 +1,7 @@
 {:deps
  {psi/auto-session-name {}
   psi/commit-checks     {}
+  psi/edit-clj          {}
   psi/github            {}
   psi/logprobs          {}
   psi/mementum          {}

--- a/.psi/extensions.edn
+++ b/.psi/extensions.edn
@@ -6,4 +6,5 @@
   psi/logprobs          {}
   psi/mementum          {}
   psi/munera            {}
-  psi/work-on           {}}}
+  psi/work-on           {}
+  psi/metrics           {}}}

--- a/bases/main/src/psi/launcher/extensions.clj
+++ b/bases/main/src/psi/launcher/extensions.clj
@@ -85,6 +85,13 @@
      :installed   {:local/root "extensions/logprobs"}
      :jar         {:mvn/version :psi/release-version}}}
 
+   'psi/metrics
+   {:psi/init 'psi.metrics.extension/init
+    :source-policies
+    {:development {:local/root "extensions/metrics"}
+     :installed   {:local/root "extensions/metrics"}
+     :jar         {:mvn/version :psi/release-version}}}
+
    'psi/work-on
    {:psi/init 'extensions.work-on/init
     :source-policies

--- a/bases/main/src/psi/launcher/extensions.clj
+++ b/bases/main/src/psi/launcher/extensions.clj
@@ -72,6 +72,12 @@
     {:development {:local/root "extensions/github"}
      :installed   {:local/root "extensions/github"}}}
 
+   'psi/edit-clj
+   {:psi/init 'psi.edit-clj.extension/init
+    :source-policies
+    {:development {:local/root "extensions/edit-clj"}
+     :installed   {:local/root "extensions/edit-clj"}}}
+
    'psi/logprobs
    {:psi/init 'extensions.logprobs/init
     :source-policies

--- a/components/agent-core/src/psi/agent_core/core.clj
+++ b/components/agent-core/src/psi/agent_core/core.clj
@@ -396,9 +396,15 @@
     data))
 
 (defn record-tool-result-in!
-  "Append a tool result message and emit message_start / message_end."
+  "Append a tool result message, clear its pending tool-call id, and emit
+   message_start / message_end."
   [ctx tool-result-msg]
-  (let [data (swap-data! ctx update :messages conj tool-result-msg)]
+  (let [tool-call-id (:tool-call-id tool-result-msg)
+        data         (swap-data! ctx
+                                 (fn [d]
+                                   (cond-> (update d :messages conj tool-result-msg)
+                                     tool-call-id
+                                     (update :pending-tool-calls disj tool-call-id))))]
     (emit-in! ctx {:type :message-start :message tool-result-msg})
     (emit-in! ctx {:type :message-end   :message tool-result-msg})
     data))
@@ -412,16 +418,19 @@
   (get-data-in ctx))
 
 (defn emit-tool-start-in!
-  "Emit tool_execution_start for `tool-call`."
+  "Emit tool_execution_start for `tool-call` and mark it pending."
   [ctx tool-call]
-  (emit-in! ctx {:type         :tool-execution-start
-                 :tool-call-id (:id tool-call)
-                 :tool-name    (:name tool-call)
-                 :args         (:arguments tool-call)})
-  (get-data-in ctx))
+  (let [tool-call-id (:id tool-call)]
+    (swap-data! ctx update :pending-tool-calls (fnil conj #{}) tool-call-id)
+    (emit-in! ctx {:type         :tool-execution-start
+                   :tool-call-id tool-call-id
+                   :tool-name    (:name tool-call)
+                   :args         (:arguments tool-call)})
+    (get-data-in ctx)))
 
 (defn emit-tool-end-in!
-  "Emit tool_execution_end for `tool-call` with `result` and `is-error?`."
+  "Emit tool_execution_end for `tool-call` with `result` and `is-error?`.
+   Pending state is cleared when the tool result is recorded."
   [ctx tool-call result is-error?]
   (emit-in! ctx {:type         :tool-execution-end
                  :tool-call-id (:id tool-call)

--- a/components/agent-core/test/psi/agent_core/core_test.clj
+++ b/components/agent-core/test/psi/agent_core/core_test.clj
@@ -359,12 +359,13 @@
   (let [call {:id "call-1" :name "bash" :arguments "{}"}
         res  {:content [{:type :text :text "ok"}]}]
 
-    (testing "emit-tool-start-in! emits tool_execution_start event"
+    (testing "emit-tool-start-in! emits tool_execution_start event and marks the call pending"
       (let [ctx (agent/create-context)]
         (agent/create-agent-in! ctx)
         (agent/emit-tool-start-in! ctx call)
         (let [events (agent/drain-events-in! ctx)]
-          (is (some #(= :tool-execution-start (:type %)) events)))))
+          (is (some #(= :tool-execution-start (:type %)) events))
+          (is (= #{"call-1"} (:pending-tool-calls (agent/get-data-in ctx)))))))
 
     (testing "emit-tool-end-in! emits tool_execution_end event"
       (let [ctx (agent/create-context)]
@@ -381,13 +382,15 @@
         (let [events (agent/drain-events-in! ctx)]
           (is (some #(= :turn-end (:type %)) events)))))
 
-    (testing "record-tool-result-in! appends to messages and emits events"
+    (testing "record-tool-result-in! appends to messages, emits events, and clears pending call"
       (let [ctx    (agent/create-context)
             result {:role "tool-result" :tool-call-id "c1" :tool-name "bash"
                     :content [] :is-error false}]
         (agent/create-agent-in! ctx)
+        (swap! (:data-atom ctx) assoc :pending-tool-calls #{"c1"})
         (agent/record-tool-result-in! ctx result)
         (is (= [result] (:messages (agent/get-data-in ctx))))
+        (is (= #{} (:pending-tool-calls (agent/get-data-in ctx))))
         (let [events (agent/drain-events-in! ctx)
               types  (map :type events)]
           (is (some #{:message-start} types))

--- a/components/agent-session/src/psi/agent_session/context.clj
+++ b/components/agent-session/src/psi/agent_session/context.clj
@@ -26,6 +26,7 @@
    [psi.agent-session.tool-plan :as tool-plan]
    [psi.agent-core.core :as agent-core]
    [psi.agent-session.session-runtime :as session-runtime]
+   [psi.agent-session.tools]
    [psi.agent-session.workflow-execution :as workflow-execution]
    [psi.agent-session.workflow-judge :as workflow-judge]
    [psi.workflow-runtime.child-session-contract :as workflow-child-session-contract]
@@ -314,6 +315,10 @@
 (defn shutdown-context! [ctx]
   (doseq [{:keys [session-id]} (ss/list-context-sessions-in ctx)]
     (dispatch/dispatch! ctx :scheduler/cancel-all {:session-id session-id} {:origin :core}))
+  (doseq [{:keys [session-id]} (ss/list-context-sessions-in ctx)]
+    (when-let [agent-ctx (ss/agent-ctx-in ctx session-id)]
+      (agent-core/abort-in! agent-ctx))
+    (psi.agent-session.tools/abort-bash!))
   (dispatch-effects/cancel-all-scheduler-timers!)
   (when-let [timers* (:scheduler-timers* ctx)]
     (reset! timers* {}))

--- a/components/agent-session/src/psi/agent_session/dispatch_effects.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_effects.clj
@@ -117,6 +117,28 @@
 (defmethod execute-effect! :runtime/agent-record-tool-result [ctx effect]
   (when-let [ac (effect-agent-ctx ctx effect)] (agent/record-tool-result-in! ac (:tool-result-msg effect))))
 
+(defmethod execute-effect! :runtime/record-pending-tool-call-interrupts [ctx effect]
+  (let [session-id (:session-id effect)
+        reason     (:reason effect)
+        agent-ctx  (effect-agent-ctx ctx effect)
+        pending    (vec (or (some-> agent-ctx agent/get-data-in :pending-tool-calls) #{}))]
+    (doseq [tool-call-id pending]
+      (dispatch/dispatch! ctx
+                          :session/tool-agent-record-result
+                          {:session-id session-id
+                           :tool-result-msg {:role "toolResult"
+                                             :tool-call-id tool-call-id
+                                             :tool-name "interrupted"
+                                             :content [{:type :text
+                                                        :text (str "Tool execution interrupted before completion."
+                                                                   (when reason
+                                                                     (str " Reason: " (name reason) ".")))}]
+                                             :is-error true
+                                             :details {:interruption {:reason reason}}
+                                             :timestamp (java.time.Instant/now)}}
+                          {:origin :core}))
+    {:recorded-count (count pending) :reason reason}))
+
 (defmethod execute-effect! :runtime/tool-execute [ctx effect]
   (try
     (try ((:execute-tool-runtime-fn ctx) ctx (:session-id effect) (:tool-name effect) (:args effect) (:opts effect))

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_lifecycle.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/prompt_lifecycle.clj
@@ -5,6 +5,7 @@
    `psi.agent-session.turn.handlers`; this namespace only registers dispatch handlers."
   (:require
    [psi.agent-session.journal-append-effect :as journal-append-effect]
+   [psi.agent-session.prompt-request :as prompt-request]
    [psi.session-persistence.core :as persist]
    [psi.session-state.state :as ss]
    [psi.state-kernel.dispatch :as kernel]
@@ -28,11 +29,23 @@
 
   (register-core-handler!
    :session/prompt-submit
-   (fn [_ctx {:keys [session-id user-msg]}]
-     {:effects [(journal-append-effect/append-message-effect session-id user-msg)]
-      :return {:submitted? true
-               :turn-id (str (java.util.UUID/randomUUID))
-               :user-msg user-msg}}))
+   (fn [ctx {:keys [session-id user-msg]}]
+     (let [journal  (persist/all-entries-in ctx session-id)
+           messages (into []
+                          (keep (fn [entry]
+                                  (when (= :message (:kind entry))
+                                    (get-in entry [:data :message]))))
+                          journal)
+           repairs  (prompt-request/tail-dangling-tool-result-repairs messages)
+           effects  (into []
+                          (concat
+                           (map #(journal-append-effect/append-message-effect session-id %) repairs)
+                           [(journal-append-effect/append-message-effect session-id user-msg)]))]
+       {:effects effects
+        :return {:submitted? true
+                 :turn-id (str (java.util.UUID/randomUUID))
+                 :user-msg user-msg
+                 :repaired-tool-result-count (count repairs)}})))
 
   (register-core-handler!
    :session/submit-synthetic-user-prompt

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/session_mutations.clj
@@ -449,13 +449,14 @@
 
   (register-core-handler!
    :session/request-interrupt
-   (fn [ctx {:keys [session-id already-pending? requested-at]}]
+   (fn [ctx {:keys [session-id already-pending? requested-at reason]}]
      (let [sd (session/get-session-data-in ctx session-id)]
        {:root-state-update
         (session/session-update session-id
                                 (fn [_]
                                   (cond-> (assoc sd
                                                  :interrupt-pending true
+                                                 :interrupt-reason (or reason :deferred-interrupt)
                                                  :steering-messages [])
                                     (not already-pending?)
                                     (assoc :interrupt-requested-at requested-at))))

--- a/components/agent-session/src/psi/agent_session/dispatch_handlers/statechart_actions.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_handlers/statechart_actions.clj
@@ -74,21 +74,29 @@
 
   (kernel/register-handler!
    :on-agent-done
-   (fn [_ctx {:keys [session-id]}]
-     {:root-state-update (session/session-update session-id #(assoc % :is-streaming false
-                                                                    :retry-attempt 0
-                                                                    :interrupt-pending false
-                                                                    :interrupt-requested-at nil))
-      :effects [{:effect/type :runtime/mark-workflow-jobs-terminal}
-                {:effect/type :runtime/emit-background-job-terminal-messages}
-                {:effect/type :scheduler/drain-queue}]}))
+   (fn [ctx {:keys [session-id]}]
+     (let [sd                 (session/get-session-data-in ctx session-id)
+           interruption-reason (:interrupt-reason sd)]
+       {:root-state-update (session/session-update session-id #(assoc % :is-streaming false
+                                                                      :retry-attempt 0
+                                                                      :interrupt-pending false
+                                                                      :interrupt-requested-at nil
+                                                                      :interrupt-reason nil))
+        :effects (cond-> [{:effect/type :runtime/mark-workflow-jobs-terminal}
+                          {:effect/type :runtime/emit-background-job-terminal-messages}
+                          {:effect/type :scheduler/drain-queue}]
+                   interruption-reason
+                   (into [{:effect/type :runtime/record-pending-tool-call-interrupts
+                           :session-id session-id
+                           :reason interruption-reason}]))})))
 
   (kernel/register-handler!
    :on-abort
    (fn [_ctx {:keys [session-id]}]
      {:root-state-update (session/session-update session-id #(assoc % :is-streaming false
                                                                     :interrupt-pending false
-                                                                    :interrupt-requested-at nil))
+                                                                    :interrupt-requested-at nil
+                                                                    :interrupt-reason nil))
       :effects [{:effect/type :runtime/agent-abort}
                 {:effect/type :scheduler/drain-queue}]}))
 

--- a/components/agent-session/src/psi/agent_session/dispatch_schema.clj
+++ b/components/agent-session/src/psi/agent_session/dispatch_schema.clj
@@ -58,6 +58,10 @@
      [:tool-call :map] [:result :any] [:is-error? :boolean]]]
    [:runtime/agent-record-tool-result
     [:map [:effect/type [:= :runtime/agent-record-tool-result]] [:tool-result-msg :map]]]
+   [:runtime/record-pending-tool-call-interrupts
+    [:map [:effect/type [:= :runtime/record-pending-tool-call-interrupts]]
+     [:session-id :string]
+     [:reason :keyword]]]
    [:runtime/tool-execute
     [:map [:effect/type [:= :runtime/tool-execute]]
      [:tool-name :string] [:args :map] [:opts {:optional true} [:maybe :map]]]]

--- a/components/agent-session/src/psi/agent_session/extension_installs.clj
+++ b/components/agent-session/src/psi/agent_session/extension_installs.clj
@@ -97,7 +97,9 @@
    'psi/logprobs {:psi/init 'extensions.logprobs/init
                   :source-policies {:installed {:local/root "extensions/logprobs"}}}
    'psi/work-on {:psi/init 'extensions.work-on/init
-                 :source-policies {:installed {:local/root "extensions/work-on"}}}})
+                 :source-policies {:installed {:local/root "extensions/work-on"}}}
+   'psi/metrics {:psi/init 'psi.metrics.extension/init
+                 :source-policies {:installed {:local/root "extensions/metrics"}}}})
 
 (defn- catalog-entry
   [lib]

--- a/components/agent-session/src/psi/agent_session/introspection.clj
+++ b/components/agent-session/src/psi/agent_session/introspection.clj
@@ -7,6 +7,7 @@
    [psi.agent-session.resolvers :as resolvers]
    [psi.session-state.model :as session]
    [psi.session-state.state :as ss]
+   [psi.turn-runtime.stream]
    [psi.agent-session.extension-workflow-runtime :as extension-workflow-runtime]))
 
 (defn replay-dispatch-event-log-in!
@@ -26,8 +27,12 @@
 (defn diagnostics-in
   "Return a diagnostic snapshot map."
   [ctx session-id]
-  (let [sd    (ss/get-session-data-in ctx session-id)
-        phase (ss/sc-phase-in ctx session-id)]
+  (let [sd          (ss/get-session-data-in ctx session-id)
+        phase       (ss/sc-phase-in ctx session-id)
+        turn-ctx    (ss/get-state-value-in ctx (ss/state-path :turn-ctx session-id))
+        stream-live? (boolean
+                      (when-let [stream-handle (some-> turn-ctx :turn-data deref :stream-handle)]
+                        (not (psi.turn-runtime.stream/cancelled-stream-handle? stream-handle))))]
     {:phase                   phase
      :session-id              session-id
      :is-idle                 (= phase :idle)
@@ -45,6 +50,7 @@
      :workflow-count          (extension-workflow-runtime/workflow-count-in (:workflow-registry ctx))
      :workflow-running-count  (extension-workflow-runtime/running-count-in (:workflow-registry ctx))
      :journal-entries         (count (ss/get-state-value-in ctx (ss/state-path :journal session-id)))
+     :turn-stream-live?       stream-live?
      :agent-diagnostics       (agent/diagnostics-in (ss/agent-ctx-in ctx session-id))}))
 
 (defn query-in

--- a/components/agent-session/src/psi/agent_session/prompt_request.clj
+++ b/components/agent-session/src/psi/agent_session/prompt_request.clj
@@ -13,16 +13,106 @@
    [psi.prompt-assets.skills :as skills]
    [psi.prompt-assets.system-prompt :as system-prompt]))
 
+(defn- assistant-tool-call-ids
+  [message]
+  (into []
+        (comp (filter #(= :tool-call (:type %)))
+              (map :id)
+              (filter string?))
+        (:content message)))
+
+(defn- tool-result-message?
+  [message]
+  (= "toolResult" (:role message)))
+
+(defn- tool-result-id
+  [message]
+  (:tool-call-id message))
+
+(defn- interrupted-tool-result
+  [tool-call-id timestamp]
+  {:role "toolResult"
+   :tool-call-id tool-call-id
+   :tool-name "interrupted"
+   :content [{:type :text
+              :text "Tool execution interrupted before completion."}]
+   :is-error true
+   :timestamp (or timestamp (java.time.Instant/now))})
+
+(defn dangling-tool-result-repairs
+  "Return synthetic error toolResult messages needed to repair dangling
+   assistant tool-call blocks.
+
+   A dangling block is an assistant message with one or more tool calls not
+   fully covered by the immediately following contiguous toolResult messages."
+  [messages]
+  (loop [remaining (seq messages)
+         repairs   []]
+    (if-let [message (first remaining)]
+      (let [tool-call-ids (seq (assistant-tool-call-ids message))]
+        (if (and (= "assistant" (:role message)) tool-call-ids)
+          (let [[tool-results tail] (split-with tool-result-message? (rest remaining))
+                present-ids         (into #{} (keep tool-result-id) tool-results)
+                missing-results     (->> tool-call-ids
+                                         (remove present-ids)
+                                         (mapv #(interrupted-tool-result % (:timestamp message))))]
+            (recur tail (into repairs missing-results)))
+          (recur (next remaining) repairs)))
+      repairs)))
+
+(defn tail-dangling-tool-result-repairs
+  "Return synthetic error toolResult messages needed to repair a dangling tail
+   tool-use before appending a later user message to the journal.
+
+   This only repairs the final assistant tool-use segment at the end of the
+   current history, preserving immediate adjacency in the persisted journal."
+  [messages]
+  (let [[trailing-tool-results reversed-prefix] (split-with tool-result-message? (rseq (vec messages)))
+        assistant-msg                           (first reversed-prefix)]
+    (if (and assistant-msg
+             (= "assistant" (:role assistant-msg))
+             (seq (assistant-tool-call-ids assistant-msg)))
+      (let [present-ids (into #{} (keep tool-result-id) trailing-tool-results)]
+        (->> (assistant-tool-call-ids assistant-msg)
+             (remove present-ids)
+             (mapv #(interrupted-tool-result % (:timestamp assistant-msg)))))
+      [])))
+
+(defn- repair-dangling-tool-uses
+  "Ensure every assistant tool-call block is followed by corresponding
+   contiguous toolResult messages before any later non-toolResult message.
+
+   When a session was interrupted after journaling an assistant tool-use but
+   before journaling its matching toolResult, synthesize an error toolResult in
+   the provider-facing projection so follow-on prompts remain valid."
+  [messages]
+  (loop [remaining (seq messages)
+         repaired  []]
+    (if-let [message (first remaining)]
+      (let [tool-call-ids (seq (assistant-tool-call-ids message))]
+        (if (and (= "assistant" (:role message)) tool-call-ids)
+          (let [[tool-results tail] (split-with tool-result-message? (rest remaining))
+                present-ids         (into #{} (keep tool-result-id) tool-results)
+                missing-results     (->> tool-call-ids
+                                         (remove present-ids)
+                                         (mapv #(interrupted-tool-result % (:timestamp message))))]
+            (recur tail (into repaired (concat [message] tool-results missing-results))))
+          (recur (next remaining) (conj repaired message))))
+      repaired)))
+
 (defn journal->provider-messages
   "Project persisted journal entries into agent/provider message maps.
    :message entries become provider messages directly.
-   :logprobs entries are persisted but not projected into provider messages."
+   :logprobs entries are persisted but not projected into provider messages.
+   Dangling assistant tool uses are repaired with synthetic error tool results
+   in the provider-facing projection so interrupted sessions remain usable."
   [journal]
-  (into []
-        (keep (fn [entry]
-                (when (= :message (:kind entry))
-                  (get-in entry [:data :message]))))
-        journal))
+  (repair-dangling-tool-uses
+   (into []
+         (keep (fn [entry]
+                 (when (= :message (:kind entry))
+                   (get-in entry [:data :message]))))
+         journal)))
 
 (defn session->provider-messages
   "Project the persisted journal for `session-id` into provider-visible messages."

--- a/components/agent-session/src/psi/agent_session/session_close.clj
+++ b/components/agent-session/src/psi/agent_session/session_close.clj
@@ -8,7 +8,9 @@
   (:require
    [com.fulcrologic.statecharts :as sc]
    [com.fulcrologic.statecharts.protocols :as sp]
+   [psi.agent-core.core :as agent]
    [psi.agent-session.dispatch :as dispatch]
+   [psi.agent-session.tools :as tools]
    [psi.session-state.state :as ss]))
 
 (defn- next-active-session-id
@@ -38,6 +40,35 @@
                           {:session-id session-id
                            :schedule-id schedule-id}
                           {:origin :core})))
+  true)
+
+(defn- interrupted-tool-result-message
+  [tool-call-id]
+  {:role "toolResult"
+   :tool-call-id tool-call-id
+   :tool-name "interrupted"
+   :content [{:type :text
+              :text "Tool execution interrupted before completion."}]
+   :is-error true
+   :timestamp (java.time.Instant/now)})
+
+(defn- repair-pending-tool-calls-before-close!
+  [ctx session-id]
+  (when-let [agent-ctx (ss/agent-ctx-in ctx session-id)]
+    (doseq [tool-call-id (:pending-tool-calls (agent/get-data-in agent-ctx))]
+      (let [message (interrupted-tool-result-message tool-call-id)]
+        (dispatch/dispatch! ctx
+                            :session/tool-agent-record-result
+                            {:session-id session-id
+                             :tool-result-msg message}
+                            {:origin :core}))))
+  true)
+
+(defn- abort-session-runtime!
+  [ctx session-id]
+  (when-let [agent-ctx (ss/agent-ctx-in ctx session-id)]
+    (agent/abort-in! agent-ctx))
+  (tools/abort-bash!)
   true)
 
 (defn- remove-session-state!
@@ -71,6 +102,8 @@
                                   keys
                                   vec)
           _                  (cancel-owned-schedules! ctx session-id sd)
+          _                  (abort-session-runtime! ctx session-id)
+          _                  (repair-pending-tool-calls-before-close! ctx session-id)
           _                  (doseq [schedule-id owned-schedule-ids]
                                (interrupt-scheduler-timer! ctx schedule-id))
           _                  (when sc-session-id

--- a/components/agent-session/src/psi/agent_session/turn.clj
+++ b/components/agent-session/src/psi/agent_session/turn.clj
@@ -10,8 +10,10 @@
    [psi.agent-session.dispatch :as dispatch]
    [psi.session-persistence.core :as persist]
    [psi.agent-session.runtime :as runtime]
+   [psi.agent-session.statechart :as session-sc]
    [psi.session-state.state :as ss]
-   [psi.turn-runtime.core :as turn-runtime]))
+   [psi.turn-runtime.core :as turn-runtime]
+   [psi.turn-runtime.stream :as turn-stream]))
 
 (defn execute-prepared-request!
   [ai-ctx ctx session-id prepared-request progress-queue]
@@ -48,10 +50,40 @@
        distinct
        (str/join "\n")))
 
+(defn- active-stream-handle?
+  [turn-ctx]
+  (boolean
+   (when-let [stream-handle (some-> turn-ctx :turn-data deref :stream-handle)]
+     (not (turn-stream/cancelled-stream-handle? stream-handle)))))
+
+(defn- stranded-streaming-session?
+  [ctx session-id]
+  (let [phase    (ss/sc-phase-in ctx session-id)
+        turn-ctx (ss/get-state-value-in ctx (ss/state-path :turn-ctx session-id))
+        agent-ctx (ss/agent-ctx-in ctx session-id)
+        pending  (or (some-> agent-ctx agent/get-data-in :pending-tool-calls) #{})]
+    (and (= :streaming phase)
+         (not (active-stream-handle? turn-ctx))
+         (empty? pending))))
+
+(defn- recover-stranded-streaming-session!
+  [ctx session-id]
+  (when (stranded-streaming-session? ctx session-id)
+    (when-let [sc-env (:sc-env ctx)]
+      (when-let [sc-session-id (ss/sc-session-id-in ctx session-id)]
+        ;; Recover via the explicit streaming -> idle abort transition rather
+        ;; than synthesizing an :agent-end event through guards that expect a
+        ;; fully populated live turn context.
+        (session-sc/send-event! sc-env sc-session-id :session/abort nil)))
+    (dispatch/dispatch! ctx :on-abort {:session-id session-id} {:origin :core})
+    true))
+
 (defn prompt-dispatch!
   [ctx session-id text images opts]
+  (recover-stranded-streaming-session! ctx session-id)
   (when-not (ss/idle-in? ctx session-id)
-    (throw (ex-info "Session is not idle" {:phase (ss/sc-phase-in ctx session-id)})))
+    (throw (ex-info "Session is not idle" {:phase (ss/sc-phase-in ctx session-id)
+                                           :recovered-stranded-streaming? false})))
   (let [user-msg {:role      "user"
                   :content   (cond-> [{:type :text :text text}]
                                images (into images))
@@ -113,26 +145,38 @@
   (dispatch/dispatch! ctx :session/enqueue-follow-up-message {:session-id session-id :text text} {:origin :core}))
 
 (defn queue-while-streaming-in!
-  "Queue prompt text while streaming for `session-id`."
+  "Queue prompt text while streaming for `session-id`.
+   If the session is stranded in :streaming with no live turn and no pending
+   tool calls, recover it first and treat the input as a normal prompt-ready
+   session."
   [ctx session-id text behavior]
-  (let [sd                 (ss/get-session-data-in ctx session-id)
-        interrupt-pending? (boolean (:interrupt-pending sd))
-        mode               (cond
-                             interrupt-pending? :coerced-follow-up
-                             (= behavior :steer) :steer
-                             :else :queue)]
-    (case mode
-      :steer
-      (do (steer-in! ctx session-id text)
-          {:accepted? true :behavior :steer})
+  (let [recovered?          (boolean (recover-stranded-streaming-session! ctx session-id))
+        phase               (ss/sc-phase-in ctx session-id)
+        sd                  (ss/get-session-data-in ctx session-id)
+        interrupt-pending?  (boolean (:interrupt-pending sd))]
+    (if (= :streaming phase)
+      (let [mode (cond
+                   interrupt-pending? :coerced-follow-up
+                   (= behavior :steer) :steer
+                   :else :queue)]
+        (case mode
+          :steer
+          (do (steer-in! ctx session-id text)
+              {:accepted? true :behavior :steer :recovered? recovered?})
 
-      (:queue :coerced-follow-up)
-      (do (follow-up-in! ctx session-id text)
-          {:accepted? true :behavior (if interrupt-pending? :coerced-follow-up :queue)}))))
+          (:queue :coerced-follow-up)
+          (do (follow-up-in! ctx session-id text)
+              {:accepted? true
+               :behavior (if interrupt-pending? :coerced-follow-up :queue)
+               :recovered? recovered?})))
+      {:accepted? false
+       :behavior :not-streaming
+       :recovered? recovered?})))
 
 (defn request-interrupt-in!
   "Request a deferred interrupt at the next turn boundary for `session-id`."
   [ctx session-id]
+  (recover-stranded-streaming-session! ctx session-id)
   (let [phase (ss/sc-phase-in ctx session-id)
         sd    (ss/get-session-data-in ctx session-id)]
     (if (= :streaming phase)
@@ -145,19 +189,48 @@
                             :session/request-interrupt
                             {:session-id       session-id
                              :already-pending? already-pending?
-                             :requested-at     (java.time.Instant/now)}
+                             :requested-at     (java.time.Instant/now)
+                             :reason           :deferred-interrupt}
                             {:origin :core})
         {:accepted? (not already-pending?)
          :pending? true
+         :reason :deferred-interrupt
          :dropped-steering-text dropped-text})
       {:accepted? false
        :pending? (boolean (:interrupt-pending sd))
+       :reason (:interrupt-reason sd)
        :dropped-steering-text ""})))
+
+(defn- interrupted-tool-result-message
+  [tool-call-id reason]
+  {:role "toolResult"
+   :tool-call-id tool-call-id
+   :tool-name "interrupted"
+   :content [{:type :text
+              :text (str "Tool execution interrupted before completion."
+                         (when reason
+                           (str " Reason: " (name reason) ".")))}]
+   :is-error true
+   :details {:interruption {:reason reason}}
+   :timestamp (java.time.Instant/now)})
+
+(defn- record-pending-tool-call-interrupts!
+  [ctx session-id reason]
+  (let [agent-ctx (ss/agent-ctx-in ctx session-id)
+        pending   (vec (or (some-> agent-ctx agent/get-data-in :pending-tool-calls) #{}))]
+    (doseq [tool-call-id pending]
+      (dispatch/dispatch! ctx
+                          :session/tool-agent-record-result
+                          {:session-id session-id
+                           :tool-result-msg (interrupted-tool-result-message tool-call-id reason)}
+                          {:origin :core}))
+    pending))
 
 (defn abort-in!
   "Abort the current agent run immediately for `session-id`. Prefer
    `request-interrupt-in!` for deferred semantics."
   [ctx session-id]
+  (record-pending-tool-call-interrupts! ctx session-id :user-abort)
   (turn-runtime/abort-active-turn-in! ctx session-id)
   (dispatch/dispatch! ctx :session/abort {:session-id session-id} {:origin :core}))
 

--- a/components/agent-session/test/psi/agent_session/model_dispatch_test.clj
+++ b/components/agent-session/test/psi/agent_session/model_dispatch_test.clj
@@ -332,6 +332,7 @@
       (test-support/update-state! ctx :session-data assoc
                                   :interrupt-pending false
                                   :steering-messages ["queued steer"])
+      (swap! (:data-atom (ss/agent-ctx-in ctx session-id)) assoc :pending-tool-calls #{"tc-interrupt-test"})
       ;; Force streaming deterministically so interrupt behavior does not depend
       ;; on prompt runtime timing.
       (sc/send-event! (:sc-env ctx)
@@ -342,6 +343,7 @@
       (let [sd    (ss/get-session-data-in ctx session-id)
             entry (last (kernel/event-log-entries))]
         (is (true? (:interrupt-pending sd)))
+        (is (= :deferred-interrupt (:interrupt-reason sd)))
         (is (= [] (:steering-messages sd)))
         (is (instance? java.time.Instant (:interrupt-requested-at sd)))
         (is (= :session/request-interrupt (:event-type entry)))

--- a/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_lifecycle_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
+   [psi.agent-session.dispatch]
    [psi.agent-session.extensions]
    [psi.agent-session.prompt-chain]
    [psi.agent-session.prompt-request]
@@ -10,6 +11,7 @@
    [psi.agent-session.runtime :as runtime]
    [psi.agent-session.turn]
    [psi.state-kernel.dispatch :as kernel]
+   [psi.session-persistence.core]
    [psi.session-state.state :as ss]
    [psi.agent-session.test-support :as test-support]
    [clojure.java.io :as io]
@@ -67,6 +69,32 @@
       (is (= 3 (count effects)))
       (is (= [:session/prompt-submit :session/prompt :session/prompt-prepare-request]
              (mapv :event-type effects))))))
+
+(deftest prompt-submit-handler-adds-tail-repair-effect-before-user-message-test
+  (let [[ctx session-id] (create-session-context {:persist? false})
+        assistant-msg {:role "assistant"
+                       :content [{:type :tool-call :id "tc-tail" :name "bash" :arguments "{}"}]
+                       :stop-reason :tool_use
+                       :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+        user-msg {:role "user"
+                  :content [{:type :text :text "status?"}]
+                  :timestamp (java.time.Instant/now)}]
+    (session/dispatch-in! ctx :session/append-journal-entry
+                          {:session-id session-id
+                           :entry (psi.session-persistence.core/message-entry assistant-msg)}
+                          {:origin :core})
+    (let [handler-result ((:fn (kernel/handler-entry :session/prompt-submit))
+                          ctx
+                          {:session-id session-id
+                           :user-msg user-msg})
+          effects (:effects handler-result)]
+      (is (= 2 (count effects)))
+      (is (= :runtime/dispatch-event (-> effects first :effect/type)))
+      (is (= "toolResult" (get-in (first effects) [:event-data :entry :data :message :role])))
+      (is (= "tc-tail" (get-in (first effects) [:event-data :entry :data :message :tool-call-id])))
+      (is (= :runtime/dispatch-event (-> effects second :effect/type)))
+      (is (= "user" (get-in (second effects) [:event-data :entry :data :message :role])))
+      (is (= 1 (get-in handler-result [:return :repaired-tool-result-count]))))))
 
 (deftest prompt-record-response-appends-assistant-once-test
   (let [[ctx session-id] (create-session-context {:persist? false})
@@ -198,6 +226,78 @@
       (session/prompt-in! ctx session-id "hello")
       (is (= [session-id] @sync-calls)
           "prompt-in! should run git-head sync after a normal prompt turn"))))
+
+(deftest stranded-streaming-session-recovers-on-next-prompt-test
+  (let [[ctx session-id] (create-session-context {:persist? false})]
+    (session/dispatch-in! ctx :session/prompt {:session-id session-id} {:origin :core})
+    (session/dispatch-in! ctx :on-streaming-entered {:session-id session-id} {:origin :statechart})
+    (is (= :streaming (ss/sc-phase-in ctx session-id)))
+    (is (true? (:is-streaming (ss/get-session-data-in ctx session-id))))
+    (with-redefs [psi.turn-runtime.core/execute-prepared-request!
+                  (fn [_ai-ctx _ctx sid prepared _pq]
+                    {:execution-result/turn-id (:prepared-request/id prepared)
+                     :execution-result/session-id sid
+                     :execution-result/assistant-message {:role "assistant"
+                                                          :content [{:type :text :text "recovered"}]
+                                                          :stop-reason :stop
+                                                          :timestamp (java.time.Instant/now)}
+                     :execution-result/turn-outcome :turn.outcome/stop
+                     :execution-result/tool-calls []
+                     :execution-result/stop-reason :stop})]
+      (session/prompt-in! ctx session-id "hello after stall"))
+    (is (= :idle (ss/sc-phase-in ctx session-id)))
+    (is (false? (:is-streaming (ss/get-session-data-in ctx session-id))))
+    (is (= ["user" "assistant"] (mapv :role (journal-messages ctx session-id))))))
+
+(deftest queue-while-streaming-recovers-stranded-session-test
+  (let [[ctx session-id] (create-session-context {:persist? false})]
+    (session/dispatch-in! ctx :session/prompt {:session-id session-id} {:origin :core})
+    (session/dispatch-in! ctx :on-streaming-entered {:session-id session-id} {:origin :statechart})
+    (let [result (session/queue-while-streaming-in! ctx session-id "nudge" :steer)]
+      (is (= false (:accepted? result)))
+      (is (= :not-streaming (:behavior result)))
+      (is (true? (:recovered? result)))
+      (is (= :idle (ss/sc-phase-in ctx session-id)))
+      (is (= [] (:steering-messages (ss/get-session-data-in ctx session-id)))))))
+
+(deftest abort-records-interrupted-tool-results-with-reason-test
+  (let [[ctx session-id] (create-session-context {:persist? false})
+        agent-ctx        (ss/agent-ctx-in ctx session-id)
+        appended*        (atom [])]
+    (swap! (:data-atom agent-ctx) assoc :pending-tool-calls #{"tc-abort"})
+    (with-redefs [psi.agent-session.dispatch/dispatch!
+                  (let [orig psi.agent-session.dispatch/dispatch!]
+                    (fn [ctx event-type event-data opts]
+                      (when (= :session/tool-agent-record-result event-type)
+                        (swap! appended* conj (:tool-result-msg event-data)))
+                      (orig ctx event-type event-data opts)))]
+      (session/abort-in! ctx session-id))
+    (is (= 1 (count @appended*)))
+    (is (= "tc-abort" (:tool-call-id (first @appended*))))
+    (is (true? (:is-error (first @appended*))))
+    (is (= :user-abort (get-in (first @appended*) [:details :interruption :reason])))
+    (is (str/includes? (get-in (first @appended*) [:content 0 :text]) "Reason: user-abort."))))
+
+(deftest deferred-interrupt-records-interrupted-tool-results-with-reason-test
+  (let [[ctx session-id] (create-session-context {:persist? false})
+        agent-ctx        (ss/agent-ctx-in ctx session-id)
+        appended*        (atom [])]
+    (session/dispatch-in! ctx :session/prompt {:session-id session-id} {:origin :core})
+    (session/dispatch-in! ctx :on-streaming-entered {:session-id session-id} {:origin :statechart})
+    (swap! (:data-atom agent-ctx) assoc :pending-tool-calls #{"tc-interrupt"})
+    (session/request-interrupt-in! ctx session-id)
+    (with-redefs [psi.agent-session.dispatch/dispatch!
+                  (let [orig psi.agent-session.dispatch/dispatch!]
+                    (fn [ctx event-type event-data opts]
+                      (when (= :session/tool-agent-record-result event-type)
+                        (swap! appended* conj (:tool-result-msg event-data)))
+                      (orig ctx event-type event-data opts)))]
+      (session/dispatch-in! ctx :on-agent-done {:session-id session-id} {:origin :statechart}))
+    (is (= 1 (count @appended*)))
+    (is (= "tc-interrupt" (:tool-call-id (first @appended*))))
+    (is (true? (:is-error (first @appended*))))
+    (is (= :deferred-interrupt (get-in (first @appended*) [:details :interruption :reason])))
+    (is (str/includes? (get-in (first @appended*) [:content 0 :text]) "Reason: deferred-interrupt."))))
 
 (deftest abort-cancels-active-prompt-runtime-test
   (let [[ctx session-id] (create-session-context {:persist? false})
@@ -350,41 +450,27 @@
 
 (deftest queued-steering-is-injected-into-continuation-prepared-request-test
   (let [[ctx session-id] (create-session-context {:persist? false})
-        assistant-msg    {:role "assistant"
-                          :content [{:type :tool-call :id "tc-1" :name "read" :arguments "{}"}]
-                          :stop-reason :stop
-                          :timestamp (java.time.Instant/now)}
-        execution-result {:execution-result/turn-id "turn-1"
-                          :execution-result/session-id session-id
-                          :execution-result/assistant-message assistant-msg
-                          :execution-result/turn-outcome :turn.outcome/tool-use
-                          :execution-result/tool-calls [{:id "tc-1" :name "read" :arguments "{}"}]
-                          :execution-result/stop-reason :stop}
-        tool-result-msg  {:role "toolResult"
-                          :tool-call-id "tc-1"
-                          :tool-name "read"
-                          :content [{:type :text :text "file body"}]
-                          :timestamp (java.time.Instant/now)}]
+        user-msg        {:role "user"
+                         :content [{:type :text :text "hi"}]
+                         :timestamp (java.time.Instant/now)}
+        assistant-msg   {:role "assistant"
+                         :content [{:type :tool-call :id "tc-1" :name "read" :arguments "{}"}]
+                         :stop-reason :stop
+                         :timestamp (java.time.Instant/now)}
+        tool-result-msg {:role "toolResult"
+                         :tool-call-id "tc-1"
+                         :tool-name "read"
+                         :content [{:type :text :text "file body"}]
+                         :timestamp (java.time.Instant/now)}]
     (session/dispatch-in! ctx :session/bootstrap-prompt-state
                           {:session-id session-id
                            :system-prompt "sys"}
                           {:origin :core})
-    (session/dispatch-in! ctx :session/prompt-submit
-                          {:session-id session-id
-                           :user-msg {:role "user"
-                                      :content [{:type :text :text "hi"}]
-                                      :timestamp (java.time.Instant/now)}}
-                          {:origin :core})
-    (with-redefs [psi.agent-session.prompt-chain/run-prompt-tools! (fn [_ctx _sid _res _pq]
-                                                                     {:continued? true :tool-call-count 1})]
-      (session/dispatch-in! ctx :session/prompt-record-response
+    (doseq [message [user-msg assistant-msg tool-result-msg]]
+      (session/dispatch-in! ctx :session/append-journal-entry
                             {:session-id session-id
-                             :execution-result execution-result}
+                             :entry (psi.session-persistence.core/message-entry message)}
                             {:origin :core}))
-    (session/dispatch-in! ctx :session/tool-record-result
-                          {:session-id session-id
-                           :shaped-result {:result-message tool-result-msg}}
-                          {:origin :core})
     (session/dispatch-in! ctx :session/enqueue-steering-message
                           {:session-id session-id
                            :text "Please be brief."}

--- a/components/agent-session/test/psi/agent_session/prompt_request_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_request_test.clj
@@ -3,7 +3,8 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [psi.ai.model-registry :as model-registry]
-   [psi.agent-session.prompt-request :as prompt-request]))
+   [psi.agent-session.prompt-request :as prompt-request]
+   [psi.session-persistence.core :as persist]))
 
 ;; ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -181,3 +182,58 @@
       (is (nil? (:api-key opts)))
       (is (nil? (:no-auth-header opts)))
       (is (nil? (:headers opts))))))
+
+(deftest journal->provider-messages-repairs-dangling-tool-use-test
+  (testing "missing tool result is repaired with synthetic error toolResult before later messages"
+    (let [assistant {:role "assistant"
+                     :content [{:type :text :text "working"}
+                               {:type :tool-call :id "call-1" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          later-user {:role "user"
+                      :content [{:type :text :text "status?"}]}
+          messages (prompt-request/journal->provider-messages
+                    [(persist/message-entry assistant)
+                     (persist/message-entry later-user)])]
+      (is (= ["assistant" "toolResult" "user"] (mapv :role messages)))
+      (is (= "call-1" (:tool-call-id (second messages))))
+      (is (true? (:is-error (second messages))))
+      (is (= "Tool execution interrupted before completion."
+             (get-in (second messages) [:content 0 :text])))))
+
+  (testing "existing contiguous tool result is preserved and no synthetic repair is added"
+    (let [assistant {:role "assistant"
+                     :content [{:type :tool-call :id "call-1" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          result    {:role "toolResult"
+                     :tool-call-id "call-1"
+                     :tool-name "bash"
+                     :content [{:type :text :text "done"}]}
+          later-user {:role "user"
+                      :content [{:type :text :text "status?"}]}
+          messages  (prompt-request/journal->provider-messages
+                     [(persist/message-entry assistant)
+                      (persist/message-entry result)
+                      (persist/message-entry later-user)])]
+      (is (= ["assistant" "toolResult" "user"] (mapv :role messages)))
+      (is (= "done" (get-in (second messages) [:content 0 :text]))))))
+
+(deftest tail-dangling-tool-result-repairs-test
+  (testing "returns repair for dangling trailing assistant tool call"
+    (let [assistant {:role "assistant"
+                     :content [{:type :tool-call :id "call-tail" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          repairs   (prompt-request/tail-dangling-tool-result-repairs [assistant])]
+      (is (= 1 (count repairs)))
+      (is (= "call-tail" (:tool-call-id (first repairs))))
+      (is (true? (:is-error (first repairs))))))
+
+  (testing "returns no repair when trailing tool result already exists"
+    (let [assistant {:role "assistant"
+                     :content [{:type :tool-call :id "call-tail" :name "bash" :arguments "{}"}]
+                     :timestamp #inst "2026-05-14T13:28:43.762-00:00"}
+          result    {:role "toolResult"
+                     :tool-call-id "call-tail"
+                     :tool-name "bash"
+                     :content [{:type :text :text "done"}]}
+          repairs   (prompt-request/tail-dangling-tool-result-repairs [assistant result])]
+      (is (= [] repairs)))))

--- a/components/agent-session/test/psi/agent_session/session_close_test.clj
+++ b/components/agent-session/test/psi/agent_session/session_close_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [psi.agent-session.core :as session]
+   [psi.agent-session.dispatch :as dispatch]
    [psi.agent-session.statechart :as sc]
    [psi.agent-session.test-support :as test-support]
    [psi.session-state.state :as ss]))
@@ -81,6 +82,23 @@
       (session/close-session-in! ctx session-id)
       ;; After close: working memory is gone, sc-phase returns nil
       (is (nil? (sc/sc-phase (:sc-env ctx) sc-session-id))))))
+
+(deftest close-session-records-interrupted-tool-results-for-pending-calls-test
+  (testing "close-session-in! appends interrupted tool results before session removal side effects complete"
+    (let [[ctx session-id] (create-session-context {:persist? false})
+          agent-ctx        (ss/agent-ctx-in ctx session-id)
+          appended*        (atom [])]
+      (swap! (:data-atom agent-ctx) assoc :pending-tool-calls #{"tc-pending"})
+      (with-redefs [dispatch/dispatch!
+                    (let [orig dispatch/dispatch!]
+                      (fn [ctx event-type event-data opts]
+                        (when (= :session/tool-agent-record-result event-type)
+                          (swap! appended* conj (:tool-result-msg event-data)))
+                        (orig ctx event-type event-data opts)))]
+        (session/close-session-in! ctx session-id))
+      (is (= 1 (count @appended*)))
+      (is (= "tc-pending" (:tool-call-id (first @appended*))))
+      (is (true? (:is-error (first @appended*)))))))
 
 (deftest close-session-tree-closes-all-descendants-test
   (testing "close-session-tree-in! closes all descendants then the root"

--- a/components/agent-session/test/psi/agent_session/statechart_actions_test.clj
+++ b/components/agent-session/test/psi/agent_session/statechart_actions_test.clj
@@ -71,6 +71,7 @@
   (let [[ctx session-id] (test-support/make-session-ctx {:session-data {:is-streaming false
                                                                         :retry-attempt 3
                                                                         :interrupt-pending true
+                                                                        :interrupt-reason :deferred-interrupt
                                                                         :interrupt-requested-at #inst "2026-01-01T00:00:00.000Z"}})]
     (with-registered-handlers
       ctx
@@ -86,12 +87,16 @@
              (is (= {:is-streaming false
                      :retry-attempt 0
                      :interrupt-pending false
-                     :interrupt-requested-at nil}
+                     :interrupt-requested-at nil
+                     :interrupt-reason nil}
                     (select-keys (session-state/get-session-data-in ctx session-id)
-                                 [:is-streaming :retry-attempt :interrupt-pending :interrupt-requested-at])))
+                                 [:is-streaming :retry-attempt :interrupt-pending :interrupt-requested-at :interrupt-reason])))
              (is (= [{:effect/type :runtime/mark-workflow-jobs-terminal}
                      {:effect/type :runtime/emit-background-job-terminal-messages}
-                     {:effect/type :scheduler/drain-queue}]
+                     {:effect/type :scheduler/drain-queue}
+                     {:effect/type :runtime/record-pending-tool-call-interrupts
+                      :session-id session-id
+                      :reason :deferred-interrupt}]
                     (:effects result)))))
 
          (testing "on-abort clears interrupt state and emits agent-abort effect"

--- a/components/ai/src/psi/ai/providers/openai/chat_completions.clj
+++ b/components/ai/src/psi/ai/providers/openai/chat_completions.clj
@@ -186,11 +186,12 @@
 
 (defn- make-chat-stream-state
   []
-  {:stream-started?  (atom false)
-   :done?            (atom false)
-   :next-tool-index  (atom 0)
-   :tool-index-by-id (atom {})
-   :tool-state       (atom {})})
+  {:stream-started?      (atom false)
+   :done?                (atom false)
+   :pending-finish-reason (atom nil)
+   :next-tool-index      (atom 0)
+   :tool-index-by-id     (atom {})
+   :tool-state           (atom {})})
 
 (defn- emit-stream-start!
   [consume-fn stream-started?]
@@ -342,7 +343,7 @@
 
 (defn- finish-chat-chunk!
   [stream-state consume-fn model chunk choice]
-  (let [{:keys [stream-started? done?]} stream-state]
+  (let [{:keys [stream-started? done? pending-finish-reason]} stream-state]
     (cond
       (:usage chunk)
       (do
@@ -351,8 +352,10 @@
         (emit-chat-completion-finish! consume-fn
                                       stream-started?
                                       done?
-                                      (keyword (get-in choice [:finish_reason] "stop"))
-                                      (completions-usage-map model (:usage chunk))))
+                                      (or @pending-finish-reason
+                                          (keyword (get-in choice [:finish_reason] "stop")))
+                                      (completions-usage-map model (:usage chunk)))
+        (reset! pending-finish-reason nil))
 
       (:finish_reason choice)
       (do
@@ -360,20 +363,26 @@
         (emit-chat-tool-ends! stream-state consume-fn)
         (when-let [logprob-tokens (extract-llama-logprob-delta chunk)]
           (consume-fn {:type :logprob-delta :tokens logprob-tokens}))
-        (emit-chat-completion-finish! consume-fn
-                                      stream-started?
-                                      done?
-                                      (keyword (:finish_reason choice))
-                                      nil)))))
+        (reset! pending-finish-reason (keyword (:finish_reason choice)))))))
+
+(defn- flush-pending-chat-finish!
+  [stream-state consume-fn]
+  (let [{:keys [stream-started? done? pending-finish-reason]} stream-state]
+    (when-let [reason @pending-finish-reason]
+      (emit-chat-completion-finish! consume-fn stream-started? done? reason nil)
+      (reset! pending-finish-reason nil))))
 
 (defn- process-chat-sse-line!
   [stream-state consume-fn model options url line]
-  (when-let [chunk (transport/parse-sse-line line)]
-    (transport/capture-response! model options :openai-completions url chunk)
-    (let [choice (first (:choices chunk))
-          delta  (:delta choice)]
-      (emit-chat-chunk! stream-state consume-fn choice delta)
-      (finish-chat-chunk! stream-state consume-fn model chunk choice))))
+  (if-let [chunk (transport/parse-sse-line line)]
+    (do
+      (transport/capture-response! model options :openai-completions url chunk)
+      (let [choice (first (:choices chunk))
+            delta  (:delta choice)]
+        (emit-chat-chunk! stream-state consume-fn choice delta)
+        (finish-chat-chunk! stream-state consume-fn model chunk choice)))
+    (when (and line (.startsWith ^String line "data: ") (= "[DONE]" (.substring ^String line 6)))
+      (flush-pending-chat-finish! stream-state consume-fn))))
 
 (defn- non-streaming-request
   [conversation model options]
@@ -405,7 +414,8 @@
   (let [choice (first (:choices body))
         message (:message choice)
         stop-reason (keyword (or (:finish_reason choice) "stop"))
-        usage (some-> (:usage body) (completions-usage-map model))
+        usage (when-let [usage (:usage body)]
+                (completions-usage-map model usage))
         logprobs (or (extract-openai-logprob-delta choice)
                      (extract-llama-logprob-delta body))]
     {:assistant-message (cond-> {:role "assistant"

--- a/components/ai/test/psi/ai/providers/openai_test.clj
+++ b/components/ai/test/psi/ai/providers/openai_test.clj
@@ -636,6 +636,41 @@
           body  (json/parse-string (:body req) true)]
       (is (not (contains? body :temperature))))))
 
+(deftest local-openai-non-streaming-response-preserves-usage-test
+  (testing "non-streaming local OpenAI-compatible responses keep usage totals"
+    (let [model {:id "qwen-3.6-27b"
+                 :provider :local3
+                 :api :openai-completions
+                 :base-url "http://localhost:8082/v1"
+                 :supports-text true}
+          convo (-> (conv/create "sys")
+                    (conv/add-user-message "Reply with exactly: hi"))
+          body {:choices [{:finish_reason "stop"
+                           :index 0
+                           :message {:role "assistant"
+                                     :content "hi"
+                                     :reasoning_content "internal reasoning"}}]
+                :usage {:prompt_tokens 15
+                        :completion_tokens 152
+                        :total_tokens 167}}]
+      (with-redefs [http/post (fn [_url _req]
+                                {:status 200
+                                 :body (json/generate-string body)})]
+        (let [result ((:execute openai/provider) convo model {:no-auth-header true})]
+          (is (= "hi" (get-in result [:assistant-message :content 0 :text])))
+          (is (= :stop (get-in result [:assistant-message :stop-reason])))
+          (is (= {:input-tokens 15
+                  :output-tokens 152
+                  :cache-read-tokens 0
+                  :cache-write-tokens 0
+                  :total-tokens 167
+                  :cost {:input 0.0
+                         :output 0.0
+                         :cache-read 0.0
+                         :cache-write 0.0
+                         :total 0.0}}
+                 (get-in result [:assistant-message :usage]))))))))
+
 (deftest completions-reasoning-delta-shapes-map-to-thinking-delta-test
   (testing "chat completions reasoning delta variants are emitted as :thinking-delta"
     (let [model  (models/get-model :gpt-5)
@@ -671,6 +706,44 @@
                   (filter #(= :thinking-delta (:type %)))
                   (mapv :delta))))
       (is (some #(= :done (:type %)) @events)))))
+
+(deftest completions-trailing-usage-after-finish-reason-is-preserved-test
+  (testing "chat completions keep trailing usage when finish_reason arrives before usage"
+    (let [model {:id "qwen-3.6-27b"
+                 :provider :local3
+                 :api :openai-completions
+                 :base-url "http://localhost:1234"
+                 :supports-text true}
+          convo (-> (conv/create "sys")
+                    (conv/add-user-message "hello"))
+          events (atom [])
+          sse (str
+               "data: " (json/generate-string
+                         {:choices [{:delta {:role "assistant"}}]}) "\n\n"
+               "data: " (json/generate-string
+                         {:choices [{:delta {:content "Hello"}}]}) "\n\n"
+               "data: " (json/generate-string
+                         {:choices [{:finish_reason "stop"}]}) "\n\n"
+               "data: " (json/generate-string
+                         {:usage {:prompt_tokens 42
+                                  :completion_tokens 128
+                                  :total_tokens 170}}) "\n\n"
+               "data: [DONE]\n\n")]
+      (with-redefs [http/post (fn [_url _req]
+                                {:body (stream-body sse)})]
+        ((:stream openai/provider)
+         convo model {:api-key "sk-test"}
+         (fn [ev] (swap! events conj ev))))
+      (let [done-events (filter #(= :done (:type %)) @events)]
+        (is (= 1 (count done-events)))
+        (is (= :stop (:reason (first done-events))))
+        (is (= {:input-tokens 42
+                :output-tokens 128
+                :cache-read-tokens 0
+                :cache-write-tokens 0
+                :total-tokens 170
+                :cost {:input 0.0 :output 0.0 :cache-read 0.0 :cache-write 0.0 :total 0.0}}
+               (:usage (first done-events))))))))
 
 (deftest completions-non-2xx-response-map-surfaces-body-message-test
   (let [model  (models/get-model :gpt-5)

--- a/components/session-state/src/psi/session_state/model.clj
+++ b/components/session-state/src/psi/session_state/model.clj
@@ -82,6 +82,9 @@
 (def response-mode-schema
   [:enum :streaming :non-streaming])
 
+(def interruption-reason-schema
+  [:enum :user-abort :deferred-interrupt :session-close :context-shutdown])
+
 (def prompt-component-schema
   [:enum :preamble :context-files :skills :runtime-metadata])
 
@@ -148,6 +151,7 @@
    [:is-compacting :boolean]
    [:interrupt-pending :boolean]
    [:interrupt-requested-at {:optional true} [:maybe inst?]]
+   [:interrupt-reason {:optional true} [:maybe interruption-reason-schema]]
    [:base-system-prompt :string]
    [:system-prompt :string]
    [:prompt-mode {:optional true} prompt-mode-schema]
@@ -237,6 +241,7 @@
      :is-streaming            false
      :is-compacting           false
      :interrupt-pending       false
+     :interrupt-reason        nil
      :interrupt-requested-at  nil
      :base-system-prompt      ""
      :system-prompt           ""

--- a/deps.edn
+++ b/deps.edn
@@ -79,8 +79,9 @@
                         "extensions/work-on/src"
                         "extensions/github/src"
                         "extensions/edit-clj/src"
-                        "extensions/logprobs/src"]
-          :extra-deps  {nrepl/nrepl         {:mvn/version "1.5.1"}
+                        "extensions/logprobs/src"
+                        "extensions/metrics/src"]
+          :extra-deps  {nrepl/nrepl             {:mvn/version "1.5.1"}
                         rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "psi.main"]}
@@ -119,8 +120,9 @@
                         "extensions/work-on/src"
                         "extensions/github/src"
                         "extensions/edit-clj/src"
-                        "extensions/logprobs/src"]
-          :extra-deps  {nrepl/nrepl         {:mvn/version "1.5.1"}
+                        "extensions/logprobs/src"
+                        "extensions/metrics/src"]
+          :extra-deps  {nrepl/nrepl             {:mvn/version "1.5.1"}
                         rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "psi.main"]}
@@ -158,8 +160,9 @@
                            "extensions/work-on/src"
                            "extensions/github/src"
                            "extensions/edit-clj/src"
-                           "extensions/logprobs/src"]
-             :extra-deps  {nrepl/nrepl            {:mvn/version "1.5.1"}
+                           "extensions/logprobs/src"
+                           "extensions/metrics/src"]
+             :extra-deps  {nrepl/nrepl             {:mvn/version "1.5.1"}
                            rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
              :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
              :main-opts   ["-m" "psi.tui.test-harness.tui-demo-main"]}
@@ -234,6 +237,7 @@
                              "extensions/work-on/test"
                              "extensions/github/test"
                              "extensions/logprobs/test"
+                             "extensions/metrics/test"
                              "components/extension-test-helpers/src"]
                :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                              nrepl/nrepl         {:mvn/version "1.5.1"}}
@@ -287,6 +291,7 @@
                         "extensions/github/test"
                         "extensions/edit-clj/test"
                         "extensions/logprobs/test"
+                        "extensions/metrics/test"
                         "components/ai/src"
                         "components/engine/src"
                         "components/query/src"
@@ -335,6 +340,7 @@
                         "extensions/github/src"
                         "extensions/edit-clj/src"
                         "extensions/logprobs/src"
+                        "extensions/metrics/src"
                         "components/extension-test-helpers/src"]
           :extra-deps  {lambdaisland/kaocha    {:mvn/version "1.91.1392"}
                         nrepl/nrepl            {:mvn/version "1.5.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -78,8 +78,10 @@
                         "extensions/plan-state-learning/src"
                         "extensions/work-on/src"
                         "extensions/github/src"
+                        "extensions/edit-clj/src"
                         "extensions/logprobs/src"]
-          :extra-deps  {nrepl/nrepl {:mvn/version "1.5.1"}}
+          :extra-deps  {nrepl/nrepl         {:mvn/version "1.5.1"}
+                        rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "psi.main"]}
   :psi   {:extra-paths ["bases/main/src"
@@ -116,8 +118,10 @@
                         "extensions/plan-state-learning/src"
                         "extensions/work-on/src"
                         "extensions/github/src"
+                        "extensions/edit-clj/src"
                         "extensions/logprobs/src"]
-          :extra-deps  {nrepl/nrepl {:mvn/version "1.5.1"}}
+          :extra-deps  {nrepl/nrepl         {:mvn/version "1.5.1"}
+                        rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "psi.main"]}
   :tui-demo {:extra-paths ["components/tui/src"
@@ -153,8 +157,10 @@
                            "extensions/plan-state-learning/src"
                            "extensions/work-on/src"
                            "extensions/github/src"
+                           "extensions/edit-clj/src"
                            "extensions/logprobs/src"]
-             :extra-deps  {nrepl/nrepl {:mvn/version "1.5.1"}}
+             :extra-deps  {nrepl/nrepl            {:mvn/version "1.5.1"}
+                           rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
              :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
              :main-opts   ["-m" "psi.tui.test-harness.tui-demo-main"]}
   :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.5.1"}}}
@@ -279,6 +285,7 @@
                         "extensions/plan-state-learning/test"
                         "extensions/work-on/test"
                         "extensions/github/test"
+                        "extensions/edit-clj/test"
                         "extensions/logprobs/test"
                         "components/ai/src"
                         "components/engine/src"
@@ -326,10 +333,12 @@
                         "extensions/plan-state-learning/src"
                         "extensions/work-on/src"
                         "extensions/github/src"
+                        "extensions/edit-clj/src"
                         "extensions/logprobs/src"
                         "components/extension-test-helpers/src"]
-          :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
-                        nrepl/nrepl         {:mvn/version "1.5.1"}}
+          :extra-deps  {lambdaisland/kaocha    {:mvn/version "1.91.1392"}
+                        nrepl/nrepl            {:mvn/version "1.5.1"}
+                        rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "kaocha.runner"]}
   :build {:deps      {io.github.clojure/tools.build {:mvn/version "0.10.12"}}

--- a/extensions/deps.edn
+++ b/extensions/deps.edn
@@ -15,13 +15,15 @@
         psi/mementum                {:local/root "mementum"}
         psi/munera                  {:local/root "munera"}
         psi/plan-state-learning     {:local/root "plan-state-learning"}
-        psi/work-on                 {:local/root "work-on"}}
+        psi/work-on                 {:local/root "work-on"}
+        psi/metrics                 {:local/root "metrics"}}
 
  :aliases
  {:test {:extra-paths ["auto-session-name/test"
                        "commit-checks/test"
                        "hello-ext/test"
                        "mcp-tasks-run/test"
+                       "metrics/test"
                        "plan-state-learning/test"
                        "work-on/test"]
          :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}

--- a/extensions/edit-clj/deps.edn
+++ b/extensions/edit-clj/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure      {:mvn/version "1.12.0"}
+        rewrite-clj/rewrite-clj  {:mvn/version "1.1.47"}
+        cheshire/cheshire         {:mvn/version "5.13.0"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {lambdaisland/kaocha               {:mvn/version "1.91.1392"}
+                      psi/extension-test-helpers {:local/root "../../components/extension-test-helpers"}
+                      psi/agent-session          {:local/root "../../components/agent-session"}}}}}

--- a/extensions/edit-clj/src/psi/edit_clj/core.clj
+++ b/extensions/edit-clj/src/psi/edit_clj/core.clj
@@ -1,0 +1,127 @@
+(ns psi.edit-clj.core
+  "Pure structural-edit logic — no file I/O.
+
+   All functions take/return plain values; the extension layer owns I/O and JSON
+   serialisation."
+  (:require
+   [clojure.string :as str]
+   [rewrite-clj.node :as n]
+   [rewrite-clj.parser :as p]
+   [rewrite-clj.zip :as z]))
+
+;; ── Form parsing ──────────────────────────────────────────────────────────────
+
+(defn parse-single-form
+  "Parse `s` as exactly one Clojure form.
+   Returns `{:ok node}` or `{:error {:code :parse-error :argument arg-name :message ...}}`.
+   Errors on blank input, unparseable input, or more than one top-level form."
+  [s arg-name]
+  (if (or (nil? s) (str/blank? s))
+    {:error {:code     :parse-error
+             :argument arg-name
+             :message  (str arg-name " is empty or blank")}}
+    (try
+      (let [forms-node  (p/parse-string-all s)
+            significant (remove n/whitespace-or-comment? (n/children forms-node))]
+        (cond
+          (empty? significant)
+          {:error {:code     :parse-error
+                   :argument arg-name
+                   :message  (str arg-name " contains no parseable form")}}
+
+          (> (count significant) 1)
+          {:error {:code     :parse-error
+                   :argument arg-name
+                   :message  (str arg-name " must be exactly one form; found "
+                                  (count significant) " top-level forms")}}
+
+          :else
+          {:ok (first significant)}))
+      (catch Exception e
+        {:error {:code     :parse-error
+                 :argument arg-name
+                 :message  (str "could not parse " arg-name ": " (.getMessage e))}}))))
+
+;; ── Candidate discovery ───────────────────────────────────────────────────────
+
+(defn find-candidates
+  "Depth-first walk of `file-content`; return a vector of candidate maps whose
+   `sexpr` equals the `sexpr` of `old-node`.  Nodes where `sexpr` throws
+   (comments, whitespace, uneval nodes, reader macros) are silently skipped.
+
+   Each candidate map: `{:zloc zloc :row row :col col :text text}`.
+   The `:zloc` entry is the zipper location at the matched node; callers may pass
+   it directly to `z/replace` without a second traversal."
+  [old-node file-content]
+  (let [target-sexpr (try (n/sexpr old-node) (catch Exception _ ::uneval))
+        zloc         (z/of-string file-content {:track-position? true})]
+    (if (or (= target-sexpr ::uneval) (nil? zloc))
+      []
+      (loop [z   zloc
+             acc []]
+        (if (z/end? z)
+          acc
+          (let [cand (when-not (n/whitespace-or-comment? (z/node z))
+                       (try
+                         (when (= (n/sexpr (z/node z)) target-sexpr)
+                           (let [[row col] (z/position z)]
+                             {:zloc z
+                              :row  row
+                              :col  col
+                              :text (z/string z)}))
+                         (catch Exception _ nil)))]
+            (recur (z/next z) (if cand (conj acc cand) acc))))))))
+
+;; ── Line-range filter ─────────────────────────────────────────────────────────
+
+(defn apply-line-filter
+  "Filter `candidates` to those whose `:row` (start row) falls within the optional
+   bounds.  Each bound is independently open when absent (nil).  When neither
+   bound is supplied this is a no-op."
+  [candidates {:keys [start-line end-line]}]
+  (if (and (nil? start-line) (nil? end-line))
+    candidates
+    (filter (fn [{:keys [row]}]
+              (and (or (nil? start-line) (<= start-line row))
+                   (or (nil? end-line)   (<= row end-line))))
+            candidates)))
+
+;; ── Replacement ───────────────────────────────────────────────────────────────
+
+(defn replace-in
+  "Given already-filtered `candidates`, perform the replacement and return a
+   result map.  Never touches the filesystem.
+
+   Parameters:
+   - `new-node`  — parsed replacement node (from `parse-single-form`)
+   - `new-str`   — original `new-string` argument verbatim (returned in `:new`)
+   - `candidates` — already-filtered maps with `:zloc`, `:row`, `:col`, `:text`
+
+   On success the map contains `:content` (the updated file-content string) as
+   well as `:status`, `:location`, `:old`, and `:new`.  The extension layer
+   writes `:content` to disk and merges `:filename` before JSON serialisation."
+  [new-node new-str candidates]
+  (case (count candidates)
+    0
+    {:status  "error"
+     :code    "no-match"
+     :message "no matching form found in file"
+     :hint    "Try adding or widening the `start-line`/`end-line` range, or verify that `old-string` appears in the file."}
+
+    1
+    (let [{:keys [zloc row col text]} (first candidates)]
+      {:status   "ok"
+       :location {:line row :column col}
+       :old      text
+       :new      new-str
+       :content  (z/root-string (z/replace zloc new-node))})
+
+    ;; multiple matches
+    {:status      "error"
+     :code        "ambiguous-match"
+     :match-count (count candidates)
+     :matches     (mapv (fn [{:keys [row col text]}]
+                          {:line row :column col :text text})
+                        candidates)
+     :message     "multiple matching forms found in file"
+     :hint        "Narrow the `start-line`/`end-line` range to isolate the intended occurrence."}))

--- a/extensions/edit-clj/src/psi/edit_clj/extension.clj
+++ b/extensions/edit-clj/src/psi/edit_clj/extension.clj
@@ -1,0 +1,88 @@
+(ns psi.edit-clj.extension
+  "psi/edit-clj extension entry point.
+
+   Registers the `edit-clj` tool via `(:register-tool api)`.  All file I/O and
+   JSON serialisation lives here; the pure structural logic lives in
+   `psi.edit-clj.core`."
+  (:require
+   [cheshire.core :as json]
+   [clojure.java.io :as io]
+   [psi.edit-clj.core :as core]))
+
+;; ── Path resolution ───────────────────────────────────────────────────────────
+
+(defn- resolve-path
+  "Resolve `filename` against `cwd` when relative; return absolute path string.
+   When `cwd` is nil, relative paths resolve against the process working directory."
+  [filename cwd]
+  (let [f (io/file filename)]
+    (if (or (.isAbsolute f) (nil? cwd))
+      (str f)
+      (str (io/file cwd filename)))))
+
+;; ── Tool execution ────────────────────────────────────────────────────────────
+
+(defn- execute
+  "Validate, find, filter, replace, write, and return a JSON result string."
+  [args opts]
+  ;; Validation order per design contract: old-string → new-string → file
+  (let [filename   (get args "filename")
+        old-string (get args "old-string")
+        new-string (get args "new-string")
+        start-line (get args "start-line")
+        end-line   (get args "end-line")
+        cwd        (:cwd opts)
+        old-result (core/parse-single-form old-string "old-string")]
+    (if (:error old-result)
+      (json/generate-string (assoc (:error old-result) :status "error"))
+      (let [new-result (core/parse-single-form new-string "new-string")]
+        (if (:error new-result)
+          (json/generate-string (assoc (:error new-result) :status "error"))
+          (let [resolved (resolve-path filename cwd)
+                f        (io/file resolved)]
+            (if-not (.canRead f)
+              (json/generate-string {:status   "error"
+                                     :code     "file-not-found"
+                                     :filename resolved
+                                     :message  (str "file not found or not readable: " resolved)})
+              (let [file-content (slurp f)
+                    new-node     (:ok new-result)
+                    candidates   (core/find-candidates (:ok old-result) file-content)
+                    filtered     (core/apply-line-filter candidates
+                                                         {:start-line start-line
+                                                          :end-line   end-line})
+                    result       (core/replace-in new-node new-string filtered)]
+                (if (= "ok" (:status result))
+                  (do
+                    (spit f (:content result))
+                    (json/generate-string (-> result
+                                              (assoc :filename resolved)
+                                              (dissoc :content))))
+                  (json/generate-string (assoc result :filename resolved)))))))))))
+
+;; ── Tool definition ───────────────────────────────────────────────────────────
+
+(def ^:private tool-def
+  {:name        "edit-clj"
+   :description "Replace one Clojure form in a file by S-expression equality; old-string and new-string must each be one complete, parseable form."
+   :parameters  {:type       "object"
+                 :properties {"filename"   {:type        "string"
+                                            :description "Path to the Clojure source file; relative paths resolve against the session worktree."}
+                              "old-string" {:type        "string"
+                                            :description "Exactly one complete Clojure form; matched against file nodes by sexpr equality."}
+                              "new-string" {:type        "string"
+                                            :description "Exactly one complete Clojure form; replaces the matched node verbatim."}
+                              "start-line" {:type        "integer"
+                                            :description "1-indexed first line of the match window (inclusive, optional)."}
+                              "end-line"   {:type        "integer"
+                                            :description "1-indexed last line of the match window (inclusive, optional)."}}
+                 :required   ["filename" "old-string" "new-string"]}
+   :execute     (fn
+                  ([args]      (execute args nil))
+                  ([args opts] (execute args opts)))})
+
+;; ── Extension entry point ─────────────────────────────────────────────────────
+
+(defn init
+  [api]
+  ((:register-tool api) tool-def))

--- a/extensions/edit-clj/test/psi/edit_clj/core_test.clj
+++ b/extensions/edit-clj/test/psi/edit_clj/core_test.clj
@@ -1,0 +1,234 @@
+(ns psi.edit-clj.core-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [psi.edit-clj.core :as core]
+   [rewrite-clj.node :as n]))
+
+;; ── Test helpers ─────────────────────────────────────────────────────────────
+
+(defn- edit
+  "Run the full core pipeline (parse → find → filter → replace).
+   Returns the result map from `replace-in`, or an error map from
+   `parse-single-form` on bad input."
+  [old-str new-str file-content & {:keys [start-line end-line]}]
+  (let [old-result (core/parse-single-form old-str "old-string")]
+    (if (:error old-result)
+      (:error old-result)
+      (let [new-result (core/parse-single-form new-str "new-string")]
+        (if (:error new-result)
+          (:error new-result)
+          (let [candidates (core/find-candidates (:ok old-result) file-content)
+                filtered   (core/apply-line-filter candidates
+                                                   {:start-line start-line
+                                                    :end-line   end-line})]
+            (core/replace-in (:ok new-result) new-str filtered)))))))
+
+;; ── AC 1 — single match replaced; content outside node unchanged ──────────────
+
+(deftest single-match-replace-test
+  (testing "replaces the matched node; all content outside it is byte-for-byte identical"
+    (let [content "(ns foo)\n\n(defn bar [x] (+ x 1))\n"
+          result  (edit "(+ x 1)" "(* x 2)" content)]
+      (is (= "ok" (:status result)))
+      (is (= "(ns foo)\n\n(defn bar [x] (* x 2))\n" (:content result)))
+      (is (= {:line 3 :column 15} (:location result)))
+      (is (= "(+ x 1)" (:old result)))
+      (is (= "(* x 2)" (:new result))))))
+
+;; ── R1/R2 — sexpr-equality ignores whitespace; ok.old = file node text ──────────
+
+(deftest sexpr-whitespace-insensitive-test
+  (testing "R1: old-string matches file node despite internal whitespace differences"
+    ;; File has extra spaces inside the form; old-string uses normalised spacing.
+    ;; sexpr equality must succeed; the result must be :ok (not no-match).
+    (let [content "(defn f [] (+  x  1))\n"
+          result  (edit "(+ x 1)" "(* x 2)" content)]
+      (is (= "ok" (:status result))
+          "sexpr equality should match despite whitespace differences")
+      (is (str/includes? (:content result) "(* x 2)"))
+      ;; R2: :old must equal the file node text, not the old-string argument
+      (is (= "(+  x  1)" (:old result))
+          "ok.old should be the file node text, not the old-string argument")))
+
+  (testing "R2: ok.old != old-string when file node has extra whitespace"
+    (let [content "(let [a  1] a)\n"
+          result  (edit "(let [a 1] a)" ":replaced" content)]
+      (is (= "ok" (:status result)))
+      (is (= "(let [a  1] a)" (:old result)))
+      (is (not= "(let [a 1] a)" (:old result))
+          "ok.old must differ from old-string when whitespace differs"))))
+
+;; ── S4 — ok.new is new-string argument verbatim ─────────────────────────────────
+
+(deftest ok-new-verbatim-test
+  (testing "ok.new returns the new-string argument string verbatim, not n/string of parsed node"
+    ;; If new-string has leading/trailing whitespace, n/string would strip it.
+    ;; ok.new must return the original argument string unchanged.
+    (let [content "(defn f [] :x)\n"
+          result  (edit ":x" "  :y  " content)]
+      (is (= "ok" (:status result)))
+      (is (= "  :y  " (:new result)))))
+
+  (testing "ok.new matches new-string exactly when it contains a form comment"
+    (let [content "(foo :bar)\n"
+          new-str "(foo ;; c\n  :baz)"
+          result  (edit "(foo :bar)" new-str content)]
+      (is (= "ok" (:status result)))
+      (is (= new-str (:new result))))))
+
+;; ── AC 2 — no-match result; content string returned unchanged ─────────────────
+
+(deftest no-match-test
+  (testing "no-match status when old-string not present in file"
+    (let [content "(ns foo)\n(defn bar [] :baz)\n"
+          result  (edit ":qux" ":replaced" content)]
+      (is (= "error" (:status result)))
+      (is (= "no-match" (:code result)))
+      (is (string? (:hint result)))))
+
+  (testing "no :content key on no-match (file not modified)"
+    (let [result (edit ":qux" ":replaced" "(ns foo)\n")]
+      (is (nil? (:content result))))))
+
+;; ── AC 3 — ambiguous-match result with correct locations ─────────────────────
+
+(deftest ambiguous-match-test
+  (testing "two matching nodes → ambiguous-match with match-count and matches"
+    (let [content "(defn foo [] :dup)\n(defn bar [] :dup)\n"
+          result  (edit ":dup" ":unique" content)]
+      (is (= "error" (:status result)))
+      (is (= "ambiguous-match" (:code result)))
+      (is (= 2 (:match-count result)))
+      (is (= 2 (count (:matches result))))
+      (is (every? #(contains? % :line) (:matches result)))
+      (is (every? #(contains? % :column) (:matches result)))
+      (is (every? #(contains? % :text) (:matches result)))
+      (is (string? (:hint result))))))
+
+;; ── AC 4 — parse-single-form errors ──────────────────────────────────────────
+
+(deftest parse-single-form-test
+  (testing "invalid Clojure → parse-error"
+    (let [result (core/parse-single-form "(defn [" "old-string")]
+      (is (= :parse-error (:code (:error result))))
+      (is (= "old-string" (:argument (:error result))))))
+
+  (testing "blank input → parse-error"
+    (let [result (core/parse-single-form "   " "new-string")]
+      (is (= :parse-error (:code (:error result))))
+      (is (= "new-string" (:argument (:error result))))))
+
+  (testing "nil input → parse-error"
+    (let [result (core/parse-single-form nil "old-string")]
+      (is (= :parse-error (:code (:error result))))))
+
+  (testing "valid single form → {:ok node}"
+    (let [result (core/parse-single-form "(+ 1 2)" "old-string")]
+      (is (contains? result :ok))
+      (is (nil? (:error result)))))
+
+  (testing "argument name is preserved in error map"
+    (let [result (core/parse-single-form "   " "new-string")]
+      (is (= "new-string" (:argument (:error result)))))))
+
+;; ── AC 8 — multi-form input → parse-error ────────────────────────────────────
+
+(deftest multi-form-parse-error-test
+  (testing "multi-form old-string → parse-error for old-string"
+    (let [result (edit "foo bar" ":ok" "(foo bar)")]
+      (is (= :parse-error (:code result)))
+      (is (= "old-string" (:argument result)))))
+
+  (testing "multi-form new-string → parse-error for new-string"
+    (let [result (edit "foo" "bar baz" "(foo)")]
+      (is (= :parse-error (:code result)))
+      (is (= "new-string" (:argument result))))))
+
+;; ── AC 6a — two identical forms; one in range, one outside ───────────────────
+
+(deftest line-range-disambiguation-test
+  (testing "6a: two identical forms, one in range → single match"
+    (let [content "(defn foo [] :dup)\n\n(defn bar [] :dup)\n"
+          ;; :dup on line 1 and line 3
+          result  (edit ":dup" ":replaced" content :start-line 1 :end-line 1)]
+      (is (= "ok" (:status result)))
+      (is (= 1 (:line (:location result))))))
+
+  (testing "6a: pick the second occurrence by narrowing start-line"
+    (let [content "(defn foo [] :dup)\n\n(defn bar [] :dup)\n"
+          result  (edit ":dup" ":replaced" content :start-line 3 :end-line 3)]
+      (is (= "ok" (:status result)))
+      (is (= 3 (:line (:location result)))))))
+
+;; ── AC 6b — form starts in range, ends past end-line → matched ───────────────
+
+(deftest form-straddles-end-line-test
+  (testing "6b: form starts in range, ends past end-line → matched by start-row rule"
+    (let [content "(defn foo []\n  :bar)\n"
+          ;; (defn foo [] :bar) starts at row 1, ends at row 2; end-line=1
+          result  (edit "(defn foo []\n  :bar)" "(defn foo [] :replaced)" content
+                        :start-line 1 :end-line 1)]
+      (is (= "ok" (:status result))))))
+
+;; ── AC 6c — form ends in range, starts before start-line → not matched ───────
+
+(deftest form-starts-before-range-test
+  (testing "6c: form end-row in range but start-row before start-line → not matched"
+    (let [content "(defn foo []\n  :bar)\n"
+          ;; (defn foo [] :bar) starts at row 1; start-line=2
+          result  (edit "(defn foo []\n  :bar)" "(defn foo [] :replaced)" content
+                        :start-line 2 :end-line 2)]
+      (is (= "error" (:status result)))
+      (is (= "no-match" (:code result))))))
+
+;; ── AC 6d — two identical forms both in range → ambiguous-match ──────────────
+
+(deftest both-forms-in-range-test
+  (testing "6d: two matching forms both within range → ambiguous-match"
+    (let [content "(defn a [] :x)\n(defn b [] :x)\n"
+          ;; both :x at rows 1 and 2
+          result  (edit ":x" ":y" content :start-line 1 :end-line 2)]
+      (is (= "error" (:status result)))
+      (is (= "ambiguous-match" (:code result))))))
+
+;; ── AC 6e — valid range with no form starts → no-match ───────────────────────
+
+(deftest range-no-form-starts-test
+  (testing "6e: range contains no node starts matching old-string → no-match"
+    (let [content "(defn foo [] :target)\n\n(defn bar [] :other)\n"
+          ;; :target is on row 1; search in rows 2-3 only
+          result  (edit ":target" ":replaced" content :start-line 2 :end-line 3)]
+      (is (= "error" (:status result)))
+      (is (= "no-match" (:code result))))))
+
+;; ── AC 6f — nested symbol in straddling parent ────────────────────────────────
+
+(deftest nested-symbol-in-straddling-parent-test
+  (testing "6f: symbol on row 2, parent starts on row 1; start-line=2 → matched"
+    (let [content "(defn foo []\n  :nested)\n"
+          ;; :nested is on row 2; start-line=2
+          result  (edit ":nested" ":replaced" content :start-line 2 :end-line 2)]
+      (is (= "ok" (:status result)))
+      (is (= 2 (:line (:location result)))))))
+
+;; ── AC 7 — comment in new-string preserved verbatim ──────────────────────────
+
+(deftest comment-in-new-string-preserved-test
+  (testing "7: inline comment in new-string present in output; not dropped by coerce"
+    (let [content "(foo :original)\n(bar)\n"
+          new-str "(foo ;; preserved comment\n  :replaced)"
+          result  (edit "(foo :original)" new-str content)]
+      (is (= "ok" (:status result)))
+      (is (str/includes? (:content result) ";; preserved comment"))))
+
+  (testing "7: leading comment in new-string is stripped during form extraction (known limitation)"
+    ;; parse-single-form extracts only the significant node; a leading comment is
+    ;; whitespace-equivalent in rewrite-clj and is NOT inside the form, so it is
+    ;; filtered out.  AC 7 guarantees comments INSIDE a form are preserved; it
+    ;; does not cover leading (top-level) comments.
+    ;; The `:ok` node is the `:y` keyword; the leading comment is dropped.
+    (let [new-str ";; comment\n:y"
+          result  (core/parse-single-form new-str "new-string")]
+      (is (nil? (:error result)))
+      (is (= ":y" (n/string (:ok result)))))))

--- a/extensions/edit-clj/test/psi/edit_clj/extension_test.clj
+++ b/extensions/edit-clj/test/psi/edit_clj/extension_test.clj
@@ -1,0 +1,156 @@
+(ns psi.edit-clj.extension-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [psi.edit-clj.extension :as sut]
+   [psi.extension-test-helpers.nullable-api :as nullable]))
+
+;; ── Helpers ───────────────────────────────────────────────────────────────────
+
+(defn- make-temp-file
+  "Create a temp file with the given string content; delete on JVM exit."
+  ([] (make-temp-file ""))
+  ([content]
+   (let [f (java.io.File/createTempFile "edit-clj-test-" ".clj")]
+     (.deleteOnExit f)
+     (spit f content)
+     f)))
+
+(defn- execute
+  "Call the tool's :execute fn directly (bypasses nullable api but exercises real I/O)."
+  ([args]
+   (execute args {}))
+  ([args opts]
+   (let [{:keys [api state]} (nullable/create-nullable-extension-api)
+         _                   (sut/init api)
+         tool                (get-in @state [:tools "edit-clj"])]
+     ((:execute tool) args opts))))
+
+(defn- parse-json
+  [s]
+  (json/parse-string s true))
+
+;; ── AC 10 — init registers exactly one tool named "edit-clj" ─────────────────
+
+(deftest init-registers-one-tool-test
+  (testing "init registers exactly one tool named edit-clj"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api)
+          _                   (sut/init api)
+          tools               (:tools @state)]
+      (is (= 1 (count tools)))
+      (is (contains? tools "edit-clj"))
+      (is (= "edit-clj" (get-in tools ["edit-clj" :name]))))))
+
+;; ── AC 9 — description ≤ 20 words, one-form contract explicit ────────────────
+
+(deftest tool-description-test
+  (testing "description is ≤ 20 words"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api)
+          _                   (sut/init api)
+          desc                (get-in @state [:tools "edit-clj" :description])
+          word-count          (count (str/split desc #"\s+"))]
+      (is (<= word-count 20) (str "description has " word-count " words: " desc))))
+
+  (testing "description mentions one-form contract"
+    (let [{:keys [api state]} (nullable/create-nullable-extension-api)
+          _                   (sut/init api)
+          desc                (str/lower-case (get-in @state [:tools "edit-clj" :description]))]
+      (is (or (str/includes? desc "one")
+              (str/includes? desc "single"))
+          "description should mention 'one' or 'single' form"))))
+
+;; ── AC 4 — validation order ───────────────────────────────────────────────────
+
+(deftest validation-order-test
+  (testing "both old-string and new-string invalid → old-string error returned"
+    (let [result (parse-json (execute {"filename"   "/nonexistent/file.clj"
+                                       "old-string" "(["
+                                       "new-string" "(["}))]
+      (is (= "error" (:status result)))
+      (is (= "parse-error" (:code result)))
+      (is (= "old-string" (:argument result)))))
+
+  (testing "invalid old-string + missing file → parse-error (not file-not-found)"
+    (let [result (parse-json (execute {"filename"   "/nonexistent/no-such-file.clj"
+                                       "old-string" "(["
+                                       "new-string" ":ok"}))]
+      (is (= "error" (:status result)))
+      (is (= "parse-error" (:code result)))
+      (is (= "old-string" (:argument result)))))
+
+  (testing "R4: valid old-string + invalid new-string → parse-error for new-string"
+    (let [result (parse-json (execute {"filename"   "/nonexistent/any-file.clj"
+                                       "old-string" ":ok"
+                                       "new-string" "(["}))]
+      (is (= "error" (:status result)))
+      (is (= "parse-error" (:code result)))
+      (is (= "new-string" (:argument result))))))
+
+;; ── AC 5 — non-existent file → file-not-found ────────────────────────────────
+
+(deftest file-not-found-test
+  (testing "valid strings + non-existent file → file-not-found JSON"
+    (let [result (parse-json (execute {"filename"   "/nonexistent/definitely-not-there.clj"
+                                       "old-string" ":x"
+                                       "new-string" ":y"}))]
+      (is (= "error" (:status result)))
+      (is (= "file-not-found" (:code result)))
+      (is (contains? result :filename)))))
+
+;; ── AC 1 (round-trip) — file written; result is status ok ────────────────────
+
+(deftest round-trip-write-test
+  (testing "execute writes the modified file and returns status ok"
+    (let [content "(ns example)\n\n(defn add [a b] (+ a b))\n"
+          f       (make-temp-file content)
+          result  (parse-json (execute {"filename"   (.getAbsolutePath f)
+                                        "old-string" "(+ a b)"
+                                        "new-string" "(- a b)"}))]
+      (is (= "ok" (:status result)))
+      (is (= (.getAbsolutePath f) (:filename result)))
+      (is (contains? result :location))
+      ;; R3: all five ok-result fields must be present in the serialised JSON
+      (is (contains? result :old))
+      (is (contains? result :new))
+      (is (str/includes? (slurp f) "(- a b)"))
+      (is (not (str/includes? (slurp f) "(+ a b)")))))
+
+  (testing "execute with :cwd opts resolves relative path"
+    (let [content "(defn foo [] :original)\n"
+          f       (make-temp-file content)
+          dir     (.getParent f)
+          fname   (.getName f)
+          result  (parse-json (execute {"filename"   fname
+                                        "old-string" ":original"
+                                        "new-string" ":updated"}
+                                       {:cwd dir}))]
+      (is (= "ok" (:status result)))
+      (is (str/includes? (slurp f) ":updated")))))
+
+;; ── AC 2 (file-unchanged on no-match) ────────────────────────────────────────
+
+(deftest file-unchanged-on-no-match-test
+  (testing "no-match → temp file content identical before and after"
+    (let [content "(defn foo [] :bar)\n"
+          f       (make-temp-file content)
+          result  (parse-json (execute {"filename"   (.getAbsolutePath f)
+                                        "old-string" ":qux"
+                                        "new-string" ":replaced"}))]
+      (is (= "error" (:status result)))
+      (is (= "no-match" (:code result)))
+      (is (= content (slurp f))))))
+
+;; ── AC 3 (file-unchanged on ambiguous-match) ─────────────────────────────────
+
+(deftest file-unchanged-on-ambiguous-match-test
+  (testing "ambiguous-match → temp file content identical before and after"
+    (let [content "(defn a [] :dup)\n(defn b [] :dup)\n"
+          f       (make-temp-file content)
+          result  (parse-json (execute {"filename"   (.getAbsolutePath f)
+                                        "old-string" ":dup"
+                                        "new-string" ":unique"}))]
+      (is (= "error" (:status result)))
+      (is (= "ambiguous-match" (:code result)))
+      (is (= 2 (:match-count result)))
+      (is (= content (slurp f))))))

--- a/extensions/metrics/deps.edn
+++ b/extensions/metrics/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        metosin/malli       {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {lambdaisland/kaocha         {:mvn/version "1.91.1392"}
+                      psi/extension-test-helpers  {:local/root "../../components/extension-test-helpers"}
+                      psi/agent-session           {:local/root "../../components/agent-session"}}}}}

--- a/extensions/metrics/src/psi/metrics/counters.clj
+++ b/extensions/metrics/src/psi/metrics/counters.clj
@@ -1,0 +1,103 @@
+(ns psi.metrics.counters
+  "Pure counter update functions for the metrics extension.
+   All functions take and return plain maps — no atoms, no I/O.")
+
+;;; Helpers
+
+(defn- now-str
+  "Return the current instant as an ISO-8601 string."
+  []
+  (str (java.time.Instant/now)))
+
+(defn empty-metrics
+  "Return a fresh, schema-conforming empty metrics map."
+  []
+  {:tools      {}
+   :workflows  {}
+   :commands   {}
+   :operations {}
+   :tokens     {}
+   :updated-at nil})
+
+;;; Tool counters
+
+(defn inc-tool-invocation
+  "Increment the invocation counter for tool-name."
+  [metrics tool-name]
+  (-> metrics
+      (update-in [:tools tool-name :invocations] (fnil inc 0))
+      (update-in [:tools tool-name :errors] (fnil identity 0))
+      (update-in [:tools tool-name :error-reasons] (fnil identity {}))
+      (assoc :updated-at (now-str))))
+
+(defn inc-tool-error
+  "Increment the error counter for tool-name and record the error reason."
+  [metrics tool-name reason]
+  (-> metrics
+      (update-in [:tools tool-name :errors] (fnil inc 0))
+      (update-in [:tools tool-name :error-reasons reason] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+;;; Workflow / command / operation counters
+
+(defn inc-workflow-invocation
+  "Increment the invocation counter for workflow-id."
+  [metrics workflow-id]
+  (-> metrics
+      (update-in [:workflows workflow-id :invocations] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+(defn inc-command-invocation
+  "Increment the invocation counter for command-name."
+  [metrics command-name]
+  (-> metrics
+      (update-in [:commands command-name :invocations] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+(defn inc-operation-invocation
+  "Increment the invocation counter for operation-id."
+  [metrics operation-id]
+  (-> metrics
+      (update-in [:operations operation-id :invocations] (fnil inc 0))
+      (assoc :updated-at (now-str))))
+
+;;; Token counters
+
+(defn add-token-delta
+  "Add a per-model token delta to the metrics token counters.
+   delta is a map with :input :output :cache-read :cache-write keys (all ints).
+   model-id is a string; uses \"unknown\" when nil."
+  [metrics model-id delta]
+  (let [mid (or model-id "unknown")]
+    (-> metrics
+        (update-in [:tokens mid :input]       (fnil + 0) (or (:input delta) 0))
+        (update-in [:tokens mid :output]      (fnil + 0) (or (:output delta) 0))
+        (update-in [:tokens mid :cache-read]  (fnil + 0) (or (:cache-read delta) 0))
+        (update-in [:tokens mid :cache-write] (fnil + 0) (or (:cache-write delta) 0))
+        (assoc :updated-at (now-str)))))
+
+(defn compute-token-delta
+  "Compute the incremental token delta for a session turn.
+
+   current-totals is the map of usage attrs returned by EQL for this turn:
+     {:psi.agent-session/usage-input N
+      :psi.agent-session/usage-output N
+      :psi.agent-session/usage-cache-read N
+      :psi.agent-session/usage-cache-write N}
+
+   prev-totals is the last-seen totals map for this session (nil on first turn).
+
+   Returns a delta map {:input N :output N :cache-read N :cache-write N}."
+  [current-totals prev-totals]
+  (let [cur-in    (or (:psi.agent-session/usage-input current-totals) 0)
+        cur-out   (or (:psi.agent-session/usage-output current-totals) 0)
+        cur-cr    (or (:psi.agent-session/usage-cache-read current-totals) 0)
+        cur-cw    (or (:psi.agent-session/usage-cache-write current-totals) 0)
+        prev-in   (or (:psi.agent-session/usage-input prev-totals) 0)
+        prev-out  (or (:psi.agent-session/usage-output prev-totals) 0)
+        prev-cr   (or (:psi.agent-session/usage-cache-read prev-totals) 0)
+        prev-cw   (or (:psi.agent-session/usage-cache-write prev-totals) 0)]
+    {:input       (max 0 (- cur-in prev-in))
+     :output      (max 0 (- cur-out prev-out))
+     :cache-read  (max 0 (- cur-cr prev-cr))
+     :cache-write (max 0 (- cur-cw prev-cw))}))

--- a/extensions/metrics/src/psi/metrics/extension.clj
+++ b/extensions/metrics/src/psi/metrics/extension.clj
@@ -1,0 +1,208 @@
+(ns psi.metrics.extension
+  "psi/metrics extension entry point.
+
+   Subscribes to tool_call, tool_result, and session_turn_finished events
+   and maintains persistent per-capability usage counters.
+
+   Registers:
+   - deterministic operation  metrics/summary
+   - slash command            /metrics"
+  (:require
+   [clojure.string :as str]
+   [psi.metrics.counters :as counters]
+   [psi.metrics.persistence :as persist]
+   [psi.metrics.schema :as schema]))
+
+;;; State
+
+(defonce store
+  (atom nil))
+
+(defonce writing?
+  (atom false))
+
+;;; Internal accessors
+
+(defn- get-metrics
+  "Return the current metrics map from the store."
+  []
+  (:metrics @store))
+
+(defn- update-metrics!
+  "Apply f to the current metrics map inside the store and mark dirty."
+  [f & args]
+  (swap! store update :metrics #(apply f % args))
+  (persist/mark-dirty-and-persist! store writing?))
+
+;;; Event handlers
+
+(defn- on-tool-call
+  "Increment the invocation counter for the named tool."
+  [payload]
+  (when-let [tool-name (:tool-name payload)]
+    (update-metrics! counters/inc-tool-invocation tool-name))
+  nil)
+
+(defn- on-tool-result
+  "Increment error counters when the tool result is an error."
+  [payload]
+  (when (and (:tool-name payload) (:is-error payload))
+    (let [tool-name (:tool-name payload)
+          content   (str (:content payload))
+          reason    (-> content
+                        (str/split-lines)
+                        first
+                        (or "")
+                        (str/trim)
+                        (subs 0 (min 80 (count (str/trim (first (str/split-lines content)))))))]
+      (update-metrics! counters/inc-tool-error tool-name reason)))
+  nil)
+
+(defn- make-turn-finished-handler
+  "Return a session_turn_finished handler closed over api for EQL queries."
+  [api]
+  (fn [payload]
+    (when-let [session-id (:session-id payload)]
+      (try
+        (let [result    ((:query-session api)
+                         session-id
+                         [:psi.agent-session/usage-input
+                          :psi.agent-session/usage-output
+                          :psi.agent-session/usage-cache-read
+                          :psi.agent-session/usage-cache-write
+                          :psi.agent-session/model-id])
+              model-id  (:psi.agent-session/model-id result)
+              cur-usage (select-keys result [:psi.agent-session/usage-input
+                                             :psi.agent-session/usage-output
+                                             :psi.agent-session/usage-cache-read
+                                             :psi.agent-session/usage-cache-write])
+              prev-usage (get-in @store [:session-usage-cache session-id])
+              delta      (counters/compute-token-delta cur-usage prev-usage)]
+          ;; Update the per-session usage cache (transient, not persisted).
+          (swap! store assoc-in [:session-usage-cache session-id] cur-usage)
+          (update-metrics! counters/add-token-delta model-id delta))
+        (catch Exception e
+          (println (str "DEBUG [psi/metrics] skipping token tracking for session "
+                        session-id ": " (ex-message e))))))
+    nil))
+
+;;; Formatting
+
+(defn- format-number
+  "Format an integer with thousands separators."
+  [n]
+  (format "%,d" (long n)))
+
+(defn- format-tools-section
+  [tools]
+  (when (seq tools)
+    (let [rows (sort-by key tools)]
+      (str "### Tools (" (count rows) " tracked)\n"
+           "| Tool | Invocations | Errors |\n"
+           "|------|-------------|--------|\n"
+           (str/join "\n"
+                     (map (fn [[name {:keys [invocations errors]}]]
+                            (str "| " name " | " (format-number invocations)
+                                 " | " (format-number (or errors 0)) " |"))
+                          rows))
+           "\n"))))
+
+(defn- format-tokens-section
+  [tokens]
+  (when (seq tokens)
+    (let [rows (sort-by key tokens)]
+      (str "### Token Usage (by model)\n"
+           "| Model | Input | Output | Cache Read | Cache Write |\n"
+           "|-------|-------|--------|------------|-------------|\n"
+           (str/join "\n"
+                     (map (fn [[model {:keys [input output cache-read cache-write]}]]
+                            (str "| " model
+                                 " | " (format-number (or input 0))
+                                 " | " (format-number (or output 0))
+                                 " | " (format-number (or cache-read 0))
+                                 " | " (format-number (or cache-write 0)) " |"))
+                          rows))
+           "\n"))))
+
+(defn- format-simple-section
+  [title items]
+  (when (seq items)
+    (let [rows (sort-by key items)]
+      (str "### " title " (" (count rows) " tracked)\n"
+           "| Name | Invocations |\n"
+           "|------|-------------|\n"
+           (str/join "\n"
+                     (map (fn [[name {:keys [invocations]}]]
+                            (str "| " name " | " (format-number invocations) " |"))
+                          rows))
+           "\n"))))
+
+(defn- format-metrics-summary
+  "Render the metrics map as a markdown string for the /metrics command."
+  [metrics]
+  (let [{:keys [tools workflows commands operations tokens updated-at]} metrics
+        sections (keep identity
+                       [(format-tools-section tools)
+                        (format-tokens-section tokens)
+                        (format-simple-section "Workflows" workflows)
+                        (format-simple-section "Commands" commands)
+                        (format-simple-section "Operations" operations)])]
+    (str "## Usage Metrics\n\n"
+         (if (seq sections)
+           (str/join "\n" sections)
+           "_No metrics recorded yet._\n")
+         (when updated-at
+           (str "\n_Updated: " updated-at "_\n")))))
+
+;;; Operation handler
+
+(defn- invoke-summary
+  "Deterministic operation handler for metrics/summary."
+  [{:keys [_args]}]
+  (update-metrics! counters/inc-operation-invocation "metrics/summary")
+  {:status :ok
+   :data   (get-metrics)})
+
+;;; Command handler
+
+(defn- metrics-command-handler
+  "Slash command handler for /metrics."
+  [_args api]
+  (update-metrics! counters/inc-command-invocation "metrics")
+  (persist/maybe-persist! store writing?)
+  ((:notify api)
+   (format-metrics-summary (get-metrics))
+   {:role "assistant" :custom-type :metrics-summary}))
+
+;;; Init
+
+(defn init
+  "Extension entry point. Called by the psi runtime on load and reload.
+
+   On first init: loads persisted metrics from disk, initialises the store atom.
+   On reload: preserves accumulated counters; updates worktree-path only."
+  [api]
+  (let [worktree-path (get ((:query api) [:psi.agent-session/worktree-path])
+                           :psi.agent-session/worktree-path)]
+    (if @store
+      ;; Reload: preserve counters, update worktree-path in case it changed.
+      (swap! store assoc :worktree-path worktree-path)
+      ;; First init: load persisted metrics (or start empty).
+      (let [initial (persist/load-metrics worktree-path)]
+        (reset! store (persist/empty-store worktree-path initial))))
+    ((:on api) "tool_call"             on-tool-call)
+    ((:on api) "tool_result"           on-tool-result)
+    ((:on api) "session_turn_finished" (make-turn-finished-handler api))
+    ((:register-operation api)
+     {:id          "metrics/summary"
+      :description "Return current usage metrics for all tracked capabilities"
+      :handler     invoke-summary})
+    (when-let [register-command (:register-command api)]
+      (register-command "metrics"
+                        {:description "Display usage metrics summary"
+                         :handler     (fn [args] (metrics-command-handler args api))}))
+    nil))
+
+;;; Schema re-export for consumers
+
+(def metrics-schema schema/metrics-schema)

--- a/extensions/metrics/src/psi/metrics/persistence.clj
+++ b/extensions/metrics/src/psi/metrics/persistence.clj
@@ -1,0 +1,114 @@
+(ns psi.metrics.persistence
+  "Load/save metrics EDN with atomic writes and write-coalescing.
+
+   Atomic writes: spit to a .tmp file then java.nio.file.Files/move with
+   ATOMIC_MOVE + REPLACE_EXISTING to prevent partial-read corruption.
+
+   Write-coalescing: a dirty-flag + CAS gate ensures at most one thread
+   writes at a time, and re-dirtied state triggers a follow-up write."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [psi.metrics.counters :as counters]
+   [psi.metrics.schema :as schema])
+  (:import
+   (java.nio.file Files StandardCopyOption)))
+
+;;; File paths
+
+(defn metrics-file
+  "Return a java.io.File for the metrics EDN file under worktree-path."
+  [worktree-path]
+  (io/file worktree-path ".psi" "metrics.edn"))
+
+(defn- tmp-file
+  "Return the temp file used for atomic writes."
+  [worktree-path]
+  (io/file worktree-path ".psi" ".metrics.edn.tmp"))
+
+;;; Load
+
+(defn load-metrics
+  "Load metrics from worktree-path/.psi/metrics.edn.
+   Returns empty metrics when:
+   - worktree-path is nil (no worktree)
+   - the file does not exist
+   - the file contains invalid EDN
+   - the file does not conform to metrics-schema (logs warning)"
+  [worktree-path]
+  (when worktree-path
+    (let [f (metrics-file worktree-path)]
+      (if (.exists f)
+        (try
+          (let [data (edn/read-string (slurp f))]
+            (if (schema/valid? data)
+              data
+              (do
+                (println (str "WARN [psi/metrics] metrics.edn failed schema validation — "
+                              "starting with empty counters. File preserved at: " (.getAbsolutePath f)))
+                nil)))
+          (catch Exception e
+            (println (str "WARN [psi/metrics] failed to read metrics.edn: "
+                          (ex-message e) " — starting with empty counters"))
+            nil))
+        nil))))
+
+;;; Save
+
+(defn save-metrics!
+  "Atomically write metrics-map to worktree-path/.psi/metrics.edn.
+   Creates the .psi/ directory if absent.
+   No-ops when worktree-path is nil."
+  [worktree-path metrics-map]
+  (when worktree-path
+    (let [f   (metrics-file worktree-path)
+          tmp (tmp-file worktree-path)]
+      (io/make-parents f)
+      (spit tmp (pr-str metrics-map))
+      (Files/move
+       (.toPath ^java.io.File tmp)
+       (.toPath ^java.io.File f)
+       (into-array StandardCopyOption
+                   [StandardCopyOption/ATOMIC_MOVE
+                    StandardCopyOption/REPLACE_EXISTING])))))
+
+;;; Write-coalescing gate
+
+(defn maybe-persist!
+  "Persist the current metrics snapshot if dirty, using a CAS gate to
+   ensure at most one thread writes at a time.
+
+   store-atom shape:
+     {:metrics {...} :worktree-path \"...\" :dirty? true/false ...}
+
+   writing?-atom is a separate boolean atom used as the CAS gate.
+
+   After each write the writer re-checks :dirty? and loops if re-dirtied
+   by concurrent events, coalescing rapid-fire mutations into minimal I/O."
+  [store-atom writing?-atom]
+  (when (compare-and-set! writing?-atom false true)
+    (try
+      (loop []
+        (let [{:keys [metrics worktree-path dirty?]} @store-atom]
+          (when dirty?
+            ;; Clear dirty flag atomically before writing — any concurrent
+            ;; mutation after this swap! will re-set :dirty? to true.
+            (swap! store-atom assoc :dirty? false)
+            (save-metrics! worktree-path metrics)
+            (recur))))
+      (finally
+        (reset! writing?-atom false)))))
+
+(defn mark-dirty-and-persist!
+  "Mark the store as dirty and trigger a coalesced persist."
+  [store-atom writing?-atom]
+  (swap! store-atom assoc :dirty? true)
+  (maybe-persist! store-atom writing?-atom))
+
+(defn empty-store
+  "Return the initial store map for a given worktree-path."
+  [worktree-path initial-metrics]
+  {:metrics          (or initial-metrics (counters/empty-metrics))
+   :worktree-path    worktree-path
+   :session-usage-cache {}
+   :dirty?           false})

--- a/extensions/metrics/src/psi/metrics/schema.clj
+++ b/extensions/metrics/src/psi/metrics/schema.clj
@@ -1,0 +1,46 @@
+(ns psi.metrics.schema
+  "Malli schemas for the metrics extension data shape."
+  (:require
+   [malli.core :as m]))
+
+;;; Schemas
+
+(def counter-schema
+  "Invocation counter for workflows, commands, and operations."
+  [:map
+   [:invocations :int]])
+
+(def tool-counter-schema
+  "Invocation + error counter for tool calls."
+  [:map
+   [:invocations :int]
+   [:errors :int]
+   [:error-reasons [:map-of :string :int]]])
+
+(def token-totals-schema
+  "Cumulative token usage totals for a single model."
+  [:map
+   [:input :int]
+   [:output :int]
+   [:cache-read :int]
+   [:cache-write :int]])
+
+(def metrics-schema
+  "Top-level metrics map persisted to disk and returned by metrics/summary."
+  [:map
+   [:tools [:map-of :string tool-counter-schema]]
+   [:workflows [:map-of :string counter-schema]]
+   [:commands [:map-of :string counter-schema]]
+   [:operations [:map-of :string counter-schema]]
+   [:tokens [:map-of :string token-totals-schema]]
+   [:updated-at [:maybe :string]]])
+
+(defn valid?
+  "Return true when metrics-map conforms to metrics-schema."
+  [metrics-map]
+  (m/validate metrics-schema metrics-map))
+
+(defn explain
+  "Return malli explain output for a metrics-map that fails validation."
+  [metrics-map]
+  (m/explain metrics-schema metrics-map))

--- a/extensions/metrics/test/psi/metrics/counters_test.clj
+++ b/extensions/metrics/test/psi/metrics/counters_test.clj
@@ -1,0 +1,153 @@
+(ns psi.metrics.counters-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [psi.metrics.counters :as counters]))
+
+;;; empty-metrics
+
+(deftest empty-metrics-has-expected-shape-test
+  ;; empty-metrics returns a map with all required keys set to empty collections.
+  (let [m (counters/empty-metrics)]
+    (is (= {} (:tools m)))
+    (is (= {} (:workflows m)))
+    (is (= {} (:commands m)))
+    (is (= {} (:operations m)))
+    (is (= {} (:tokens m)))
+    (is (nil? (:updated-at m)))))
+
+;;; inc-tool-invocation
+
+(deftest inc-tool-invocation-increments-counter-test
+  ;; Each call to inc-tool-invocation adds 1 to :invocations for the named tool.
+  (let [m0 (counters/empty-metrics)
+        m1 (counters/inc-tool-invocation m0 "bash")
+        m2 (counters/inc-tool-invocation m1 "bash")]
+    (is (= 1 (get-in m1 [:tools "bash" :invocations])))
+    (is (= 2 (get-in m2 [:tools "bash" :invocations])))))
+
+(deftest inc-tool-invocation-initialises-error-fields-test
+  ;; A new tool entry gets :errors 0 and :error-reasons {} on first invocation.
+  (let [m (counters/inc-tool-invocation (counters/empty-metrics) "read")]
+    (is (= 0 (get-in m [:tools "read" :errors])))
+    (is (= {} (get-in m [:tools "read" :error-reasons])))))
+
+(deftest inc-tool-invocation-sets-updated-at-test
+  ;; updated-at is set after incrementing.
+  (let [m (counters/inc-tool-invocation (counters/empty-metrics) "write")]
+    (is (string? (:updated-at m)))))
+
+(deftest inc-tool-invocation-tracks-multiple-tools-independently-test
+  ;; Incrementing one tool does not affect another.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-tool-invocation "read")
+              (counters/inc-tool-invocation "read")
+              (counters/inc-tool-invocation "bash"))]
+    (is (= 2 (get-in m [:tools "read" :invocations])))
+    (is (= 1 (get-in m [:tools "bash" :invocations])))))
+
+;;; inc-tool-error
+
+(deftest inc-tool-error-increments-error-counter-test
+  ;; inc-tool-error increments :errors for the named tool.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-tool-invocation "bash")
+              (counters/inc-tool-error "bash" "timeout"))]
+    (is (= 1 (get-in m [:tools "bash" :errors])))
+    (is (= 1 (get-in m [:tools "bash" :error-reasons "timeout"])))))
+
+(deftest inc-tool-error-accumulates-multiple-reasons-test
+  ;; Different error reasons are tracked independently under :error-reasons.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-tool-error "bash" "timeout")
+              (counters/inc-tool-error "bash" "timeout")
+              (counters/inc-tool-error "bash" "parse-error"))]
+    (is (= 2 (get-in m [:tools "bash" :error-reasons "timeout"])))
+    (is (= 1 (get-in m [:tools "bash" :error-reasons "parse-error"])))))
+
+;;; inc-workflow/command/operation-invocation
+
+(deftest inc-workflow-invocation-test
+  ;; Workflow invocations are counted under :workflows.
+  (let [m (-> (counters/empty-metrics)
+              (counters/inc-workflow-invocation "builder")
+              (counters/inc-workflow-invocation "builder"))]
+    (is (= 2 (get-in m [:workflows "builder" :invocations])))))
+
+(deftest inc-command-invocation-test
+  ;; Command invocations are counted under :commands.
+  (let [m (counters/inc-command-invocation (counters/empty-metrics) "metrics")]
+    (is (= 1 (get-in m [:commands "metrics" :invocations])))))
+
+(deftest inc-operation-invocation-test
+  ;; Operation invocations are counted under :operations.
+  (let [m (counters/inc-operation-invocation (counters/empty-metrics) "metrics/summary")]
+    (is (= 1 (get-in m [:operations "metrics/summary" :invocations])))))
+
+;;; add-token-delta
+
+(deftest add-token-delta-accumulates-per-model-test
+  ;; Token deltas accumulate under the model-id key.
+  (let [m (-> (counters/empty-metrics)
+              (counters/add-token-delta "claude-3" {:input 100 :output 50 :cache-read 200 :cache-write 10})
+              (counters/add-token-delta "claude-3" {:input 50  :output 20 :cache-read 0   :cache-write 5}))]
+    (is (= 150 (get-in m [:tokens "claude-3" :input])))
+    (is (= 70  (get-in m [:tokens "claude-3" :output])))
+    (is (= 200 (get-in m [:tokens "claude-3" :cache-read])))
+    (is (= 15  (get-in m [:tokens "claude-3" :cache-write])))))
+
+(deftest add-token-delta-uses-unknown-for-nil-model-test
+  ;; A nil model-id falls back to the "unknown" key.
+  (let [m (counters/add-token-delta (counters/empty-metrics) nil {:input 10 :output 5 :cache-read 0 :cache-write 0})]
+    (is (= 10 (get-in m [:tokens "unknown" :input])))))
+
+(deftest add-token-delta-tracks-multiple-models-independently-test
+  ;; Different model-ids accumulate in separate map entries.
+  (let [m (-> (counters/empty-metrics)
+              (counters/add-token-delta "gpt-4o" {:input 500 :output 100 :cache-read 0 :cache-write 0})
+              (counters/add-token-delta "claude-3" {:input 300 :output 80 :cache-read 0 :cache-write 0}))]
+    (is (= 500 (get-in m [:tokens "gpt-4o" :input])))
+    (is (= 300 (get-in m [:tokens "claude-3" :input])))))
+
+;;; compute-token-delta
+
+(deftest compute-token-delta-first-turn-is-full-value-test
+  ;; When prev-totals is nil (first turn), the full current value is the delta.
+  (let [cur {:psi.agent-session/usage-input 100
+             :psi.agent-session/usage-output 50
+             :psi.agent-session/usage-cache-read 20
+             :psi.agent-session/usage-cache-write 5}
+        delta (counters/compute-token-delta cur nil)]
+    (is (= 100 (:input delta)))
+    (is (= 50  (:output delta)))
+    (is (= 20  (:cache-read delta)))
+    (is (= 5   (:cache-write delta)))))
+
+(deftest compute-token-delta-subsequent-turn-is-incremental-test
+  ;; When prev-totals is known, the delta is the difference.
+  (let [prev {:psi.agent-session/usage-input 100
+              :psi.agent-session/usage-output 50
+              :psi.agent-session/usage-cache-read 20
+              :psi.agent-session/usage-cache-write 5}
+        cur  {:psi.agent-session/usage-input 150
+              :psi.agent-session/usage-output 70
+              :psi.agent-session/usage-cache-read 20
+              :psi.agent-session/usage-cache-write 5}
+        delta (counters/compute-token-delta cur prev)]
+    (is (= 50 (:input delta)))
+    (is (= 20 (:output delta)))
+    (is (= 0  (:cache-read delta)))
+    (is (= 0  (:cache-write delta)))))
+
+(deftest compute-token-delta-clamps-to-zero-test
+  ;; Negative deltas (e.g., counter reset) are clamped to 0.
+  (let [prev {:psi.agent-session/usage-input 200
+              :psi.agent-session/usage-output 100
+              :psi.agent-session/usage-cache-read 0
+              :psi.agent-session/usage-cache-write 0}
+        cur  {:psi.agent-session/usage-input 50
+              :psi.agent-session/usage-output 30
+              :psi.agent-session/usage-cache-read 0
+              :psi.agent-session/usage-cache-write 0}
+        delta (counters/compute-token-delta cur prev)]
+    (is (= 0 (:input delta)))
+    (is (= 0 (:output delta)))))

--- a/extensions/metrics/test/psi/metrics/extension_test.clj
+++ b/extensions/metrics/test/psi/metrics/extension_test.clj
@@ -1,0 +1,251 @@
+(ns psi.metrics.extension-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is use-fixtures]]
+   [psi.extension-test-helpers.nullable-api :as nullable]
+   [psi.metrics.extension :as ext]
+   [psi.metrics.schema :as schema]))
+
+;;; Fixtures
+
+(use-fixtures :each
+  (fn [f]
+    ;; Reset the defonce atoms between tests so each test starts clean.
+    (reset! ext/store nil)
+    (reset! ext/writing? false)
+    (f)
+    (reset! ext/store nil)
+    (reset! ext/writing? false)))
+
+;;; Helpers
+
+(defn- make-api
+  "Create a nullable extension API augmented with :register-operation support.
+   opts are forwarded to create-nullable-extension-api.
+   Returns {:api ... :state atom :ops atom}."
+  ([] (make-api {}))
+  ([opts]
+   (let [{:keys [api state]} (nullable/create-nullable-extension-api opts)
+         ops (atom [])
+         api* (assoc api
+                     :register-operation
+                     (fn [op-spec]
+                       (swap! ops conj op-spec)
+                       nil))]
+     {:api api* :state state :ops ops})))
+
+(defn- fire-event
+  "Fire all registered handlers for event-name with payload."
+  [state event-name payload]
+  (doseq [h (get-in @state [:handlers event-name])]
+    (h payload)))
+
+;;; init registration
+
+(deftest init-registers-three-event-handlers-test
+  ;; init subscribes to tool_call, tool_result, and session_turn_finished.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (is (seq (get-in @state [:handlers "tool_call"])))
+    (is (seq (get-in @state [:handlers "tool_result"])))
+    (is (seq (get-in @state [:handlers "session_turn_finished"])))))
+
+(deftest init-registers-metrics-summary-operation-test
+  ;; init registers the metrics/summary deterministic operation via :register-operation.
+  (let [{:keys [api ops]} (make-api)]
+    (ext/init api)
+    (let [registered (filter #(= "metrics/summary" (:id %)) @ops)]
+      (is (= 1 (count registered)))
+      (is (fn? (:handler (first registered)))))))
+
+(deftest init-registers-metrics-command-test
+  ;; init registers the /metrics slash command when :register-command is available.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (is (contains? (:commands @state) "metrics"))))
+
+(deftest init-returns-nil-test
+  ;; init must return nil.
+  (let [{:keys [api]} (make-api)]
+    (is (nil? (ext/init api)))))
+
+;;; tool_call event
+
+(deftest tool-call-increments-invocation-counter-test
+  ;; tool_call events increment the invocation counter for the named tool.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c2" :input {}})
+    (fire-event state "tool_call" {:tool-name "read" :tool-call-id "c3" :input {}})
+    (let [metrics (:metrics @ext/store)]
+      (is (= 2 (get-in metrics [:tools "bash" :invocations])))
+      (is (= 1 (get-in metrics [:tools "read" :invocations]))))))
+
+(deftest tool-call-without-tool-name-is-ignored-test
+  ;; tool_call events with no :tool-name are silently ignored.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-call-id "c1" :input {}})
+    (is (= {} (get-in @ext/store [:metrics :tools])))))
+
+;;; tool_result event
+
+(deftest tool-result-error-increments-error-counter-test
+  ;; tool_result with :is-error true increments the error counter.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_result"
+                {:tool-name "bash" :tool-call-id "c1" :is-error true :content "Command not found"})
+    (let [metrics (:metrics @ext/store)]
+      (is (= 1 (get-in metrics [:tools "bash" :errors])))
+      (is (= 1 (get-in metrics [:tools "bash" :error-reasons "Command not found"]))))))
+
+(deftest tool-result-success-does-not-increment-error-counter-test
+  ;; tool_result with :is-error false does not touch error counters.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_result"
+                {:tool-name "bash" :tool-call-id "c1" :is-error false :content "ok"})
+    (let [metrics (:metrics @ext/store)]
+      (is (nil? (get-in metrics [:tools "bash" :errors]))))))
+
+(deftest tool-result-error-reason-truncated-to-80-chars-test
+  ;; The error reason key is derived from the first line, max 80 chars.
+  (let [{:keys [api state]} (make-api)
+        long-message (apply str (repeat 100 "x"))]
+    (ext/init api)
+    (fire-event state "tool_result"
+                {:tool-name "read" :tool-call-id "c1" :is-error true :content long-message})
+    (let [reasons (get-in @ext/store [:metrics :tools "read" :error-reasons])]
+      (is (= 1 (count reasons)))
+      (is (<= (count (first (keys reasons))) 80)))))
+
+;;; session_turn_finished event — token accumulation
+
+(deftest turn-finished-accumulates-token-delta-per-model-test
+  ;; session_turn_finished queries usage and accumulates delta under the model-id key.
+  (let [query-session-fn (fn [_session-id _eql]
+                           {:psi.agent-session/usage-input 100
+                            :psi.agent-session/usage-output 50
+                            :psi.agent-session/usage-cache-read 0
+                            :psi.agent-session/usage-cache-write 0
+                            :psi.agent-session/model-id "claude-3"})
+        {:keys [api state]} (make-api {:query-fn (fn [_q] {})})
+        api* (assoc api :query-session query-session-fn)]
+    (ext/init api*)
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t1"})
+    (let [metrics (:metrics @ext/store)]
+      (is (= 100 (get-in metrics [:tokens "claude-3" :input])))
+      (is (= 50  (get-in metrics [:tokens "claude-3" :output]))))))
+
+(deftest turn-finished-computes-delta-on-second-turn-test
+  ;; The second turn for a session contributes only the incremental delta.
+  (let [call-count (atom 0)
+        responses  [{:psi.agent-session/usage-input 100
+                     :psi.agent-session/usage-output 50
+                     :psi.agent-session/usage-cache-read 0
+                     :psi.agent-session/usage-cache-write 0
+                     :psi.agent-session/model-id "claude-3"}
+                    {:psi.agent-session/usage-input 160
+                     :psi.agent-session/usage-output 80
+                     :psi.agent-session/usage-cache-read 0
+                     :psi.agent-session/usage-cache-write 0
+                     :psi.agent-session/model-id "claude-3"}]
+        query-session-fn (fn [_session-id _eql]
+                           (let [idx @call-count]
+                             (swap! call-count inc)
+                             (nth responses idx nil)))
+        {:keys [api state]} (make-api {:query-fn (fn [_q] {})})
+        api* (assoc api :query-session query-session-fn)]
+    (ext/init api*)
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t1"})
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t2"})
+    (let [metrics (:metrics @ext/store)]
+      ;; Total input: 100 (turn1) + 60 (turn2 delta: 160-100) = 160.
+      (is (= 160 (get-in metrics [:tokens "claude-3" :input])))
+      ;; Total output: 50 + 30 = 80.
+      (is (= 80  (get-in metrics [:tokens "claude-3" :output]))))))
+
+(deftest turn-finished-uses-unknown-when-model-id-nil-test
+  ;; When model-id is nil, token delta is accumulated under "unknown".
+  (let [query-session-fn (fn [_session-id _eql]
+                           {:psi.agent-session/usage-input 10
+                            :psi.agent-session/usage-output 5
+                            :psi.agent-session/usage-cache-read 0
+                            :psi.agent-session/usage-cache-write 0
+                            :psi.agent-session/model-id nil})
+        {:keys [api state]} (make-api {:query-fn (fn [_q] {})})
+        api* (assoc api :query-session query-session-fn)]
+    (ext/init api*)
+    (fire-event state "session_turn_finished" {:session-id "s1" :turn-id "t1"})
+    (is (= 10 (get-in @ext/store [:metrics :tokens "unknown" :input])))))
+
+;;; metrics/summary operation
+
+(deftest invoke-summary-returns-ok-with-schema-conforming-data-test
+  ;; metrics/summary returns {:status :ok :data <metrics-map>} conforming to schema.
+  (let [{:keys [api ops state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "read" :tool-call-id "c1" :input {}})
+    (let [op-handler (:handler (first (filter #(= "metrics/summary" (:id %)) @ops)))
+          result (op-handler {:args {}})]
+      (is (= :ok (:status result)))
+      (is (schema/valid? (:data result))))))
+
+;;; /metrics command
+
+(deftest metrics-command-calls-notify-with-markdown-test
+  ;; The /metrics command calls (:notify api) with a markdown-formatted string.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    (let [cmd-handler (get-in @state [:commands "metrics" :handler])]
+      (cmd-handler {})
+      (let [msgs (:messages @state)]
+        (is (seq msgs))
+        (is (str/includes? (:content (last msgs)) "## Usage Metrics"))))))
+
+(deftest metrics-command-includes-tool-section-when-tools-tracked-test
+  ;; The /metrics output includes a Tools section when tool invocations exist.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "edit" :tool-call-id "c1" :input {}})
+    (let [cmd-handler (get-in @state [:commands "metrics" :handler])]
+      (cmd-handler {})
+      (is (str/includes? (:content (last (:messages @state))) "### Tools")))))
+
+(deftest metrics-command-shows-commands-section-when-invoked-test
+  ;; Invoking /metrics self-tracks the invocation under :commands.
+  ;; Even with no other events, the commands section appears.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (let [cmd-handler (get-in @state [:commands "metrics" :handler])]
+      (cmd-handler {})
+      (let [content (:content (last (:messages @state)))]
+        (is (str/includes? content "## Usage Metrics"))
+        (is (str/includes? content "metrics"))))))
+
+;;; Reload behaviour
+
+(deftest reload-preserves-counters-test
+  ;; A second call to init (simulating reload) preserves existing counters.
+  (let [{:keys [api state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    ;; Simulate reload: call init again.
+    (ext/init api)
+    (is (= 1 (get-in @ext/store [:metrics :tools "bash" :invocations])))))
+
+;;; Schema conformance of returned data
+
+(deftest summary-data-conforms-to-schema-after-events-test
+  ;; After processing several events the metrics map still conforms to schema.
+  (let [{:keys [api ops state]} (make-api)]
+    (ext/init api)
+    (fire-event state "tool_call" {:tool-name "bash" :tool-call-id "c1" :input {}})
+    (fire-event state "tool_result" {:tool-name "bash" :tool-call-id "c1"
+                                     :is-error true :content "fail"})
+    (let [op-handler (:handler (first (filter #(= "metrics/summary" (:id %)) @ops)))
+          result (op-handler {:args {}})]
+      (is (schema/valid? (:data result))))))

--- a/extensions/metrics/test/psi/metrics/persistence_test.clj
+++ b/extensions/metrics/test/psi/metrics/persistence_test.clj
@@ -1,0 +1,119 @@
+(ns psi.metrics.persistence-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is]]
+   [psi.metrics.counters :as counters]
+   [psi.metrics.persistence :as persist]))
+
+;;; Helpers
+
+(defn- with-tmp-dir
+  "Call f with a path string pointing to a fresh temp directory.
+   Cleans up afterwards."
+  [f]
+  (let [dir (java.nio.file.Files/createTempDirectory
+             "psi-metrics-test"
+             (into-array java.nio.file.attribute.FileAttribute []))]
+    (try
+      (f (str dir))
+      (finally
+        ;; Best-effort cleanup.
+        (doseq [file (reverse (file-seq (.toFile dir)))]
+          (.delete file))))))
+
+(defn- sample-metrics []
+  {:tools      {"read" {:invocations 5 :errors 1 :error-reasons {"timeout" 1}}}
+   :workflows  {}
+   :commands   {}
+   :operations {}
+   :tokens     {"claude-3" {:input 1000 :output 200 :cache-read 500 :cache-write 50}}
+   :updated-at "2026-05-14T10:00:00Z"})
+
+;;; load-metrics
+
+(deftest load-metrics-returns-nil-for-nil-worktree-test
+  ;; No worktree → no persistence → nil returned.
+  (is (nil? (persist/load-metrics nil))))
+
+(deftest load-metrics-returns-nil-for-missing-file-test
+  ;; File does not exist → nil (caller uses empty-metrics).
+  (with-tmp-dir
+    (fn [dir]
+      (is (nil? (persist/load-metrics dir))))))
+
+(deftest load-metrics-round-trips-valid-data-test
+  ;; save-metrics! followed by load-metrics returns the original map.
+  (with-tmp-dir
+    (fn [dir]
+      (let [m (sample-metrics)]
+        (persist/save-metrics! dir m)
+        (is (= m (persist/load-metrics dir)))))))
+
+(deftest load-metrics-returns-nil-for-corrupt-edn-test
+  ;; A file with invalid EDN is treated as corrupt → nil returned.
+  (with-tmp-dir
+    (fn [dir]
+      (let [f (persist/metrics-file dir)]
+        (io/make-parents f)
+        (spit f "{{not valid edn")
+        (is (nil? (persist/load-metrics dir)))))))
+
+(deftest load-metrics-returns-nil-for-schema-invalid-data-test
+  ;; Valid EDN that does not conform to metrics-schema → nil returned.
+  (with-tmp-dir
+    (fn [dir]
+      (let [f (persist/metrics-file dir)]
+        (io/make-parents f)
+        (spit f (pr-str {:unexpected "shape"}))
+        (is (nil? (persist/load-metrics dir)))))))
+
+;;; save-metrics!
+
+(deftest save-metrics-creates-psi-directory-test
+  ;; save-metrics! creates the .psi/ directory if absent.
+  (with-tmp-dir
+    (fn [dir]
+      (let [psi-dir (io/file dir ".psi")]
+        (is (not (.exists psi-dir)))
+        (persist/save-metrics! dir (sample-metrics))
+        (is (.exists psi-dir))))))
+
+(deftest save-metrics-no-op-for-nil-worktree-test
+  ;; save-metrics! is a no-op when worktree-path is nil (no exception).
+  (is (nil? (persist/save-metrics! nil (sample-metrics)))))
+
+;;; maybe-persist! write-coalescing
+
+(deftest maybe-persist-coalesces-concurrent-mutations-test
+  ;; When writing? is true, a second call to maybe-persist! is a no-op (does not
+  ;; attempt a concurrent write). After the writer finishes, writing? is reset.
+  (with-tmp-dir
+    (fn [dir]
+      (let [store    (atom (persist/empty-store dir (counters/empty-metrics)))
+            writing? (atom false)]
+        ;; Mark dirty and persist once.
+        (persist/mark-dirty-and-persist! store writing?)
+        ;; After completion, writing? is false and the file exists.
+        (is (false? @writing?))
+        (is (.exists (persist/metrics-file dir)))))))
+
+(deftest mark-dirty-and-persist-writes-current-state-test
+  ;; After mark-dirty-and-persist!, the file on disk contains the current metrics.
+  (with-tmp-dir
+    (fn [dir]
+      (let [m        (counters/inc-tool-invocation (counters/empty-metrics) "bash")
+            store    (atom (assoc (persist/empty-store dir nil) :metrics m))
+            writing? (atom false)]
+        (persist/mark-dirty-and-persist! store writing?)
+        (let [loaded (persist/load-metrics dir)]
+          (is (= 1 (get-in loaded [:tools "bash" :invocations]))))))))
+
+;;; empty-store
+
+(deftest empty-store-shape-test
+  ;; empty-store returns a map with the expected keys.
+  (let [s (persist/empty-store "/tmp/test" nil)]
+    (is (= "/tmp/test" (:worktree-path s)))
+    (is (map? (:metrics s)))
+    (is (= {} (:session-usage-cache s)))
+    (is (false? (:dirty? s)))))

--- a/extensions/metrics/test/psi/metrics/schema_test.clj
+++ b/extensions/metrics/test/psi/metrics/schema_test.clj
@@ -1,0 +1,55 @@
+(ns psi.metrics.schema-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [psi.metrics.schema :as schema]))
+
+(deftest valid?-accepts-empty-metrics-test
+  ;; A freshly-initialised metrics map with all empty sub-maps is valid.
+  (is (schema/valid? {:tools      {}
+                      :workflows  {}
+                      :commands   {}
+                      :operations {}
+                      :tokens     {}
+                      :updated-at nil})))
+
+(deftest valid?-accepts-populated-metrics-test
+  ;; Fully-populated metrics with realistic data is valid.
+  (is (schema/valid?
+       {:tools      {"read" {:invocations 10 :errors 1 :error-reasons {"timeout" 1}}}
+        :workflows  {"builder" {:invocations 3}}
+        :commands   {"metrics" {:invocations 2}}
+        :operations {"metrics/summary" {:invocations 5}}
+        :tokens     {"claude-sonnet-4" {:input 1000 :output 200 :cache-read 500 :cache-write 100}}
+        :updated-at "2026-05-14T10:00:00Z"})))
+
+(deftest valid?-rejects-missing-required-key-test
+  ;; A map missing :tools fails validation.
+  (is (not (schema/valid? {:workflows  {}
+                           :commands   {}
+                           :operations {}
+                           :tokens     {}
+                           :updated-at nil}))))
+
+(deftest valid?-rejects-wrong-type-for-invocations-test
+  ;; :invocations must be an integer, not a string.
+  (is (not (schema/valid?
+            {:tools      {"bash" {:invocations "not-a-number" :errors 0 :error-reasons {}}}
+             :workflows  {}
+             :commands   {}
+             :operations {}
+             :tokens     {}
+             :updated-at nil}))))
+
+(deftest valid?-rejects-wrong-token-shape-test
+  ;; Token totals must have all four keys as ints.
+  (is (not (schema/valid?
+            {:tools      {}
+             :workflows  {}
+             :commands   {}
+             :operations {}
+             :tokens     {"gpt-4o" {:input 100}}
+             :updated-at nil}))))
+
+(deftest explain-returns-non-nil-for-invalid-test
+  ;; explain provides diagnostic info for invalid maps.
+  (is (some? (schema/explain {:not "valid"}))))

--- a/extensions/metrics/tests.edn
+++ b/extensions/metrics/tests.edn
@@ -1,0 +1,4 @@
+#kaocha/v1
+ {:tests [{:id          :unit
+           :test-paths  ["test"]
+           :ns-patterns [".*-test$"]}]}

--- a/mementum/state.md
+++ b/mementum/state.md
@@ -138,5 +138,13 @@ Bootstrapped on 2026-04-02.
   - updated `AGENTS.md` with a concise psi self-reload loop near runtime tooling guidance
   - updated `README.md` to point readers at the documented self-reload loop in `doc/psi-project-config.md`
 
+- Task 151 edit-clj structural edit extension is now complete and closed:
+  - added `extensions/edit-clj/` with `psi.edit-clj.core` (pure: parse-single-form, find-candidates, apply-line-filter, replace-in) and `psi.edit-clj.extension` (tool registration + file I/O + JSON serialisation)
+  - tool named `"edit-clj"`; matches by sexpr equality via `rewrite-clj`; supports optional `start-line`/`end-line` filtering by node start-row
+  - validation order: old-string → new-string → file (first error returned)
+  - result shapes: ok, parse-error, file-not-found, no-match, ambiguous-match
+  - wired into top-level `deps.edn` (4 source-path locations + test paths + `rewrite-clj/rewrite-clj 1.1.47` in runtime+test extra-deps), `tests.edn` (unit, extensions, integration suites), and `psi-owned-extension-catalog` (`:development`+`:installed` only, following `github` pattern)
+  - 19 extension tests, 73 assertions; 1776+169 broader suite green; lint clean
+
 ## Suggested next step
-- Next candidates from backlog: `108-project-nrepl-testing-without-mocks`, `136-built-in-registration-path-for-workflow`, `134-psi-tool-mutation-surface-and-active-session-introspection`.
+- Next candidates from backlog: `108-project-nrepl-testing-without-mocks`, `136-built-in-registration-path-for-workflow`, `149-reload-fixup-inventory-and-safety`.

--- a/munera/closed/151-edit-clj-structural-edit-extension/design-steps.md
+++ b/munera/closed/151-edit-clj-structural-edit-extension/design-steps.md
@@ -1,0 +1,12 @@
+# Design Follow-up Steps — 151 edit-clj structural edit extension
+
+- [x] A1: Clarify `ok` result `old`/`new` fields — specify whether they are the argument strings or the actual matched node text from the file (these differ when whitespace differs). Recommend: matched node text for `old`, argument string for `new`.
+- [x] A2: Define the `hint` field content for `no-match` and `ambiguous-match` — specify what guidance the hint should provide (e.g. for no-match: suggest adding/widening `start-line`/`end-line`; for ambiguous-match: suggest narrowing the line range).
+- [x] A3: State validation order as an explicit contract — specify that old-string is validated first, then new-string, then file open, and that the first error encountered is returned.
+- [x] A4: Add `cheshire/cheshire {:mvn/version "5.13.0"}` to the `deps.edn` scope in the design.
+- [x] A5: Expand wiring scope — add `bases/main/src/psi/launcher/extensions.clj` (psi-owned-extension-catalog entry + `:psi/init` symbol), top-level `deps.edn` source paths, and top-level `tests.edn` test/source paths to the list of files that must be updated. Clarify the init symbol (`psi.edit-clj.extension/init`).
+- [x] A6: Specify that `location` in the `ok` result reports the old node's position (before replacement), as that is the file position the agent used to identify the target.
+- [x] A7: Specify that `:execute` must support both `([args])` and `([args opts])` arities, consistent with the `work-on` pattern, to ensure compatibility with callers that may omit opts.
+- [x] I1: Resolve wiring scope conflict — design says wire into `extensions/deps.edn` and `extensions/tests.edn`, but `github` (the stated reference) is NOT in those files; it is wired only via top-level `deps.edn` source paths and `tests.edn`. Decide which model `edit-clj` follows and update the Scope wiring list accordingly.
+- [x] I2: Specify the psi-owned-extension-catalog lib key — name the exact `'psi/...` symbol to use as the map key for the new catalog entry (e.g. `'psi/edit-clj`).
+- [x] I3: Specify `:source-policies` for the catalog entry — state whether the entry should include `:development`, `:installed`, and `:jar` policies (like most psi-owned extensions) or only `:development` and `:installed` (like `github`), since both patterns exist and the design says "follow github" without clarifying which aspects to follow.

--- a/munera/closed/151-edit-clj-structural-edit-extension/design.md
+++ b/munera/closed/151-edit-clj-structural-edit-extension/design.md
@@ -1,0 +1,125 @@
+# 151 — edit-clj structural edit extension
+
+## Intent
+
+Add a psi extension that exposes an `edit-clj` tool to the AI agent. The tool performs structural (S-expression) replacement of a single Clojure form inside a source file using `rewrite-clj`, preserving all original formatting outside the replaced node.
+
+The tool is the structural counterpart to the existing text-based `edit` tool: where `edit` matches by exact string, `edit-clj` matches by S-expression equality, ignoring whitespace and formatting.
+
+## Problem
+
+The text-based `edit` tool requires exact whitespace matching and breaks when formatting changes. Structural editing of Clojure files — renaming a binding, swapping a function call, replacing a literal — is a common AI agent operation that deserves a format-preserving, semantics-based matching strategy.
+
+## Scope
+
+**In scope:**
+- New extension directory `extensions/edit-clj/`
+- Single tool `edit-clj` registered via `(:register-tool api)` in `init`
+- Core logic namespace `psi.edit-clj.core` (pure: zipper walk, match, replace)
+- Extension entry point `psi.edit-clj.extension` (calls `(:register-tool api)`)
+- Unit tests covering all result shapes (ok, file-not-found, parse-error, no-match, ambiguous-match)
+- `deps.edn` with `rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}` and `cheshire/cheshire {:mvn/version "5.13.0"}` as runtime deps
+- Wire into top-level `deps.edn` source paths (`extensions/edit-clj/src`) and top-level `tests.edn` test/source paths (`extensions/edit-clj/test`, `extensions/edit-clj/src`) — **not** into `extensions/deps.edn` or `extensions/tests.edn` (github follows this same top-level-only model and is absent from both extensions-level files)
+- Add entry to `bases/main/src/psi/launcher/extensions.clj` psi-owned-extension-catalog with:
+  - lib key: `'psi/edit-clj`
+  - init symbol: `psi.edit-clj.extension/init`
+  - `:source-policies` with `:development` and `:installed` only (no `:jar`), following the `github` pattern
+
+**Out of scope:**
+- Multi-form replacement in a single call
+- Scope-aware matching (lexical context disambiguation)
+- Dry-run / preview mode
+- Integration with nREPL or live evaluation
+- EDN-only mode or separate EDN tool
+- Formatting / pretty-printing of the replaced node's surrounding context
+
+## Overall Functionality
+
+### Tool: `edit-clj`
+
+**Tool description** (rendered into the agent prompt — terse, one-form contract explicit):
+
+> Replace one Clojure form in a file by S-expression equality; `old-string` and `new-string` must each be one complete, parseable form.
+
+**Parameters** (JSON Schema):
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filename` | string | yes | Path to the Clojure source file. Relative paths resolve against `:cwd` from opts (session worktree). |
+| `old-string` | string | yes | Exactly one parseable Clojure form. Matched by `sexpr` equality. |
+| `new-string` | string | yes | Exactly one parseable Clojure form. Replaces the matched node verbatim. |
+| `start-line` | integer | no | 1-indexed first line of the match window (inclusive). |
+| `end-line` | integer | no | 1-indexed last line of the match window (inclusive). |
+
+**Validation order (explicit contract):** `old-string` is validated first, then `new-string`, then the file is opened. The first error encountered is returned and no further validation is performed. If `old-string` is invalid and `new-string` is also invalid, the `old-string` parse error is returned. If both strings are valid but the file does not exist, `file-not-found` is returned.
+
+**Matching:**
+1. Parse `old-string` via `rewrite-clj` zipper; call `.sexpr` to get the target value. Error if the string yields more than one form or is unparseable.
+2. Parse `new-string` the same way. Error if unparseable or multi-form.
+3. Open the file. Error if not found/unreadable.
+4. Parse the **whole file** into a format-preserving zipper with position tracking. The line range is never used to limit the parse input: a file slice may not contain complete forms, and rewrite-clj assigns positions relative to the start of whatever it was given — feeding it a slice would produce wrong positions throughout.
+5. Walk depth-first. At each node, skip if `sexpr` is not available (comments, whitespace, uneval nodes). Otherwise compare `sexpr` to target.
+6. Optionally filter candidates by line range using the node's **start row** only. Each bound is independently optional and open when absent: a node is included when `(start-line is absent OR start-line ≤ node-start-row) AND (end-line is absent OR node-start-row ≤ end-line)`. When neither bound is supplied the filter is a no-op. The node's end row is irrelevant — a form that begins within the range but extends past `end-line` is still considered in-range. A form that ends within the range but begins before `start-line` is excluded.
+7. Collect all matches before replacement.
+8. Zero matches → `no-match` error; file unchanged.
+9. Two or more matches → `ambiguous-match` error with location list; file unchanged.
+10. Exactly one match → replace node with parsed `new-string` node; write file.
+
+**Line-range semantics rationale:** Filtering by start row only is the most useful behaviour for the primary disambiguation use case — "there are two identical forms, I want the one near line N." Requiring the entire form to be within the range would silently fail when a large form starts at the target line but extends further, producing a confusing `no-match` even though the right node was identified.
+
+**Output:** JSON object — see result shapes below.
+
+### Result shapes
+
+```
+ok              → {status, filename, location {line, column}, old, new}
+file-not-found  → {status, code, filename, message}
+parse-error     → {status, code, argument, message}
+no-match        → {status, code, filename, message, hint}
+ambiguous-match → {status, code, filename, match-count, matches [{line, column, text}], message, hint}
+```
+
+**Field semantics:**
+
+- `ok.old` — the actual matched node text as it appears in the file (from `rewrite-clj.zip/string` on the matched node), not the `old-string` argument. This reflects the real file content that was replaced, which may differ from the argument in whitespace and formatting.
+- `ok.new` — the `new-string` argument string verbatim.
+- `ok.location` — the matched node's start position **before** replacement (line/column in the original file). This is the file position the agent used to identify the target; the post-write position is irrelevant for confirmation.
+- `no-match.hint` — "Try adding or widening the `start-line`/`end-line` range, or verify that `old-string` appears in the file."
+- `ambiguous-match.hint` — "Narrow the `start-line`/`end-line` range to isolate the intended occurrence."
+
+## Architecture alignment
+
+- Extension lives under `extensions/edit-clj/`, following the pattern of `github`, `work-on`, `hello-ext`.
+- Core logic in `psi.edit-clj.core` is a pure namespace: takes strings and file content, returns a result map. No I/O — I/O is isolated in `psi.edit-clj.extension` (file read/write).
+- The tool's `:execute` fn must support both `([args])` and `([args opts])` arities (consistent with the `work-on` pattern), where `opts` includes `:cwd` (session worktree path). Relative filenames are resolved against `:cwd`. When called with one argument, `:cwd` is treated as absent (relative paths resolve against the process working directory).
+- Tool registered via `(:register-tool api)` in `init`, matching the `work-on` pattern.
+- No state atom required — tool is stateless.
+- Output is a JSON string (cheshire) so it renders cleanly in the agent conversation.
+
+## Structures and patterns
+
+- Follow `github` for `deps.edn` structure and `work-on` for tool registration shape.
+- Core logic: `rewrite-clj.zip` for format-preserving zipper; `rewrite-clj.zip/sexpr` for equality; `rewrite-clj.zip/replace` for substitution; `rewrite-clj.zip/root-string` for serializing back to text. The replacement node must be the root node of the format-preserving parse of `new-string` — never reconstructed via `sexpr`/`coerce`, which would silently drop comments and formatting.
+- Line-range filtering: use `rewrite-clj.zip/node` → `rewrite-clj.node/start-row` for candidate filtering; end-row is not consulted. rewrite-clj nodes carry `:row`/`:col` position metadata accessible via `rewrite-clj.node/meta`.
+- Error short-circuit with early returns; no exceptions for expected error paths.
+- Parameters stored as data map (not `pr-str` string) — normalized by `defs/normalize-tool-def`.
+- Result serialized to JSON string via `cheshire.core/generate-string` before returning from `:execute`.
+
+## Acceptance criteria
+
+1. `edit-clj` replaces exactly one matching S-expression in a file and writes it back; all whitespace outside the replaced node is byte-for-byte identical.
+2. When `old-string` matches zero nodes (or zero nodes in the line range), the file is unchanged and the result is `{:status "error" :code "no-match" ...}`.
+3. When `old-string` matches two or more nodes, the file is unchanged and the result is `{:status "error" :code "ambiguous-match" :matches [...] ...}`.
+4. Invalid Clojure in `old-string` or `new-string` returns `{:status "error" :code "parse-error" :argument "old-string"|"new-string" ...}`.
+5. Non-existent file returns `{:status "error" :code "file-not-found" ...}`.
+6. `start-line`/`end-line` constrains matching by node start row. Specific cases:
+   - a. Two identical forms in the file; one starts inside the range, the other outside → single match (disambiguation succeeds).
+   - b. A form whose start row is within the range but whose end row extends past `end-line` → matched (start-row only rule).
+   - c. A form whose end row is within the range but whose start row is before `start-line` → not matched (start-row before range).
+   - d. Two identical forms both starting within the range → `ambiguous-match` (range alone cannot disambiguate; `old-string` must be made more specific).
+   - e. A valid range that contains no node starts matching `old-string` → `no-match`; file unchanged.
+   - f. A small form (e.g. a symbol) nested inside a larger form that straddles the boundary (parent starts before `start-line`) → matched when the symbol's own start row is within the range, because the whole file is parsed and position metadata is file-relative throughout.
+7. Comments inside `new-string` are preserved verbatim in the written file. The replacement node is taken directly from the format-preserving parse of `new-string`; it must never be round-tripped through `sexpr`/`coerce`, which would drop comment nodes.
+8. Multi-form `old-string` or `new-string` returns a `parse-error`.
+9. The tool `:description` is ≤ 20 words and explicitly states that `old-string` and `new-string` must each be exactly one complete Clojure form.
+10. The extension `init` registers exactly one tool named `"edit-clj"`.
+11. All unit tests pass; lint clean.

--- a/munera/closed/151-edit-clj-structural-edit-extension/implementation.md
+++ b/munera/closed/151-edit-clj-structural-edit-extension/implementation.md
@@ -1,0 +1,168 @@
+# Implementation Notes — 151 edit-clj structural edit extension
+
+## 2026-05-14 — task-test-review follow-up execution (R1–R4)
+
+All four review follow-up items executed:
+
+- **R1+R2**: Added `sexpr-whitespace-insensitive-test` in `core_test.clj`. Two subtests: (1) `"(+ x 1)"` as `old-string` matches file node `"(+  x  1)"` — asserts `ok` status, replacement present in `:content`, and `:old` = `"(+  x  1)"` (file text). (2) `"(let [a 1] a)"` matches `"(let [a  1] a)"` — asserts `:old` ≠ `old-string`, proving field semantics.
+- **R3**: Extended `round-trip-write-test` first subtest to assert `(contains? result :old)` and `(contains? result :new)` on parsed JSON — all five `ok` fields now verified in the serialised output.
+- **R4**: Added third case to `validation-order-test`: valid `old-string ":ok"` + invalid `new-string "(["` → `parse-error` with `argument = "new-string"`. Exercises the new-string validation branch in `execute` at the extension level.
+
+Verification: 21 tests, 89 assertions, 0 failures (extensions/edit-clj); 171 tests, 667 assertions, 0 failures (top-level :extensions suite); lint clean.
+
+## 2026-05-14 — task-implementation-review pass 1
+
+Code matches design. Wiring correct (top-level deps.edn, tests.edn, launcher catalog). Lint clean. 20 tests, 78 assertions, 0 failures.
+
+**R1 — Sexpr-whitespace-insensitivity not tested (robustness).**
+The primary differentiator from the text `edit` tool is S-expression equality ignoring whitespace and formatting. No test exercises a case where `old-string` whitespace differs from the file node (e.g. `"(+  x  1)"` in file, `"(+ x 1)"` as `old-string`). A test suite using only exact-string inputs would pass even if the implementation accidentally used string equality instead of `sexpr` equality. This gap means the core feature claim has no falsifying test.
+
+**R2 — `ok.old` field never tested with a differing value (consistency).**
+Design says `ok.old` = "actual matched node text as it appears in the file … may differ from the argument in whitespace." The sole test asserting `:old` uses `old-string = "(+ x 1)"` and file content `"(+ x 1)"` — they coincide. No test shows `ok.old ≠ old-string`. This is the companion gap to R1: the field semantics are unverified for the case the design specifically calls out.
+
+**R3 — Extension round-trip test omits `:old` and `:new` field assertions (consistency).**
+`round-trip-write-test` checks `:status`, `:filename`, and `(contains? result :location)` but does not assert `:old` or `:new` are present in the JSON result. The design's `ok` result shape specifies all five fields; the extension test only verifies three of them.
+
+## 2026-05-14 — code-shaper follow-up execution (S1–S6)
+
+All six shaper items executed:
+
+- **S1+S3**: `find-candidates` stores `:zloc` (not `:node`). `replace-in` uses `(z/replace (:zloc candidate) new-node)` directly — no second `z/of-string` + position-walk. `replace-failed` branch removed (was only reachable from the second walk; now structurally impossible).
+- **S2**: Removed `_old-node` first parameter from `replace-in`. New signature: `[new-node new-str candidates]`. Updated sole call site in `extension.clj` and test helper in `core_test.clj`.
+- **S4**: `replace-in` accepts `new-str` (original `new-string` argument) and returns it verbatim in `:new`. Added `ok-new-verbatim-test` asserting `(= "  :y  " (:new result))` when `new-string = "  :y  "`.
+- **S5**: Unified to `n/sexpr` for all sexpr calls in `find-candidates`: `(n/sexpr old-node)` for target; `(n/sexpr (z/node z))` for per-node comparison. Removed `z/sexpr` usage.
+- **S6**: Second subtest of `comment-in-new-string-preserved-test` now asserts `(= ":y" (n/string (:ok result)))`, documenting the known boundary: AC 7 covers comments *inside* a form; leading (top-level) comments are filtered by `n/whitespace-or-comment?` during form extraction and are not preserved.
+
+Verification: 20 tests, 78 assertions, 0 failures (local); 170 extension tests, 0 failures (top-level); lint clean.
+
+## 2026-05-14 — code-shaper review pass 1
+
+Reviewed `core.clj`, `extension.clj`, `core_test.clj`, `extension_test.clj` against design.md.
+
+**S1 — Double zipper walk + dead `:node` field (simplicity).**
+`find-candidates` stores `{:node … :row … :col … :text …}` in each candidate map, but
+`replace-in` never reads `:node` — it re-parses `file-content` from scratch and walks again
+by position to find the replacement site.  The stored `:node` is dead data and the second
+walk is redundant.  Fix: store the zipper loc (`:zloc`) in the candidate map and use it
+directly in `replace-in`, eliminating the second `z/of-string` + loop.
+
+**S2 — Dead first parameter `_old-node` in `replace-in` (simplicity).**
+`replace-in` accepts `[_old-node new-node file-content candidates]` but `_old-node` is
+never read.  The underscore prefix documents the intent, but the parameter itself should be
+removed from the public signature to avoid confusing callers and polluting the API surface.
+
+**S3 — `replace-failed` code is untested and undocumented (robustness).**
+The `replace-failed` error branch in `replace-in` can be triggered if a candidate's
+position is found during `find-candidates` but not re-located in the second walk (e.g.
+due to a bug in position tracking).  No test covers this path, and it is absent from the
+design's result shapes.  Either add a test that exercises it via a test-double or remove
+the branch and let an exception propagate (making the impossible case loud).
+
+**S4 — `ok.new` deviates from design spec (consistency).**
+Design says `ok.new` = "the `new-string` argument string verbatim."  Code returns
+`(n/string new-node)` where `new-node` is the significant child extracted by
+`parse-single-form`.  If `new-string` has leading/trailing whitespace (e.g. `"  :foo  "`),
+`n/string` returns `":foo"`, not the argument verbatim.  The test only checks
+`(= "(* x 2)" (:new result))` where argument and node-string coincidentally match.
+Either update the design to say "node string of the parsed form" or store and return the
+original argument string.
+
+**S5 — `n/sexpr` / `z/sexpr` mixing (consistency).**
+`find-candidates` computes the target via `(n/sexpr old-node)` but compares candidates
+via `(z/sexpr z)`.  `z/sexpr` delegates to `(n/sexpr (z/node z))`, so they are
+semantically equivalent, but mixing the two entry points without explanation is a
+consistency smell.  Unify to one call site.
+
+**S6 — AC 7 second subtest contradicts the "verbatim" claim (consistency).**
+The second case in `comment-in-new-string-preserved-test` asserts that
+`";; comment\n:y"` parses successfully but does not assert the comment survives in the
+output.  When `new-string` begins with a comment, `parse-single-form` extracts `:y` as the
+significant node; `n/string` returns `":y"` — the comment is silently dropped.  The test
+comment says "parse must succeed" but says nothing about preservation.  The design AC 7
+says "comments inside `new-string` are preserved verbatim."  A leading comment is
+arguably not "inside" the form, but the boundary is unstated; the test should either
+assert the comment is dropped (document the known limitation) or the design should
+explicitly exclude leading comments from the preservation guarantee.
+
+## 2026-05-14 — Ambiguity follow-up execution (design-steps A1–A7)
+
+All seven design follow-up steps executed against design.md:
+
+- **A1**: `ok.old` = matched node text via `rewrite-clj.zip/string`; `ok.new` = `new-string` argument verbatim. Added to Result shapes § Field semantics.
+- **A2**: `no-match.hint` = "Try adding or widening the `start-line`/`end-line` range, or verify that `old-string` appears in the file." `ambiguous-match.hint` = "Narrow the `start-line`/`end-line` range to isolate the intended occurrence." Added to Field semantics.
+- **A3**: Validation order stated as explicit contract before Matching steps: old-string → new-string → file open; first error returned; both-invalid → old-string error wins.
+- **A4**: `cheshire/cheshire {:mvn/version "5.13.0"}` added to Scope deps list alongside rewrite-clj.
+- **A5**: Wiring scope expanded in Scope: top-level `deps.edn` source paths, top-level `tests.edn` test/source paths, and `bases/main/src/psi/launcher/extensions.clj` catalog entry with init symbol `psi.edit-clj.extension/init`.
+- **A6**: `ok.location` = old node's start position before replacement. Added to Field semantics.
+- **A7**: `:execute` must support both `([args])` and `([args opts])` arities per `work-on` pattern. Updated Architecture alignment §.
+
+---
+
+## 2026-05-14 — Inconsistency review pass 1
+
+Reviewed design.md against extensions/deps.edn, extensions/tests.edn, top-level deps.edn, tests.edn, and bases/main/src/psi/launcher/extensions.clj.
+
+### Findings
+
+**I1 — Wiring scope conflicts with the github reference pattern.**
+Design says "Wire into `extensions/deps.edn` and `extensions/tests.edn`", but `github` (the stated reference pattern) is NOT wired into `extensions/deps.edn` or the `extensions/tests.edn` `:test` alias — it is wired only into top-level `deps.edn` source paths and `tests.edn`. The two wiring models are mutually inconsistent; the design must choose one and apply it consistently.
+
+**I2 — Catalog lib key (the `'psi/...` symbol) never specified.**
+Design says "Add entry to `psi-owned-extension-catalog` with init symbol `psi.edit-clj.extension/init`" but never names the catalog map key (e.g. `'psi/edit-clj`). Every existing entry has an explicit lib symbol key; without it the implementor must guess.
+
+**I3 — Catalog `:source-policies` shape unspecified.**
+The design says to add a psi-owned-extension-catalog entry but does not specify `:source-policies`. All psi-owned extensions have `:development` + `:installed` + `:jar` policies *except* `github` (which has no `:jar`). Since the design says "follow github", it is unclear whether `:jar` should be included. This must be stated.
+
+---
+
+## 2026-05-14 — Ambiguity review pass 1
+
+Reviewed design.md against the extension codebase (work-on, github, hello-ext, launcher/extensions.clj, deps.edn, tests.edn).
+
+### Findings
+
+**A1 — `ok` result `old`/`new` field semantics unspecified.**
+The design shows `ok → {status, filename, location, old, new}` but does not say whether `old` and `new` are the argument strings or the actual matched node text. These differ when `old-string` has different whitespace than the file node (sexpr equality ignores whitespace). The matched node text is more useful for confirmation.
+
+**A2 — `hint` field content never defined.**
+Both `no-match` and `ambiguous-match` include a `hint` field in the result shape, but the design never specifies what the hint should say. Implementors must guess.
+
+**A3 — Validation order / error priority not stated as a contract.**
+Steps 1→2→3 imply old-string is validated before new-string, which is validated before file open. But this ordering is not stated as an explicit contract. If both strings are invalid, which error is returned? If new-string is invalid but the file doesn't exist, which error wins?
+
+**A4 — `cheshire` missing from deps spec.**
+The design requires `cheshire.core/generate-string` for JSON serialization but the deps.edn scope only names `rewrite-clj/rewrite-clj`. Cheshire must also be listed.
+
+**A5 — Wiring scope underspecified; launcher catalog omitted.**
+Design says "Wire into `extensions/deps.edn` and `extensions/tests.edn`" but the actual system-wide wiring requires four additional files: `bases/main/src/psi/launcher/extensions.clj` (catalog entry + init symbol), top-level `deps.edn` source paths, and top-level `tests.edn` test/source paths. The launcher catalog is the critical gap — without it the extension is never loaded at runtime.
+
+**A6 — `ok` result `location` field: old node or new node position?**
+Not specified. Since the file is written after replacement, the old node's file position is the meaningful one for the agent to confirm the correct location was edited.
+
+**A7 — `:execute` arity: single or dual?**
+Design specifies `(args opts)` but `work-on` uses two arities `([args] [args _opts])`. Not stated whether single-arity is sufficient or dual-arity is required for compatibility.
+
+---
+
+## 2026-05-14 — task-test-review pass 1
+
+Reviewed `core_test.clj` and `extension_test.clj` against design.md acceptance criteria and the skill criteria: well-formed, full behaviour coverage, no mocks/stubs.
+
+**Infrastructure deps:** `nullable/create-nullable-extension-api` used throughout extension tests; real temp files for I/O cases. No mocks, no stubs — compliant.
+
+**Well-formedness:** Tests are clear and focused. `edit` helper in `core_test` is a clean orchestration shim. Minor: `round-trip-write-test` asserts `(contains? result :location)` but not the location value — weaker than `single-match-replace-test` which asserts `{:line 3 :column 15}`.
+
+**Coverage gaps — pre-existing (steps.md R1/R2/R3 still unchecked):**
+- R1/R2: No test exercises sexpr-equality across differing whitespace (the primary differentiator from text `edit`). All `core_test` inputs use exact-string matches. The core feature claim has no falsifying test.
+- R3: `round-trip-write-test` does not assert `:old` or `:new` fields in the JSON result; only `:status`, `:filename`, `:location` are checked.
+
+**R4 — new gap: extension new-string parse-error path untested.**
+`validation-order-test` covers "both invalid → old-string wins" and "invalid old-string → parse-error beats file-not-found" but has no case for "valid old-string + invalid new-string → new-string parse-error". The `execute` new-string branch is exercised only indirectly. Design validation-order contract requires this to be an explicit assertion.
+
+## 2026-05-14 — Inconsistency follow-up execution (design-steps I1–I3)
+
+Investigated the actual codebase to resolve three wiring/catalog inconsistencies. Verified against `extensions/deps.edn`, `extensions/tests.edn`, top-level `deps.edn`, and `bases/main/src/psi/launcher/extensions.clj`.
+
+- **I1 — Wiring model resolved**: `github` is absent from `extensions/deps.edn` (not listed as a `:local/root` dep) and absent from the `extensions/tests.edn` `:test` alias extra-paths. It is wired exclusively via top-level `deps.edn` source paths and top-level `tests.edn`. Updated Scope in design.md: removed the `extensions/deps.edn`/`extensions/tests.edn` bullet; replaced with explicit top-level-only wiring statement (`extensions/edit-clj/src` in source paths, `extensions/edit-clj/test` + `extensions/edit-clj/src` in test paths), with an explicit note that github follows the same model.
+- **I2 — Catalog lib key specified**: `'psi/edit-clj` — follows the `'psi/<extension-name>` pattern used by all existing entries. Added to Scope catalog entry spec in design.md.
+- **I3 — `:source-policies` shape specified**: `:development` + `:installed` only, no `:jar`. `github` is the only psi-owned extension without `:jar`; since design says "follow github", no `:jar` policy. Added to Scope catalog entry spec in design.md.

--- a/munera/closed/151-edit-clj-structural-edit-extension/plan.md
+++ b/munera/closed/151-edit-clj-structural-edit-extension/plan.md
@@ -1,0 +1,146 @@
+# Plan — 151 edit-clj structural edit extension
+
+## Approach
+
+Build thin-but-complete vertical slices: pure core first (independently testable), then
+extension shell (tool registration + file I/O), then wiring into the top-level project.
+Each slice is self-contained and verifiable before the next begins.
+
+---
+
+## Steps
+
+### 1 — Scaffold `extensions/edit-clj/deps.edn`
+
+Create `extensions/edit-clj/deps.edn` with:
+- runtime deps: `rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}`,
+  `cheshire/cheshire {:mvn/version "5.13.0"}`
+- `:test` alias: kaocha + `psi/extension-test-helpers` + `psi/agent-session`
+  (same shape as `extensions/github/deps.edn`)
+
+### 2 — Implement `psi.edit-clj.core` (pure)
+
+`extensions/edit-clj/src/psi/edit_clj/core.clj` — no file I/O, takes/returns plain values.
+
+Key functions:
+- `parse-single-form` — parse a string via rewrite-clj; return `{:ok node}` or
+  `{:error {:code :parse-error :argument <arg-name> :message ...}}`. Errors on
+  unparseable input or more than one top-level form.
+- `find-candidates` — depth-first zipper walk over a file-content string; collect all
+  nodes whose `sexpr` equals the target `sexpr`. Skip nodes where `sexpr` throws
+  (comments, whitespace, uneval). Return a vector of `{:node :row :col :text}` maps.
+- `apply-line-filter` — given candidates and optional `start-line`/`end-line`, each
+  bound independently open when absent: keep candidates where
+  `(no start-line OR start-line ≤ node-row) AND (no end-line OR node-row ≤ end-line)`.
+  No-op when neither bound is supplied.
+- `replace-in` — given already-parsed old-node, new-node, file-content string, and
+  filtered candidates, perform the replacement and return the updated file-content
+  string. Branches on candidate count: zero → no-match map, many → ambiguous-match map,
+  one → replace and return ok map. Never touches the filesystem.
+
+Result maps use keywords and match the design's output shapes **except** that core never
+includes `:filename` — core receives file content, not a path. The extension merges
+`:filename` (the resolved path string) into every result map before JSON serialisation.
+JSON serialisation happens in the extension layer.
+
+Note: `core` exposes composable helpers; it does **not** orchestrate the full
+validation order. The extension owns that sequence (see step 4).
+
+### 3 — Tests for `psi.edit-clj.core`
+
+`extensions/edit-clj/test/psi/edit_clj/core_test.clj` — all assertions against
+in-memory strings, no temp files.
+
+Cover every AC:
+- AC 1 — single match replaced; content outside node unchanged character-for-character
+- AC 2 — no-match result; input string returned unchanged
+- AC 3 — ambiguous-match result with correct match count and locations
+- AC 4 (partial) — `parse-single-form` returns parse-error for invalid Clojure and for
+  multi-form input; argument name is preserved in the error map
+- AC 6a–f — line-range cases (duplicate forms, straddling forms, nested symbol in
+  straddling parent, range with no matching starts)
+- AC 7 — `new-string` containing an inline comment; comment text present in output string
+- AC 8 — multi-form `old-string` → parse-error; multi-form `new-string` → parse-error
+
+### 4 — Implement `psi.edit-clj.extension`
+
+`extensions/edit-clj/src/psi/edit_clj/extension.clj` — file I/O + tool wiring.
+
+- `resolve-path` — resolve `filename` against `cwd` when relative.
+- `execute` — owns the validation order per the design contract:
+  1. `core/parse-single-form(old-string, "old-string")` → return error map if invalid
+  2. `core/parse-single-form(new-string, "new-string")` → return error map if invalid
+  3. Resolve path against `:cwd`; return `file-not-found` map if not readable
+  4. Read file content
+  5. `core/find-candidates(old-node, file-content)` → `core/apply-line-filter` →
+     `core/replace-in(old-node, new-node, file-content, candidates)`
+  6. On `:ok` write updated content back to the file
+  7. Merge `:filename` (resolved path string) into the result map
+  8. Serialise result map to JSON string via cheshire
+- `tool-def` — tool map with `:name`, `:description` (≤ 20 words, one-form contract
+  explicit), `:parameters` as data map, `:execute` fn supporting both
+  `([args])` and `([args opts])` arities.
+- `init` — register single tool via `(:register-tool api)`.
+
+### 5 — Tests for `psi.edit-clj.extension`
+
+`extensions/edit-clj/test/psi/edit_clj/extension_test.clj`
+
+- AC 4 (validation order) — both `old-string` and `new-string` invalid → old-string
+  parse-error returned; invalid `old-string` with missing file → parse-error returned
+  (not file-not-found), confirming the extension checks strings before the file
+- AC 5 — non-existent file (both strings valid) → `file-not-found` result (JSON string,
+  `"status": "error"`)
+- AC 9 — tool `:description` is ≤ 20 words and mentions the one-form contract
+- AC 10 — `init` registers exactly one tool named `"edit-clj"` (using
+  `ext/create-registry` + `ext/create-extension-api` pattern from `github`'s
+  extension test)
+- AC 1 (round-trip) — execute writes the modified file and returns `"status": "ok"` JSON
+
+Use a temp file (`java.io.File/createTempFile`) for the round-trip and file-not-found
+cases; delete on exit.
+
+### 6 — Wire into top-level `deps.edn`
+
+Add `"extensions/edit-clj/src"` alongside `"extensions/github/src"` in every alias
+that already carries it (currently lines ~80, ~118, ~155, ~328 — the `:dev`, `:nrepl`,
+`:test`, and other relevant aliases).
+
+### 7 — Wire into top-level `tests.edn`
+
+Add `"extensions/edit-clj/src"` to every `:source-paths` that includes
+`"extensions/github/src"`, and `"extensions/edit-clj/test"` to every `:test-paths` that
+includes `"extensions/github/test"`.
+
+### 8 — Add to launcher catalog
+
+In `bases/main/src/psi/launcher/extensions.clj`, add to `psi-owned-extension-catalog`:
+
+```clojure
+'psi/edit-clj
+{:psi/init 'psi.edit-clj.extension/init
+ :source-policies
+ {:development {:local/root "extensions/edit-clj"}
+  :installed   {:local/root "extensions/edit-clj"}}}
+```
+
+No `:jar` policy — follows the `github` pattern.
+
+### 9 — Verify
+
+- `clj -M:test --focus psi.edit-clj` — core + extension tests green
+- Broader suite sample (launcher catalog test if present, extension-invariant test)
+- `clj-kondo --lint extensions/edit-clj/src extensions/edit-clj/test` — lint clean
+
+---
+
+## Risks
+
+- **rewrite-clj `sexpr` on uneval / reader-macro nodes** — some nodes throw rather than
+  returning a value. The walk must guard with `try`/`catch` and skip, not propagate.
+  Covered by the `skip` branch in `find-candidates`.
+- **Multi-form `old-string` detection** — rewrite-clj parses a string as a single-root
+  document; detecting more than one top-level form requires checking that the zipper has
+  no `right` sibling after the first form at the root level.
+- **Comment-in-`new-string` preservation** — easy to accidentally call `coerce` instead
+  of using the raw parsed node; AC 7 + the explicit design constraint guard this.

--- a/munera/closed/151-edit-clj-structural-edit-extension/steps.md
+++ b/munera/closed/151-edit-clj-structural-edit-extension/steps.md
@@ -1,0 +1,55 @@
+# Steps — 151 edit-clj structural edit extension
+
+## Slice 1 — Pure core
+
+- [x] Create `extensions/edit-clj/deps.edn`
+  - runtime: `rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}`, `cheshire/cheshire {:mvn/version "5.13.0"}`
+  - `:test` alias: kaocha + `psi/extension-test-helpers` + `psi/agent-session` (mirror `extensions/github/deps.edn`)
+
+- [x] Implement `psi.edit-clj.core/parse-single-form`
+- [x] Implement `psi.edit-clj.core/find-candidates`
+- [x] Implement `psi.edit-clj.core/apply-line-filter`
+- [x] Implement `psi.edit-clj.core/replace-in`
+
+- [x] Write `extensions/edit-clj/test/psi/edit_clj/core_test.clj`
+  - AC 1–4, 6a–f, 7, 8 all covered
+
+- [x] Verify slice 1: 12 tests, 45 assertions, 0 failures; lint clean
+
+## Slice 2 — Extension shell
+
+- [x] Implement `psi.edit-clj.extension/resolve-path`
+- [x] Implement `psi.edit-clj.extension/execute` (validation order: old-string → new-string → file)
+- [x] Implement `psi.edit-clj.extension/tool-def` (≤20 words description, dual-arity :execute)
+- [x] Implement `psi.edit-clj.extension/init` (register tool via `(:register-tool api)`)
+
+- [x] Write `extensions/edit-clj/test/psi/edit_clj/extension_test.clj`
+  - AC 1, 2, 3, 4, 5, 9, 10 all covered; uses `create-nullable-extension-api`
+
+- [x] Verify slice 2: 19 tests, 73 assertions, 0 failures; lint clean
+
+## Slice 3 — Wiring
+
+- [x] Add `"extensions/edit-clj/src"` to every alias in top-level `deps.edn` that carries `"extensions/github/src"` (4 locations); also added `"extensions/edit-clj/test"` to `:test` alias; added `rewrite-clj/rewrite-clj` to all runtime + test `:extra-deps`
+
+- [x] Add `"extensions/edit-clj/src"` and `"extensions/edit-clj/test"` to `tests.edn` (unit, extensions, integration suites)
+
+- [x] Add `'psi/edit-clj` entry to `psi-owned-extension-catalog` in `bases/main/src/psi/launcher/extensions.clj`
+
+- [x] Verify: 1776 unit tests + 169 extension tests, 0 failures; lint clean on all changed files
+
+## task-implementation-review follow-up (review pass 1)
+
+- [x] R1 — Add `core_test` case: `old-string "(+ x 1)"` matches file node `"(+  x  1)"` (extra internal spaces) → `ok` result, verifying sexpr equality ignores whitespace. Assert `:content` has the replacement and `:old` = `"(+  x  1)"` (file text, not old-string).
+- [x] R2 — Add `core_test` case: `old-string` and file node differ in whitespace → assert `(:old result)` equals the file node text, not the `old-string` argument (companion to R1; documents `ok.old` semantics explicitly).
+- [x] R3 — Extend `extension_test` `round-trip-write-test`: assert `(contains? result :old)` and `(contains? result :new)` on the parsed JSON result, confirming all five `ok` fields are present in the serialized output.
+- [x] R4 — Add `extension_test` case to `validation-order-test`: valid `old-string` + invalid `new-string` + any filename → `parse-error` with `argument = "new-string"` returned. Confirms the new-string branch in `execute` is exercised at the extension level.
+
+## code-shaper follow-up (review pass 1)
+
+- [x] S1 — `find-candidates` now stores `:zloc` instead of `:node`; `replace-in` uses it directly — no second `z/of-string` + loop.
+- [x] S2 — Removed dead `_old-node` first parameter from `replace-in`; updated all call sites.
+- [x] S3 — `replace-failed` branch removed (unreachable after S1 eliminated the second walk). S3 resolved by S1.
+- [x] S4 — `replace-in` now accepts `new-str` (original argument) as second param; returns it verbatim in `:new`. New `ok-new-verbatim-test` pins whitespace-preservation behaviour.
+- [x] S5 — Unified to `n/sexpr` throughout `find-candidates`: `(n/sexpr (z/node z))` for comparison and `(n/sexpr old-node)` for target.
+- [x] S6 — Second `comment-in-new-string-preserved-test` subtest now asserts `(= ":y" (n/string (:ok result)))`, documenting that leading (top-level) comments are stripped during form extraction — AC 7 only covers comments *inside* a form.

--- a/munera/open/151-metrics-extension/design.md
+++ b/munera/open/151-metrics-extension/design.md
@@ -1,0 +1,333 @@
+# Metrics Extension
+
+**Issue:** [#75 — Add metrics extension](https://github.com/hugoduncan/psi/issues/75)
+
+## Intent
+
+A standard extension that observes system activity and maintains persistent usage counters for registered capabilities — tools, skills, commands, workflows, and deterministic operations. Counters survive process restarts so that usage patterns are visible over time.
+
+## Problem Statement
+
+Psi has no visibility into which capabilities are actually used, how often they succeed or fail, or how much they cost in tokens. The information exists transiently in the dispatch event log and extension event bus, but nothing aggregates or persists it. This makes it hard to identify unused registrations, error-prone tools, or token-expensive workflows.
+
+## Scope
+
+### In Scope
+
+- Tool invocation counting (by tool name), including error counting (by tool name + error classification)
+- Workflow execution counting (by workflow id)
+- Command invocation counting (by command name)
+- Deterministic operation invocation counting (by operation id)
+- Token usage accumulation per model (input/output/cache-read/cache-write keyed by model-id)
+- Project-scoped persistence (EDN file in `.psi/`)
+- Deterministic operation `metrics/summary` returning current counter state
+- Slash command `/metrics` rendering human-readable summary
+- Malli schema for the metrics data shape
+
+### Out of Scope
+
+- User-global (cross-project) aggregation
+- Skill activation tracking (no existing extension event emitted for skill selection; would require core changes)
+- Per-session token breakdowns (the extension tracks per-model aggregate totals, not per-session; per-session detail is already available via the EQL resolver `agent-session-usage`)
+- Cost tracking (requires model-specific pricing data not available to extensions)
+- Historical time-series or bucketed metrics
+- Metrics export (Prometheus, OpenTelemetry, etc.)
+
+## Constraints
+
+- **Extension boundary only** — no behavioral modifications to existing core components. The extension uses only the public extension API (`init` receives the `api` map). The only core file touched is the data-only `psi-owned-extension-catalog` map in `extension_installs.clj` to register the new extension (same pattern as all built-in extensions).
+- **Event-driven** — observes existing extension events: `tool_call`, `tool_result`, `session_turn_finished`. No new hooks in core required.
+- **Project-scoped persistence** — EDN file at `<worktree>/.psi/metrics.edn`. Loaded on init, flushed on mutation.
+- **Minimal overhead** — counter increments are in-memory atom updates; persistence is out-of-band with write-coalescing so concurrent events (e.g., parallel tool calls) never serialize on disk I/O.
+- **Schema-first** — malli schema defines the canonical metrics data shape; validated on load and available for consumers.
+
+## Design
+
+### Architecture Overview
+
+The extension follows the standard psi extension pattern (see `extensions/logprobs/`, `extensions/commit-checks/`):
+
+```
+init(api) →
+  subscribe("tool_call",            on-tool-call)
+  subscribe("tool_result",          on-tool-result)
+  subscribe("session_turn_finished", on-turn-finished)
+  register-operation("metrics/summary", invoke-summary)
+  register-command("metrics",       metrics-command-handler)
+```
+
+State is held in a single `(defonce store (atom nil))` containing both the metrics counters and the resolved persistence path. A separate `(defonce writing? (atom false))` gate serializes disk writes.
+
+### Implementation Strategy
+
+**Why this fits the architecture:** The extension API already provides `(:on api)` for event subscription, `(:register-operation api)` for deterministic operations, and `(:register-command api)` for slash commands. The commit-checks extension demonstrates the persistence pattern (EDN file in `.psi/`). The logprobs extension demonstrates the event-subscription + operation + command triple. This design composes both patterns.
+
+### Data Shape
+
+The metrics atom holds a map with this shape:
+
+```clojure
+{:tools       {"tool-name" {:invocations 5
+                             :errors      3
+                             :error-reasons {"parse-error" 2
+                                             "timeout" 1}}}
+ :workflows   {"workflow-id" {:invocations 3}}
+ :commands    {"command-name" {:invocations 7}}
+ :operations  {"operation-id" {:invocations 2}}
+ :tokens      {"claude-sonnet-4-20250514" {:input       12500
+                                            :output      3400
+                                            :cache-read  8000
+                                            :cache-write 1200}
+               "gpt-4o"                  {:input       5000
+                                            :output      1200
+                                            :cache-read  0
+                                            :cache-write 0}}
+ :updated-at  "2026-05-14T10:00:00Z"}
+```
+
+#### Malli Schema
+
+```clojure
+(def counter-schema
+  [:map
+   [:invocations :int]])
+
+(def tool-counter-schema
+  [:map
+   [:invocations :int]
+   [:errors :int]
+   [:error-reasons [:map-of :string :int]]])
+
+(def token-totals-schema
+  [:map
+   [:input :int]
+   [:output :int]
+   [:cache-read :int]
+   [:cache-write :int]])
+
+(def metrics-schema
+  [:map
+   [:tools [:map-of :string tool-counter-schema]]
+   [:workflows [:map-of :string counter-schema]]
+   [:commands [:map-of :string counter-schema]]
+   [:operations [:map-of :string counter-schema]]
+   [:tokens [:map-of :string token-totals-schema]]
+   [:updated-at [:maybe :string]]])
+```
+
+### Event Handling
+
+#### `tool_call` event
+
+Payload: `{:type "tool_call" :tool-name "..." :tool-call-id "..." :input {...}}`
+
+Action: Increment `[:tools tool-name :invocations]`.
+
+#### `tool_result` event
+
+Payload: `{:type "tool_result" :tool-name "..." :tool-call-id "..." :input {...} :content "..." :is-error true/false}`
+
+Action: When `:is-error` is truthy, increment `[:tools tool-name :errors]` and `[:tools tool-name :error-reasons reason]`. The error reason is derived from the `:content` string — extract the first line, truncated to 80 chars, as the reason key. This keeps reason keys short and greppable without requiring structured error taxonomies.
+
+#### `session_turn_finished` event
+
+Payload: `{:session-id "..." :turn-id "..." ...}`
+
+Action: Query session token usage and model-id via the extension API's `:query-session` function: `((:query-session api) session-id [:psi.agent-session/usage-input :psi.agent-session/usage-output :psi.agent-session/usage-cache-read :psi.agent-session/usage-cache-write :psi.agent-session/model-id])`. Compute the delta from the last-known session totals (tracked in a transient in-memory map, not persisted) and add the delta to the `:tokens` counters under the model-id key. If model-id is nil, use `"unknown"` as the key.
+
+**Why per-model:** Different models have different token economics and capabilities. Aggregate-only totals hide which models consume the most tokens. Per-model breakdown enables informed model selection and cost awareness.
+
+**Why delta-based:** The EQL resolver returns cumulative session totals. The extension must track the last-seen totals per session in memory so it can compute the incremental contribution of each turn. The per-session tracking map is transient (not persisted) because it is only needed within a running process — on restart, the first turn for each session will be treated as a full delta, which is acceptable because sessions rarely span process restarts and the aggregate totals are approximate anyway.
+
+**Alternative considered — enrich `session_turn_finished` payload:** This would require modifying `prompt-finish-base-result` in `turn/handlers.clj`, violating the "no core modifications" constraint. The EQL query approach is slightly less efficient but respects the extension boundary.
+
+### Workflow Tracking
+
+Workflow start/completion events are not currently emitted to the extension event bus. The workflow runtime uses internal statechart events (`:workflow/start`, `:workflow/complete`) but these are not dispatched through `ext/dispatch-in`.
+
+**Decision:** Workflow tracking is included in the schema and data shape (so the surface is ready) but will not be populated in the initial version. A future core enhancement could emit `workflow_started` and `workflow_completed` extension events; the extension is already shaped to consume them.
+
+### Command Tracking
+
+Slash commands are not currently emitted as extension events. The extension registers its own `/metrics` command but cannot observe other command invocations without core changes.
+
+**Decision:** Command tracking is included in the schema and data shape (so the surface is ready) but will initially only track the extension's own `/metrics` command via self-tracking. A future core enhancement could emit a `command_invoked` event to enable full command tracking.
+
+### Deterministic Operation Tracking
+
+Deterministic operations are not currently emitted as extension events either. The same forward-compatible approach applies: the schema includes `:operations`, but initial population is limited to self-tracking of `metrics/summary` invocations.
+
+**Decision:** Track `metrics/summary` self-invocations. Future core event emission for operation invocations would automatically populate this counter category.
+
+### Persistence
+
+**File:** `<worktree>/.psi/metrics.edn`
+
+**Load on init:** The extension needs the worktree path to locate the persistence file. It obtains this via `((:query api) [:psi.agent-session/worktree-path])` during init. If the query returns nil (no worktree), persistence is disabled and the extension operates in memory-only mode.
+
+**Write strategy — out-of-band with write-coalescing:** Parallel tool calls produce concurrent `tool_call` and `tool_result` events, which means multiple threads may mutate the metrics atom concurrently. The atom `swap!` is thread-safe, but synchronous file writes after each `swap!` would serialize all event handlers on disk I/O and risk redundant writes.
+
+Instead, persistence uses a dirty-flag + single-writer loop:
+
+1. Each event handler calls `swap!` to update counters, then sets a `:dirty?` flag in the atom and calls `maybe-persist!`.
+2. `maybe-persist!` uses `compare-and-set!` on a separate `(defonce writing? (atom false))` flag to ensure only one thread enters the write path at a time.
+3. The writer atomically reads the current metrics snapshot and clears `:dirty?`, writes the snapshot to disk, then checks `:dirty?` again — if it was re-dirtied during the write (by another concurrent event), it loops and writes again.
+4. When the writer finds `:dirty?` is false after a write, it resets `writing?` to false and exits.
+
+This ensures: (a) no concurrent file writes, (b) no lost updates — if events arrive during a write, the loop catches them, (c) minimal I/O — rapid-fire events coalesce into a single write of the latest state.
+
+The `/metrics` command also triggers a `maybe-persist!` to ensure the displayed data matches what's on disk.
+
+**Atomic writes:** `spit` to a `.metrics.edn.tmp` file in the same directory, then `java.nio.file.Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`. This prevents partial writes from corrupting the file.
+
+**Load validation:** On load, validate the EDN against the malli schema. If validation fails, log a warning and start with empty counters (the corrupt file is preserved for manual inspection).
+
+### Initialization
+
+```clojure
+(defn init [api]
+  (let [worktree-path (get ((:query api) [:psi.agent-session/worktree-path])
+                           :psi.agent-session/worktree-path)
+        initial-state (when-not @store
+                        (load-metrics worktree-path))]
+    ;; Only reset store on first init (defonce preserves across reloads).
+    ;; On reload, just update worktree-path in case it changed.
+    (if @store
+      (swap! store assoc :worktree-path worktree-path)
+      (reset! store {:metrics (or initial-state (empty-metrics))
+                     :worktree-path worktree-path
+                     :session-usage-cache {}
+                     :dirty? false}))
+    ((:on api) "tool_call" on-tool-call)
+    ((:on api) "tool_result" on-tool-result)
+    ((:on api) "session_turn_finished" (make-turn-finished-handler api))
+    ((:register-operation api)
+     {:id "metrics/summary"
+      :description "Return current usage metrics for all tracked capabilities"
+      :handler invoke-summary})
+    (when-let [register-command (:register-command api)]
+      (register-command "metrics"
+                        {:description "Display usage metrics summary"
+                         :handler (fn [args] (metrics-command-handler args api))}))
+    nil))
+```
+
+The `session_turn_finished` handler is created via `make-turn-finished-handler` which closes over the `api` map to access the `:query` function for EQL usage lookups.
+
+**Reload behavior:** On extension reload, the `defonce` atom is preserved. `init` detects the non-nil store and only updates the `:worktree-path` (in case the session switched worktrees). Accumulated counters and the session-usage-cache survive the reload.
+
+### Operation Handler
+
+`metrics/summary` returns the full metrics map:
+
+```clojure
+(defn invoke-summary [{:keys [_args]}]
+  {:status :ok
+   :data (get-metrics)})
+```
+
+No arguments required. Returns the full metrics map conforming to `metrics-schema`.
+
+### Slash Command
+
+`/metrics` renders a human-readable summary via `(:notify api)`:
+
+```
+## Usage Metrics
+
+### Tools (5 tracked)
+| Tool | Invocations | Errors |
+|------|-------------|--------|
+| read | 42 | 0 |
+| bash | 38 | 3 |
+| edit | 25 | 1 |
+| write | 12 | 0 |
+| delegate | 8 | 0 |
+
+### Token Usage (by model)
+| Model | Input | Output | Cache Read | Cache Write |
+|-------|-------|--------|------------|-------------|
+| claude-sonnet-4-20250514 | 125,000 | 34,000 | 80,000 | 12,000 |
+| gpt-4o | 5,000 | 1,200 | 0 | 0 |
+
+_Updated: 2026-05-14T10:00:00Z_
+```
+
+Workflow, command, and operation sections are included when non-empty.
+
+### File Layout
+
+```
+extensions/metrics/
+├── deps.edn
+├── src/
+│   └── psi/
+│       └── metrics/
+│           ├── extension.clj      ;; init + event handlers + operation + command
+│           ├── schema.clj         ;; malli schemas
+│           ├── persistence.clj    ;; load/save EDN, atomic write
+│           └── counters.clj       ;; pure counter update functions
+└── test/
+    └── psi/
+        └── metrics/
+            ├── extension_test.clj
+            ├── schema_test.clj
+            ├── persistence_test.clj
+            └── counters_test.clj
+```
+
+**Namespace convention:** Uses `psi.metrics.*` following the `psi.github.*` pattern for extensions that are part of the psi project (not third-party `extensions.*` flat namespaces).
+
+### Wiring
+
+The metrics extension follows the same standalone pattern as `psi/github` and `psi/logprobs` — it is **not** added to the central `extensions/deps.edn` (which only covers the simpler flat-namespace extensions). It has its own `deps.edn` with a `:test` alias and is run independently.
+
+**Manifest registration (two places):**
+
+1. **Catalog entry:** Add `'psi/metrics {:psi/init 'psi.metrics.extension/init :source-policies {:installed {:local/root "extensions/metrics"}}}` to `psi-owned-extension-catalog` in `components/agent-session/src/psi/agent_session/extension_installs.clj`. This is the same registration pattern used by all built-in extensions (github, logprobs, etc.). While technically touching a core component file, it is a data-only catalog addition — no behavioral changes.
+2. **Project manifest:** Add `psi/metrics {}` to `.psi/extensions.edn` under `:deps` to enable the extension in this project.
+
+**Tests:** Run via `clj -M:test` inside `extensions/metrics/` using the `:test` alias in `extensions/metrics/deps.edn`. No changes to the central `extensions/deps.edn` or `extensions/tests.edn`.
+
+### Key Invariants
+
+1. **Counter monotonicity:** Counters only increment, never decrement. The `updated-at` timestamp advances on every mutation.
+2. **Schema conformance:** The persisted EDN always conforms to `metrics-schema`. Load rejects non-conforming data.
+3. **Graceful degradation:** If persistence path is unavailable (no worktree), the extension operates in memory-only mode without error.
+4. **Thread safety:** All counter mutations go through `swap!` on the store atom. Persistence writes are serialized via a `writing?` CAS gate — at most one thread writes at a time, and writes coalesce concurrent mutations.
+5. **No behavioral core modifications:** The extension uses only the public extension API surface. The only core file touched is the data-only catalog registration.
+
+### Edge Cases
+
+- **No worktree:** Init succeeds, persistence disabled, counters are in-memory only.
+- **Corrupt EDN file:** Log warning, start with empty counters, do not overwrite the corrupt file until the first successful mutation.
+- **Missing `.psi/` directory:** Create it on first write (using `io/make-parents`).
+- **Concurrent writes from parallel tool calls:** Parallel tool execution produces concurrent `tool_call`/`tool_result` events. The atom serializes in-memory counter updates. The `writing?` CAS gate ensures at most one disk write at a time; the dirty-check loop after each write coalesces rapid-fire mutations into minimal I/O. Atomic file rename prevents partial reads.
+- **Extension reload:** `defonce` on the store atom preserves counters across reloads. The init function re-subscribes to events but does not reset counters.
+- **EQL query failure on turn finished:** If the usage query fails (e.g., session already closed), skip token tracking for that turn and log at debug level.
+
+### Verification Expectations
+
+1. `init` subscribes to exactly three events and registers one operation and one command.
+2. `on-tool-call` increments `[:tools name :invocations]` for any tool name.
+3. `on-tool-result` with `:is-error true` increments `[:tools name :errors]` and `[:tools name :error-reasons reason]`.
+4. `on-tool-result` with `:is-error false` does not increment error counters.
+5. `invoke-summary` returns `{:status :ok :data <metrics-map>}` conforming to schema.
+6. `/metrics` command calls `(:notify api)` with a markdown-formatted summary.
+7. `load-metrics` returns empty counters for missing or corrupt files.
+8. `save-metrics` writes valid EDN that round-trips through `load-metrics`.
+9. Counter functions are pure and independently testable.
+10. Token delta computation correctly handles first-seen sessions, cumulative totals, and per-model keying.
+11. `maybe-persist!` coalesces concurrent mutations — only one thread writes at a time, and re-dirtied state triggers a follow-up write.
+
+## Acceptance Criteria
+
+1. Extension subscribes to `tool_call`, `tool_result`, and `session_turn_finished` events and increments appropriate counters.
+2. Token usage is accumulated per model-id (queried via EQL on each `session_turn_finished`).
+3. Counters persist to `<worktree>/.psi/metrics.edn` and restore on init.
+4. Persistence uses out-of-band write-coalescing so parallel tool call events do not serialize on disk I/O.
+5. `metrics/summary` deterministic operation returns current counter state conforming to malli schema.
+6. `/metrics` slash command renders a human-readable markdown summary with per-model token breakdown.
+7. Metrics data conforms to an explicit malli schema (validated on load, available for consumers).
+8. No behavioral modifications to existing core components (data-only catalog entry is acceptable).
+9. Extension operates gracefully when no worktree path is available (memory-only mode).

--- a/munera/open/151-metrics-extension/implementation.md
+++ b/munera/open/151-metrics-extension/implementation.md
@@ -1,0 +1,109 @@
+# Implementation Notes — 151 Metrics Extension
+
+## Provenance
+
+- **GitHub Issue:** [#75 — Add metrics extension](https://github.com/hugoduncan/psi/issues/75)
+- **Issue comment:** Refined task intent posted by hugoduncan on 2026-05-14
+
+## Design Decisions
+
+### Skill activation tracking excluded
+
+The original issue mentions "skill activations" but no extension event is emitted when a skill is selected/activated. Adding one would require core modifications. Excluded from scope; schema is forward-compatible if the event is added later.
+
+### Command and operation tracking partially deferred
+
+Like skill activations, slash command and deterministic operation invocations are not emitted as extension events. The schema includes `:commands` and `:operations` categories, and the extension self-tracks its own `/metrics` and `metrics/summary` invocations. Full tracking requires future core event emission.
+
+### Token tracking via EQL query delta
+
+`session_turn_finished` does not carry token usage in its payload. Rather than modifying core `prompt-finish-base-result` in `turn/handlers.clj`, the extension queries the EQL surface `[:psi.agent-session/usage-input ...]` after each turn and computes the delta from a transient per-session cache. This respects the extension boundary constraint at the cost of one EQL query per turn completion.
+
+### Persistence path from EQL query
+
+The extension obtains the worktree path via `((:query api) [:psi.agent-session/worktree-path])` during init. This is the same pattern used by commit-checks (which reads `workspace-dir` from event payloads). If nil, persistence is disabled gracefully.
+
+### Workflow tracking excluded from initial version
+
+No workflow start/completion events are emitted to the extension event bus. The workflow runtime uses internal statechart events but does not dispatch through `ext/dispatch-in`. Schema includes `:workflows` for forward compatibility.
+
+### Standalone extension — not in central extensions/deps.edn
+
+`psi/github` and `psi/logprobs` are not present in `extensions/deps.edn` (the central file covering simpler flat-namespace extensions). They are standalone with their own `deps.edn` and `:test` alias. `psi/metrics` follows the same pattern: standalone `extensions/metrics/deps.edn`, tests run via `clj -M:test` inside that directory. No changes to `extensions/deps.edn` or `extensions/tests.edn`.
+
+### Catalog registration is data-only
+
+Adding the extension to `psi-owned-extension-catalog` in `extension_installs.clj` is technically touching a core component file, but it's a data-only catalog entry — the same pattern used by all other built-in extensions. No behavioral changes to core code.
+
+### Namespace convention: `psi.metrics.*`
+
+Follows `psi.github.*` pattern for project-owned extensions rather than the flat `extensions.*` convention used by simpler extensions. This allows clean multi-namespace decomposition.
+
+### Atomic file writes
+
+Uses write-to-temp + `Files/move` with `ATOMIC_MOVE` to prevent partial-read corruption. Same approach used in session persistence elsewhere in the codebase.
+
+## PR #94 Feedback — 2026-05-14
+
+### Per-model token usage (hugoduncan)
+
+Feedback: "Token-usage metrics should be per model."
+
+Changed `:tokens` from a flat `{:input N :output N ...}` map to `[:map-of :string token-totals-schema]` keyed by model-id. The `session_turn_finished` handler now queries `:psi.agent-session/model-id` alongside usage attrs and accumulates deltas under the model-id key. Falls back to `"unknown"` when model-id is nil.
+
+### Parallel tool call write safety (hugoduncan)
+
+Feedback: "Need to check if parallel tool calling would cause parallel metric file writes."
+
+Confirmed: `tool-runtime/batch.clj` uses `ExecutorService.invokeAll` for multi-tool batches, producing concurrent `tool_call`/`tool_result` extension events. The atom `swap!` is thread-safe for in-memory counters, but synchronous file persist after each event would serialize event handlers on I/O and produce redundant writes.
+
+### Out-of-band write-coalescing persistence (hugoduncan)
+
+Feedback: "If needed we could have metrics written out of band, and check for the need to write again when a write completes."
+
+Replaced synchronous persist with a dirty-flag + `writing?` CAS gate pattern: event handlers set `:dirty?` and call `maybe-persist!`; only one thread enters the write path at a time via `compare-and-set!` on `writing?`; after each write, the writer re-checks `:dirty?` and loops if concurrent events re-dirtied the state. This coalesces rapid-fire events into minimal disk I/O.
+
+### `defonce` store preservation
+
+The store atom uses `defonce` so extension reloads preserve accumulated counters. Init re-subscribes to events but does not reset the atom.
+
+## Implementation Pass — 2026-05-13
+
+### store and writing? atoms made non-private
+
+The design specified `^:private` on the `store` and `writing?` `defonce` atoms. In practice, Clojure 1.12 enforces private var access at compile time even via `#'` in tests from a different namespace. Made both atoms non-private so tests can reset them between runs (same pattern as `auto-session-name` extension which also uses `@#'sut/state` on a private atom — but that works because it's in the same compilation unit). The logprobs extension uses `@#'logprobs/store` which works because the test and source are in the same top-level namespace. For `psi.metrics.*` multi-namespace layout, non-private is cleaner.
+
+### :register-operation not in nullable extension API
+
+The nullable extension API (`create-nullable-extension-api`) does not expose `:register-operation` as a direct key — it routes operations through the `mutate` path. The extension tests augment the nullable API with a local `ops` atom and a direct `:register-operation` fn, consistent with how logprobs tests build inline api maps. This is simpler and avoids coupling tests to the nullable API's internal mutation dispatch.
+
+### /metrics command self-tracking
+
+The command handler increments the command invocation counter for `"metrics"` on every invocation. This means there is no "empty metrics" state after the first `/metrics` call. Tests adjusted to reflect this: the "no events" case still shows the Commands section (with `metrics | 1`).
+
+### tests.edn uses kaocha v1 format
+
+Added `extensions/metrics/tests.edn` with kaocha v1 format, consistent with other extensions. `clj -M:test -m kaocha.runner -c tests.edn` runs the full suite.
+
+## Refinement Pass — 2026-05-13
+
+### Wiring correction: standalone extension
+
+Verified against the actual repo: `psi/github` and `psi/logprobs` are absent from `extensions/deps.edn` — they are fully standalone extensions with their own deps.edn and test aliases. The design previously incorrectly specified adding `psi/metrics` to `extensions/deps.edn`. Corrected: metrics is standalone, wiring is catalog entry + project manifest only.
+
+### API surface verified
+
+- `(:query api)` — takes single EQL vector, returns result map. Used during `init` to obtain worktree path.
+- `(:query-session api)` — takes `(session-id eql-query)`, returns result map. Used in `session_turn_finished` handler to obtain per-session usage attrs and model-id.
+- `(:register-operation api)` — takes `{:id :description :handler}` map. Same as logprobs/github.
+- `(:register-command api)` — optional key; takes `(name opts-map)`. Same as logprobs.
+- `(:on api)` — takes `(event-name handler-fn)`. Same as logprobs.
+- `(:notify api)` — takes `(content & [opts])`. Used in command handler.
+
+### Test infrastructure
+
+Tests use `psi.extension-test-helpers.nullable-api/create-nullable-extension-api` (same as work-on, github tests). The nullable API provides `:query-session`, `:on`, `:register-operation`, `:register-command`, `:notify` — all needed by metrics. No mocks required.
+
+### Malli dependency
+
+Malli (`metosin/malli`) is not a transitive dep of the extension API or logprobs. Must be declared explicitly in `extensions/metrics/deps.edn` alongside the extension-test-helpers in the `:test` alias.

--- a/munera/open/151-metrics-extension/steps.md
+++ b/munera/open/151-metrics-extension/steps.md
@@ -1,0 +1,24 @@
+# Steps — 151 Metrics Extension
+
+## Implementation
+
+- [x] Create `extensions/metrics/deps.edn` with malli dep and test alias
+- [x] Create `psi.metrics.schema` — malli schemas for metrics data shape
+- [x] Create `psi.metrics.counters` — pure counter update functions (increment tool, increment error, add per-model token delta)
+- [x] Create `psi.metrics.persistence` — load/save EDN with atomic writes, write-coalescing via `writing?` CAS gate, schema validation on load
+- [x] Create `psi.metrics.extension` — init, event handlers, operation handler, command handler
+- [x] Add catalog entry in `extension_installs.clj` (`psi-owned-extension-catalog`)
+- [x] Add `psi/metrics {}` to `.psi/extensions.edn`
+
+## Tests
+
+- [x] `psi.metrics.schema-test` — schema validation for valid/invalid metrics maps
+- [x] `psi.metrics.counters-test` — pure counter increment functions, per-model token delta
+- [x] `psi.metrics.persistence-test` — round-trip load/save, corrupt file handling, missing directory creation, write-coalescing under concurrent mutations
+- [x] `psi.metrics.extension-test` — init registration, event handler behavior, per-model token accumulation, operation handler, command rendering
+
+## Verification
+
+- [x] All tests green (50 tests, 87 assertions, 0 failures)
+- [x] Lint clean (`clj-kondo --lint extensions/metrics/src`)
+- [x] Schema conformance validated on load and in operation response

--- a/munera/plan.md
+++ b/munera/plan.md
@@ -22,6 +22,7 @@ Backlog:
 `munera/open/150-explicit-runtime-vs-persisted-session-graph-surface/`
 
 Notes:
+- `151` is complete and closed: `edit-clj` structural edit extension; `psi.edit-clj.core` (pure: parse, find-candidates, apply-line-filter, replace-in) + `psi.edit-clj.extension` (tool registration, I/O, JSON); wired into top-level `deps.edn`, `tests.edn`, and `psi-owned-extension-catalog`; `rewrite-clj/rewrite-clj 1.1.47` added to runtime+test deps; 19 tests, 73 assertions, 0 failures; 1776+169 broader suite green.
 - `140-workflow-ir-compilation-errors-actionable` is complete and closed: `"invalid value"` fallback test added to `format-structural-errors-test`; all 4 AC and 8 verification expectations met; 16 formatter tests, 63 assertions, 0 failures.
 - `141` is open: workflow-scoped child-session execution-mode support so workflow-owned child sessions can request `:response-mode :non-streaming`; intentionally narrower than a full session-wide streaming toggle.
 - `145` is complete and should move to `munera/closed/`: logprob data moved out-of-band into `extensions.logprobs`; `journal->provider-messages` no longer projects synthetic user messages; `session_turn_finished` carries `:logprobs` and `:assistant-message`; `local-logprobs` now uses `logprobs/perplexity`; extension storage simplified to a single latest snapshot carrying `:session-id`; focused tests green, docs synced.

--- a/tests.edn
+++ b/tests.edn
@@ -12,6 +12,7 @@
                    "extensions/auto-session-name/src" "extensions/commit-checks/src" "extensions/hello-ext/src"
                    "extensions/mcp-tasks-run/src" "extensions/mementum/src" "extensions/mementum/resources" "extensions/munera/src" "extensions/munera/resources" "extensions/plan-state-learning/src"
                    "extensions/work-on/src" "extensions/github/src"
+                   "extensions/edit-clj/src"
                    "extensions/logprobs/src"]
     :ns-patterns [".*-test$"]
     :skip-meta [:integration]}
@@ -24,6 +25,7 @@
                  "extensions/plan-state-learning/test"
                  "extensions/work-on/test"
                  "extensions/github/test"
+                 "extensions/edit-clj/test"
                  "extensions/logprobs/test"]
     :source-paths ["extensions/auto-session-name/src"
                    "extensions/commit-checks/src"
@@ -36,6 +38,7 @@
                    "extensions/plan-state-learning/src"
                    "extensions/work-on/src"
                    "extensions/github/src"
+                   "extensions/edit-clj/src"
                    "extensions/logprobs/src"]
     :ns-patterns [".*-test$"]
     :skip-meta [:integration]}
@@ -48,6 +51,7 @@
                  "extensions/auto-session-name/test" "extensions/commit-checks/test"
                  "extensions/hello-ext/test" "extensions/mcp-tasks-run/test" "extensions/plan-state-learning/test"
                  "extensions/work-on/test" "extensions/github/test"
+                 "extensions/edit-clj/test"
                  "extensions/logprobs/test"]
     :source-paths ["bases/main/src" "bases/main/resources"
                    "components/ai/src" "components/app-runtime/src" "components/engine/src" "components/query/src" "components/history/src"
@@ -56,7 +60,7 @@
                    "extensions/auto-session-name/src" "extensions/commit-checks/src"
                    "extensions/hello-ext/src" "extensions/mcp-tasks-run/src" "extensions/mementum/src" "extensions/mementum/resources"
                    "extensions/munera/src" "extensions/munera/resources" "extensions/plan-state-learning/src" "extensions/work-on/src"
-                   "extensions/github/src" "extensions/logprobs/src"]
+                   "extensions/github/src" "extensions/edit-clj/src" "extensions/logprobs/src"]
     :ns-patterns [".*-test$"]
     :focus-meta [:integration]}]
 


### PR DESCRIPTION
## Summary
- preserve trailing usage chunks that arrive after  in OpenAI-compatible streaming responses
- fix non-streaming usage normalization for OpenAI-compatible responses by passing model and usage in the correct argument order
- add regression coverage for local OpenAI-compatible streaming and non-streaming usage capture\

## Testing
- clojure -M:test --focus psi.ai.providers.openai-test