### PR TITLE
Fix local OpenAI-compatible usage capture for streaming and non-streaming

### DIFF
--- a/components/ai/src/psi/ai/providers/openai/chat_completions.clj
+++ b/components/ai/src/psi/ai/providers/openai/chat_completions.clj
@@ -186,11 +186,12 @@
 
 (defn- make-chat-stream-state
   []
-  {:stream-started?  (atom false)
-   :done?            (atom false)
-   :next-tool-index  (atom 0)
-   :tool-index-by-id (atom {})
-   :tool-state       (atom {})})
+  {:stream-started?      (atom false)
+   :done?                (atom false)
+   :pending-finish-reason (atom nil)
+   :next-tool-index      (atom 0)
+   :tool-index-by-id     (atom {})
+   :tool-state           (atom {})})
 
 (defn- emit-stream-start!
   [consume-fn stream-started?]
@@ -342,7 +343,7 @@
 
 (defn- finish-chat-chunk!
   [stream-state consume-fn model chunk choice]
-  (let [{:keys [stream-started? done?]} stream-state]
+  (let [{:keys [stream-started? done? pending-finish-reason]} stream-state]
     (cond
       (:usage chunk)
       (do
@@ -351,8 +352,10 @@
         (emit-chat-completion-finish! consume-fn
                                       stream-started?
                                       done?
-                                      (keyword (get-in choice [:finish_reason] "stop"))
-                                      (completions-usage-map model (:usage chunk))))
+                                      (or @pending-finish-reason
+                                          (keyword (get-in choice [:finish_reason] "stop")))
+                                      (completions-usage-map model (:usage chunk)))
+        (reset! pending-finish-reason nil))
 
       (:finish_reason choice)
       (do
@@ -360,20 +363,26 @@
         (emit-chat-tool-ends! stream-state consume-fn)
         (when-let [logprob-tokens (extract-llama-logprob-delta chunk)]
           (consume-fn {:type :logprob-delta :tokens logprob-tokens}))
-        (emit-chat-completion-finish! consume-fn
-                                      stream-started?
-                                      done?
-                                      (keyword (:finish_reason choice))
-                                      nil)))))
+        (reset! pending-finish-reason (keyword (:finish_reason choice)))))))
+
+(defn- flush-pending-chat-finish!
+  [stream-state consume-fn]
+  (let [{:keys [stream-started? done? pending-finish-reason]} stream-state]
+    (when-let [reason @pending-finish-reason]
+      (emit-chat-completion-finish! consume-fn stream-started? done? reason nil)
+      (reset! pending-finish-reason nil))))
 
 (defn- process-chat-sse-line!
   [stream-state consume-fn model options url line]
-  (when-let [chunk (transport/parse-sse-line line)]
-    (transport/capture-response! model options :openai-completions url chunk)
-    (let [choice (first (:choices chunk))
-          delta  (:delta choice)]
-      (emit-chat-chunk! stream-state consume-fn choice delta)
-      (finish-chat-chunk! stream-state consume-fn model chunk choice))))
+  (if-let [chunk (transport/parse-sse-line line)]
+    (do
+      (transport/capture-response! model options :openai-completions url chunk)
+      (let [choice (first (:choices chunk))
+            delta  (:delta choice)]
+        (emit-chat-chunk! stream-state consume-fn choice delta)
+        (finish-chat-chunk! stream-state consume-fn model chunk choice)))
+    (when (and line (.startsWith ^String line "data: ") (= "[DONE]" (.substring ^String line 6)))
+      (flush-pending-chat-finish! stream-state consume-fn))))
 
 (defn- non-streaming-request
   [conversation model options]
@@ -405,7 +414,8 @@
   (let [choice (first (:choices body))
         message (:message choice)
         stop-reason (keyword (or (:finish_reason choice) "stop"))
-        usage (some-> (:usage body) (completions-usage-map model))
+        usage (when-let [usage (:usage body)]
+                (completions-usage-map model usage))
         logprobs (or (extract-openai-logprob-delta choice)
                      (extract-llama-logprob-delta body))]
     {:assistant-message (cond-> {:role "assistant"

--- a/components/ai/test/psi/ai/providers/openai_test.clj
+++ b/components/ai/test/psi/ai/providers/openai_test.clj
@@ -636,6 +636,41 @@
           body  (json/parse-string (:body req) true)]
       (is (not (contains? body :temperature))))))
 
+(deftest local-openai-non-streaming-response-preserves-usage-test
+  (testing "non-streaming local OpenAI-compatible responses keep usage totals"
+    (let [model {:id "qwen-3.6-27b"
+                 :provider :local3
+                 :api :openai-completions
+                 :base-url "http://localhost:8082/v1"
+                 :supports-text true}
+          convo (-> (conv/create "sys")
+                    (conv/add-user-message "Reply with exactly: hi"))
+          body {:choices [{:finish_reason "stop"
+                           :index 0
+                           :message {:role "assistant"
+                                     :content "hi"
+                                     :reasoning_content "internal reasoning"}}]
+                :usage {:prompt_tokens 15
+                        :completion_tokens 152
+                        :total_tokens 167}}]
+      (with-redefs [http/post (fn [_url _req]
+                                {:status 200
+                                 :body (json/generate-string body)})]
+        (let [result ((:execute openai/provider) convo model {:no-auth-header true})]
+          (is (= "hi" (get-in result [:assistant-message :content 0 :text])))
+          (is (= :stop (get-in result [:assistant-message :stop-reason])))
+          (is (= {:input-tokens 15
+                  :output-tokens 152
+                  :cache-read-tokens 0
+                  :cache-write-tokens 0
+                  :total-tokens 167
+                  :cost {:input 0.0
+                         :output 0.0
+                         :cache-read 0.0
+                         :cache-write 0.0
+                         :total 0.0}}
+                 (get-in result [:assistant-message :usage]))))))))
+
 (deftest completions-reasoning-delta-shapes-map-to-thinking-delta-test
   (testing "chat completions reasoning delta variants are emitted as :thinking-delta"
     (let [model  (models/get-model :gpt-5)
@@ -671,6 +706,44 @@
                   (filter #(= :thinking-delta (:type %)))
                   (mapv :delta))))
       (is (some #(= :done (:type %)) @events)))))
+
+(deftest completions-trailing-usage-after-finish-reason-is-preserved-test
+  (testing "chat completions keep trailing usage when finish_reason arrives before usage"
+    (let [model {:id "qwen-3.6-27b"
+                 :provider :local3
+                 :api :openai-completions
+                 :base-url "http://localhost:1234"
+                 :supports-text true}
+          convo (-> (conv/create "sys")
+                    (conv/add-user-message "hello"))
+          events (atom [])
+          sse (str
+               "data: " (json/generate-string
+                         {:choices [{:delta {:role "assistant"}}]}) "\n\n"
+               "data: " (json/generate-string
+                         {:choices [{:delta {:content "Hello"}}]}) "\n\n"
+               "data: " (json/generate-string
+                         {:choices [{:finish_reason "stop"}]}) "\n\n"
+               "data: " (json/generate-string
+                         {:usage {:prompt_tokens 42
+                                  :completion_tokens 128
+                                  :total_tokens 170}}) "\n\n"
+               "data: [DONE]\n\n")]
+      (with-redefs [http/post (fn [_url _req]
+                                {:body (stream-body sse)})]
+        ((:stream openai/provider)
+         convo model {:api-key "sk-test"}
+         (fn [ev] (swap! events conj ev))))
+      (let [done-events (filter #(= :done (:type %)) @events)]
+        (is (= 1 (count done-events)))
+        (is (= :stop (:reason (first done-events))))
+        (is (= {:input-tokens 42
+                :output-tokens 128
+                :cache-read-tokens 0
+                :cache-write-tokens 0
+                :total-tokens 170
+                :cost {:input 0.0 :output 0.0 :cache-read 0.0 :cache-write 0.0 :total 0.0}}
+               (:usage (first done-events))))))))
 
 (deftest completions-non-2xx-response-map-surfaces-body-message-test
   (let [model  (models/get-model :gpt-5)


### PR DESCRIPTION
## Summary
- preserve trailing usage chunks that arrive after `finish_reason` in OpenAI-compatible streaming responses
- fix non-streaming usage normalization for OpenAI-compatible responses by passing model and usage in the correct argument order
- add regression coverage for local OpenAI-compatible streaming and non-streaming usage capture

## Testing
- clojure -M:test --focus psi.ai.providers.openai-test