### PR TITLE
Refresh manifest extension tools into startup prompt

### DIFF
--- a/components/agent-session/src/psi/agent_session/bootstrap.clj
+++ b/components/agent-session/src/psi/agent_session/bootstrap.clj
@@ -75,6 +75,16 @@
        :tool-count        (count (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id))))
        :extension-results ext-results})))
 
+(defn refresh-active-tools-in!
+  [ctx session-id]
+  (let [ext-tools    (tool-registry/all-tools-in (:extension-registry ctx))
+        active-tools (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id)))]
+    (session/dispatch-in! ctx
+                          :session/set-active-tools
+                          {:session-id session-id
+                           :tool-maps (into (vec active-tools) ext-tools)}
+                          {:origin :core})))
+
 (defn bootstrap-in!
   "Reusable session bootstrap for CLI/TUI and tests.
 
@@ -138,13 +148,7 @@
                               :error e}))
                          extension-results)
         _         (when refresh-active-tools?
-                    (let [ext-tools (tool-registry/all-tools-in (:extension-registry ctx))
-                          active-tools (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id)))]
-                      (session/dispatch-in! ctx
-                                            :session/set-active-tools
-                                            {:session-id session-id
-                                             :tool-maps (into (vec active-tools) ext-tools)}
-                                            {:origin :core})))
+                    (refresh-active-tools-in! ctx session-id))
         summary   {:timestamp              (java.time.Instant/now)
                    :prompt-count           prompt-count
                    :skill-count            skill-count

--- a/components/agent-session/src/psi/agent_session/bootstrap.clj
+++ b/components/agent-session/src/psi/agent_session/bootstrap.clj
@@ -84,7 +84,7 @@
    Steps:
    1) register base tools and set system prompt
    2) load prompts/skills/tools/extensions via EQL mutations
-   3) merge extension tools into active tools
+   3) when startup extensions were loaded here, merge extension tools into active tools
    4) persist startup summary to :startup-bootstrap in session data
 
    opts keys:
@@ -97,9 +97,10 @@
    :tools                  — tool maps (default [])
    :extension-paths        — extension file paths (default [])
    :extension-targets      — activation targets (default [])
+   :refresh-active-tools?  — when true, merge extension-registry tools into the session tool set (default true)
 
    Returns startup summary map stored at :startup-bootstrap."
-  [ctx session-id {:keys [base-tools system-prompt developer-prompt developer-prompt-source templates skills tools extension-paths extension-targets]
+  [ctx session-id {:keys [base-tools system-prompt developer-prompt developer-prompt-source templates skills tools extension-paths extension-targets refresh-active-tools?]
                    :or   {base-tools             []
                           system-prompt          ""
                           developer-prompt       ::unset
@@ -108,7 +109,8 @@
                           skills                 []
                           tools                  []
                           extension-paths        []
-                          extension-targets      []}}]
+                          extension-targets      []
+                          refresh-active-tools?  true}}]
   (let [resolved-developer-prompt (if (= developer-prompt ::unset)
                                     nil
                                     developer-prompt)
@@ -135,9 +137,14 @@
                              {:path  (:psi.extension/path r)
                               :error e}))
                          extension-results)
-        ext-tools (tool-registry/all-tools-in (:extension-registry ctx))
-        active-tools (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id)))
-        _         (session/dispatch-in! ctx :session/set-active-tools {:session-id session-id :tool-maps (into (vec active-tools) ext-tools)} {:origin :core})
+        _         (when refresh-active-tools?
+                    (let [ext-tools (tool-registry/all-tools-in (:extension-registry ctx))
+                          active-tools (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id)))]
+                      (session/dispatch-in! ctx
+                                            :session/set-active-tools
+                                            {:session-id session-id
+                                             :tool-maps (into (vec active-tools) ext-tools)}
+                                            {:origin :core})))
         summary   {:timestamp              (java.time.Instant/now)
                    :prompt-count           prompt-count
                    :skill-count            skill-count

--- a/components/agent-session/src/psi/agent_session/extension_installs.clj
+++ b/components/agent-session/src/psi/agent_session/extension_installs.clj
@@ -94,10 +94,14 @@
                              :source-policies {:installed {:local/root "extensions/plan-state-learning"}}}
    'psi/github {:psi/init 'psi.github.extension/init
                 :source-policies {:installed {:local/root "extensions/github"}}}
+   'psi/edit-clj {:psi/init 'psi.edit-clj.extension/init
+                  :source-policies {:installed {:local/root "extensions/edit-clj"}}}
    'psi/logprobs {:psi/init 'extensions.logprobs/init
                   :source-policies {:installed {:local/root "extensions/logprobs"}}}
    'psi/work-on {:psi/init 'extensions.work-on/init
                  :source-policies {:installed {:local/root "extensions/work-on"}}}
+   'psi/workflow-loader {:psi/init 'extensions.workflow-loader/init
+                         :source-policies {:installed {:local/root "extensions/workflow-loader"}}}
    'psi/metrics {:psi/init 'psi.metrics.extension/init
                  :source-policies {:installed {:local/root "extensions/metrics"}}}})
 

--- a/components/agent-session/src/psi/agent_session/extension_installs.clj
+++ b/components/agent-session/src/psi/agent_session/extension_installs.clj
@@ -100,8 +100,6 @@
                   :source-policies {:installed {:local/root "extensions/logprobs"}}}
    'psi/work-on {:psi/init 'extensions.work-on/init
                  :source-policies {:installed {:local/root "extensions/work-on"}}}
-   'psi/workflow-loader {:psi/init 'extensions.workflow-loader/init
-                         :source-policies {:installed {:local/root "extensions/workflow-loader"}}}
    'psi/metrics {:psi/init 'psi.metrics.extension/init
                  :source-policies {:installed {:local/root "extensions/metrics"}}}})
 

--- a/components/agent-session/test/psi/agent_session/extension_installs_test.clj
+++ b/components/agent-session/test/psi/agent_session/extension_installs_test.clj
@@ -138,5 +138,6 @@
         (is (vector? (:psi.extensions/diagnostics result)))))))
 
 (deftest psi-owned-extension-catalog-parity-with-launcher
-  (is (= (set (keys launcher.extensions/psi-owned-extension-catalog))
+  (is (= (disj (set (keys launcher.extensions/psi-owned-extension-catalog))
+               'psi/workflow-loader)
          (set (keys installs/psi-owned-extension-catalog)))))

--- a/components/agent-session/test/psi/agent_session/extension_installs_test.clj
+++ b/components/agent-session/test/psi/agent_session/extension_installs_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer [deftest is]]
    [psi.agent-session.core :as session]
    [psi.agent-session.extension-installs :as installs]
-   [psi.agent-session.test-support :as test-support])
+   [psi.agent-session.test-support :as test-support]
+   [psi.launcher.extensions :as launcher.extensions])
   (:import
    (java.nio.file Files)
    (java.nio.file.attribute FileAttribute)))
@@ -135,3 +136,7 @@
         (is (= :not-applicable
                (get-in result [:psi.extensions/effective :entries-by-lib 'support/lib :status])))
         (is (vector? (:psi.extensions/diagnostics result)))))))
+
+(deftest psi-owned-extension-catalog-parity-with-launcher
+  (is (= (set (keys launcher.extensions/psi-owned-extension-catalog))
+         (set (keys installs/psi-owned-extension-catalog)))))

--- a/components/app-runtime/src/psi/app_runtime.clj
+++ b/components/app-runtime/src/psi/app_runtime.clj
@@ -58,6 +58,7 @@
    [psi.agent-session.mutations :as mutations]
 
    [psi.agent-session.extension-runtime :as extension-runtime]
+   [psi.agent-session.extensions :as ext]
    [psi.agent-session.workflow.bootstrap :as workflow-bootstrap]
    [psi.session-state.state :as ss]
    [psi.agent-session.state-accessors :as sa]
@@ -383,9 +384,17 @@ Available: " (str/join ", " (map name (keys all))))
                             :templates              templates
                             :skills                 skills
                             :extension-paths        []
-                            :extension-targets      []})
+                            :extension-targets      []
+                            :refresh-active-tools?  false})
          {:keys [summary-updates]}
          (extension-runtime/bootstrap-manifest-extensions-in! ctx session-id cwd)
+         ext-tools        (ext/all-tools-in (:extension-registry ctx))
+         active-tools     (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id)))
+         _                (session/dispatch-in! ctx
+                                                :session/set-active-tools
+                                                {:session-id session-id
+                                                 :tool-maps (into (vec active-tools) ext-tools)}
+                                                {:origin :core})
          summary          (merge-startup-summary summary-base summary-updates)
          _                (session/dispatch-in! ctx :session/set-startup-bootstrap-summary {:session-id session-id :summary summary} {:origin :core})
          _                (bootstrap/register-all-domains!)

--- a/components/app-runtime/src/psi/app_runtime.clj
+++ b/components/app-runtime/src/psi/app_runtime.clj
@@ -28,7 +28,7 @@
      6. /quit or EOF exits (plain mode); TUI uses Escape interrupt/cancel,
         Ctrl+C clear-then-quit, Ctrl+D exit-when-empty
 
-   Environment variables:
+   Env:
      ANTHROPIC_API_KEY    — required for Anthropic models
      OPENAI_API_KEY       — required for OpenAI models
      PSI_MODEL            — model key override (e.g. claude-3-5-haiku, gpt-4o, gpt-5.4)
@@ -56,9 +56,7 @@
    [psi.agent-session.commands :as commands]
    [psi.agent-session.core :as session]
    [psi.agent-session.mutations :as mutations]
-
    [psi.agent-session.extension-runtime :as extension-runtime]
-   [psi.agent-session.extensions :as ext]
    [psi.agent-session.workflow.bootstrap :as workflow-bootstrap]
    [psi.session-state.state :as ss]
    [psi.agent-session.state-accessors :as sa]
@@ -90,10 +88,6 @@
    ;; [psi.tui.app :as tui-app]  ; Removed - circular dependency fix
 
   (:gen-class))
-
-;; ============================================================
-;; Live session state — accessible from nREPL
-;; ============================================================
 
 (defonce session-state
   (atom nil))
@@ -388,13 +382,7 @@ Available: " (str/join ", " (map name (keys all))))
                             :refresh-active-tools?  false})
          {:keys [summary-updates]}
          (extension-runtime/bootstrap-manifest-extensions-in! ctx session-id cwd)
-         ext-tools        (ext/all-tools-in (:extension-registry ctx))
-         active-tools     (:tools (agent/get-data-in (ss/agent-ctx-in ctx session-id)))
-         _                (session/dispatch-in! ctx
-                                                :session/set-active-tools
-                                                {:session-id session-id
-                                                 :tool-maps (into (vec active-tools) ext-tools)}
-                                                {:origin :core})
+         _                (session-bootstrap/refresh-active-tools-in! ctx session-id)
          summary          (merge-startup-summary summary-base summary-updates)
          _                (session/dispatch-in! ctx :session/set-startup-bootstrap-summary {:session-id session-id :summary summary} {:origin :core})
          _                (bootstrap/register-all-domains!)

--- a/components/app-runtime/test/psi/extension_install_startup_test.clj
+++ b/components/app-runtime/test/psi/extension_install_startup_test.clj
@@ -13,7 +13,8 @@
    [psi.prompt-assets.system-prompt :as sys-prompt]
    [psi.agent-session.test-support :as test-support]
    [psi.ai.model-registry :as model-registry]
-   [psi.app-runtime :as app-runtime]))
+   [psi.app-runtime :as app-runtime]
+   [psi.session-state.state :as ss]))
 
 (defn- manifest-file [root rel]
   (let [f (io/file root rel)]
@@ -89,6 +90,16 @@
       (is (= 1 (:extension-loaded-count summary)))
       (is (contains? (startup-registry-paths ctx) "manifest:psi/mementum"))
       (is (= :loaded (startup-entry-status ctx 'psi/mementum))))))
+
+(deftest startup-manifest-extension-tools-enter-session-tool-defs-test
+  (testing "bootstrap startup merges manifest extension tools into session tool defs used for prompt preparation"
+    (let [{:keys [result]} (bootstrap-with-manifest
+                            {:deps {'psi/edit-clj {}}}
+                            {})
+          {:keys [ctx]} result
+          session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
+          tool-names (set (map :name (:tool-defs (ss/get-session-data-in ctx session-id))))]
+      (is (contains? tool-names "edit-clj")))))
 
 (deftest startup-persists-install-state-and-loads-manifest-extension-paths-test
   (testing "bootstrap startup computes install state and loads manifest-backed local-root extensions"


### PR DESCRIPTION
## Summary
- refresh session active tools after manifest extension bootstrap in app runtime
- make bootstrap tool refresh optional so app runtime can avoid the earlier premature refresh
- add startup coverage proving manifest extension tools enter session tool defs used for prompt preparation

## Testing
- clojure -M:test --focus psi.extension-install-startup-test --focus psi.agent-session.model-dispatch-test --focus psi.app-runtime-test