### PR TITLE
Split review-implementation into worktree-free inner + worktree-resolving outer

### DIFF
--- a/.psi/workflows/gh-issue-implement.md
+++ b/.psi/workflows/gh-issue-implement.md
@@ -65,7 +65,7 @@ description: Find an implement-labeled PR, prepare its branch worktree, design a
                      :from {:step "design" :yield :text}}]}
          {:name "review"
           :type :delegate
-          :target "review-implementation"
+          :target "review-implementation-in-worktree"
           :prompt-string {:type :map
                           :fields {:input {:from {:step "implement" :yield :text}}}}
           :context [{:type :source

--- a/.psi/workflows/gh-pr-refine.md
+++ b/.psi/workflows/gh-pr-refine.md
@@ -1,0 +1,78 @@
+---
+name: gh-pr-refine
+description: Find a PR labeled refine, incorporate new PR comments into the Munera task design and plan, iterate review until clear, push and update the PR
+---
+{:steps [{:name      "select"
+          :type      :invoke
+          :operation "github/find-pr"
+          :args      {:labels ["refine"]
+                      :input  {:from :workflow-input :path [:input]}}
+          :outputs   {:summary {:source :invoke/summary}
+                      :data    {:source :invoke/data}}
+          :yields    {:type :text :text :summary}}
+         {:name "prep"
+          :type :delegate
+          :target "builder"
+          :prompt-string {:type :template
+                          :text "Prepare the existing worktree for the PR described by {{select_report}}. Work independently.\n\nRequired procedure:\n1. Read the upstream handoff to identify the PR number, PR branch, and base branch.\n2. Find an existing worktree for the PR branch. Use `git worktree list` and match on the branch name. If no worktree exists, create one from the PR branch.\n3. In the worktree, fetch origin and ensure the PR branch is checked out and up to date with `origin/<pr-branch>`.\n4. Verify `git branch --show-current` matches the PR branch.\n\nOutput requirements:\n- Output a compact Markdown handoff with these headings exactly:\n  - `## Prep Outcome`\n  - `## Handoff Data`\n- Under `## Handoff Data`, include machine-friendly bullet lines for:\n  - `pr_number:`\n  - `pr_url:`\n  - `pr_branch:`\n  - `worktree_path:`"
+                          :vars {"select_report" {:from {:step "select" :yield :text}}}}
+          :context [{:type :source
+                     :from :workflow-original}
+                    {:type :source
+                     :from {:step "select" :yield :text}}]}
+         {:name "refine"
+          :type :delegate
+          :target "builder"
+          :prompt-string {:type :template
+                          :text "Incorporate new PR feedback into the Munera task design for the PR described by {{prep_report}}. Use the `task-design` skill and work independently.\n\nRequired procedure:\n1. Read the upstream handoff to identify the PR number, PR URL, PR branch, and worktree path.\n2. In the worktree, read `munera/plan.md` and inspect `munera/open/` to find the existing Munera task for this PR.\n3. Read the current task `design.md`, `plan.md` (if present), `steps.md`, and `implementation.md`.\n4. Retrieve PR comments with timestamps and authors:\n   ```\n   gh pr view <pr_number> --json comments,reviews\n   ```\n5. Determine the last push timestamp on the PR branch:\n   ```\n   git -C <worktree_path> log -1 --format=%cI\n   ```\n6. Identify **new feedback**: comments and review comments posted after the last commit timestamp. Exclude comments authored by bot or app accounts (look for `[bot]` suffix or `app/` author type). These are the comments that need to be addressed.\n7. If no new human comments are found since the last commit, report that explicitly and skip refinement.\n8. For each piece of new feedback, determine whether it:\n   - Requests a design change → update `design.md`\n   - Requests a plan/approach change → update `plan.md` and/or `steps.md`\n   - Asks a question → resolve it in the design if possible, or note it as an open question in `implementation.md`\n   - Is purely informational → acknowledge in `implementation.md`\n9. Refine `design.md` with the `task-design` skill to ensure it remains complete and unambiguous after incorporating the feedback.\n10. Keep `plan.md` and `steps.md` synchronized with the updated design.\n11. Record terse notes in `implementation.md` about what feedback was addressed and how.\n12. Commit the refinement changes with a descriptive commit message referencing the PR number.\n\nOutput requirements:\n- Output a compact Markdown summary with these headings exactly:\n  - `## Refine Outcome`\n  - `## Feedback Addressed`\n  - `## Handoff Data`\n- Under `## Feedback Addressed`, list each piece of feedback incorporated and what changed.\n- Under `## Handoff Data`, include machine-friendly bullet lines for:\n  - `pr_number:`\n  - `pr_url:`\n  - `pr_branch:`\n  - `worktree_path:`\n  - `munera_task_path:`\n  - `feedback_count:`\n  - `ambiguity_status:`\n\nSet `ambiguity_status:` to either `ambiguous` or `clear`."
+                          :vars {"prep_report" {:from {:step "prep" :yield :text}}}}
+          :context [{:type :source
+                     :from :workflow-original}
+                    {:type :source
+                     :from {:step "select" :yield :text}}
+                    {:type :source
+                     :from {:step "prep" :yield :text}}]}
+         {:name "review-status"
+          :type :session
+          :tools ["read" "bash"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :source
+                           :from {:step "select" :yield :text}}
+                          {:type :source
+                           :from {:step "prep" :yield :text}}
+                          {:type :source
+                           :from {:step "refine" :yield :text}}
+                          {:type :template
+                           :text "Respond exactly with one word: REPEAT or DONE.\n\nUse the actor step context to identify the specific Munera task under review, especially the `munera_task_path`, `worktree_path`, and PR metadata. Then independently inspect the task artifacts in that task directory, especially `design.md` and `plan.md`, and use `steps.md` / `implementation.md` when helpful.\n\nReturn REPEAT if the identified task design still has material ambiguities, missing decisions, incomplete acceptance criteria, or an underspecified implementation approach after incorporating the PR feedback. Return DONE only if the identified Munera task design is complete and unambiguous enough to hand off for implementation, including the implementation strategy, key algorithms, data structures, and interface changes.\n\nDo not re-review the whole repository generically. Judge the specific Munera task named by the actor output."
+                           :vars {}}]
+          :judge {:type :llm
+                  :contributions [{:type :template
+                                   :text "Respond exactly with one word: REPEAT or DONE."
+                                   :vars {}}]}
+          :on {"REPEAT" {:goto "refine"
+                          :max-iterations 4}
+               "DONE" {:goto :next}}}
+         {:name "publish"
+          :type :delegate
+          :target "builder"
+          :prompt-string {:type :template
+                          :text "Push the refined design and update the PR described by {{refine_report}}. Work independently.\n\nRequired procedure:\n1. Read the upstream handoff to identify the PR number, PR URL, PR branch, worktree path, and Munera task path.\n2. In the worktree, verify the local branch matches the PR branch.\n3. Commit any remaining uncommitted changes if needed.\n4. Read the final `design.md` content from the Munera task.\n5. Update the PR description body to reflect the current refined design:\n   ```\n   gh pr edit <pr_number> --body-file <path_to_design.md>\n   ```\n6. Push the changes to the PR branch:\n   ```\n   git push origin HEAD:refs/heads/<pr_branch>\n   ```\n7. Post a PR comment summarizing what changed in response to the feedback. Format it clearly so reviewers can see at a glance what was addressed. Example structure:\n   ```\n   ## Design Refined\n\n   Incorporated feedback from recent comments:\n\n   - [summary of change 1]\n   - [summary of change 2]\n   ...\n   ```\n8. If any step fails, report the failure clearly.\n\nOutput requirements:\n- Output a compact Markdown summary with these headings exactly:\n  - `## Publish Outcome`\n  - `## Verification`\n  - `## Handoff Data`\n- Under `## Handoff Data`, include machine-friendly bullet lines for:\n  - `pr_number:`\n  - `pr_url:`\n  - `pr_branch:`\n  - `worktree_path:`\n  - `munera_task_path:`"
+                          :vars {"refine_report" {:from {:step "refine" :yield :text}}}}
+          :context [{:type :source
+                     :from :workflow-original}
+                    {:type :source
+                     :from {:step "select" :yield :text}}
+                    {:type :source
+                     :from {:step "prep" :yield :text}}
+                    {:type :source
+                     :from {:step "refine" :yield :text}}]}
+         {:name      "edit-labels"
+          :type      :invoke
+          :operation "github/edit-labels"
+          :args      {:number {:from {:step "select" :output :data} :path [:pr-number]}
+                      :remove ["refine"]
+                      :add    ["waiting"]
+                      :target "pr"}}]}
+
+Coordinate refinement of an existing GitHub PR labeled `refine`: select the PR, locate its existing branch worktree, read new PR comments posted since the last commit, incorporate that feedback into the Munera task design and plan, iterate review until the design is complete and unambiguous, push the updated design, update the PR description to match, post a comment summarizing what changed, remove the `refine` label, and add a `waiting` label.

--- a/.psi/workflows/review-implementation-in-worktree.md
+++ b/.psi/workflows/review-implementation-in-worktree.md
@@ -1,0 +1,38 @@
+---
+name: review-implementation-in-worktree
+description: Resolve worktree from a structured handoff, then review a Munera task implementation via the review-implementation workflow
+---
+{:steps [{:name "resolve-worktree"
+          :type :session
+          :tools ["read" "bash" "work-on"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :template
+                           :text "Extract the worktree path and Munera task path from the following handoff data. Call `work-on` with the extracted worktree path to set the session worktree. Then respond with ONLY the Munera task path (e.g. `munera/open/003-foo`) on a single line — nothing else.\n\nHandoff data:\n{{input}}"
+                           :vars {"input" {:from :workflow-input
+                                           :path [:input]}}}]}
+         {:name "review"
+          :type :delegate
+          :target "review-implementation"
+          :prompt-string {:type :map
+                          :fields {:input {:from {:step "resolve-worktree" :yield :text}}}}
+          :context [{:type :source
+                     :from :workflow-original}]}
+         {:name "summary"
+          :type :session
+          :tools ["read" "bash"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :source
+                           :from {:step "review" :yield :text}}
+                          {:type :template
+                           :text "Produce the user-facing final result for the Munera task. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user. Include:\n- whether all four review passes completed cleanly\n- the key issues found and resolved across the four passes (task-implementation-review, task-test-review, test-shaper, code-shaper)\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs"
+                           :vars {}}]}]}
+
+Wraps `review-implementation` for pipeline use where the input is a structured handoff blob containing `worktree_path:` and `munera_task_path:` fields.
+
+Step 1 extracts the worktree path, calls `work-on` to set the session worktree, and emits the plain task path. Step 2 delegates to `review-implementation` which inherits the resolved worktree. Step 3 produces a user-facing summary.
+
+Input shape: `{:input "structured-handoff-text-containing-worktree_path-and-munera_task_path"}`
+
+For interactive use where you're already in the right worktree, use `review-implementation` directly.

--- a/.psi/workflows/review-implementation.md
+++ b/.psi/workflows/review-implementation.md
@@ -49,24 +49,7 @@ description: Review a Munera task implementation, record terse notes, execute ad
                     {:type :source
                      :from {:step "review-task-tests" :yield :text}}
                     {:type :source
-                     :from {:step "review-test-shape" :yield :text}}]}
-         {:name "final-summary"
-          :type :session
-          :tools ["read" "bash" "work-on"]
-          :contributions [{:type :source
-                           :from :workflow-original}
-                          {:type :source
-                           :from {:step "review-task-implementation" :yield :text}}
-                          {:type :source
-                           :from {:step "review-task-tests" :yield :text}}
-                          {:type :source
-                           :from {:step "review-test-shape" :yield :text}}
-                          {:type :source
-                           :from {:step "review-code-shape" :yield :text}}
-                          {:type :template
-                           :text "Produce the user-facing final result for the Munera task identified by {{input}}. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether all four review passes completed cleanly\n- the key issues found and resolved across the four passes (task-implementation-review, task-test-review, test-shaper, code-shaper)\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior."
-                           :vars {"input" {:from :workflow-input
-                                           :path [:input]}}}]}]}
+                     :from {:step "review-test-shape" :yield :text}}]}]}
 
 Run four sequential `review-step` passes against a Munera task, in order:
 1. `task-implementation-review` — correctness and completeness of the implementation
@@ -74,4 +57,8 @@ Run four sequential `review-step` passes against a Munera task, in order:
 3. `test-shaper` — clarity, signal, and robustness of the tests
 4. `code-shaper` — simplicity, consistency, and robustness of the code
 
-Each pass loops internally (review → follow-up → judge) until it produces no new actionable feedback. Prior pass results are forwarded as context so later passes avoid duplicating already-addressed issues. A final summary step collects all four pass outputs for the user.
+Each pass loops internally (review → follow-up → judge) until it produces no new actionable feedback. Prior pass results are forwarded as context so later passes avoid duplicating already-addressed issues.
+
+Input shape: `{:input "munera/open/003-foo"}`
+
+Child sessions inherit the invoking session's worktree — no worktree setup is needed. For pipeline use with structured handoff data, use `review-implementation-in-worktree` instead.

--- a/.psi/workflows/review-step.md
+++ b/.psi/workflows/review-step.md
@@ -4,31 +4,31 @@ description: Run a single named review skill against a Munera task, record terse
 ---
 {:steps [{:name "review"
           :type :session
-          :tools ["read" "bash" "edit" "write" "work-on"]
+          :tools ["read" "bash" "edit" "write"]
           :skills ["work-independently"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :template
-                           :text "Review the Munera task identified by {{input}} using the {{skill}} skill. Work independently. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Then read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. append a terse review note to the task's implementation.md\n2. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n3. avoid duplicating review notes or steps that already exist\n4. commit. if there is no new actionable feedback, say so explicitly\n\nEnd your final response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: NO_ACTIONABLE_FEEDBACK"
+                           :text "Review the Munera task at {{input}} using the {{skill}} skill. Work independently. Read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. append a terse review note to the task's implementation.md\n2. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n3. avoid duplicating review notes or steps that already exist\n4. commit. if there is no new actionable feedback, say so explicitly\n\nEnd your final response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: NO_ACTIONABLE_FEEDBACK"
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}
                                   "skill" {:from :workflow-input
                                            :path [:skill]}}}]}
          {:name "follow-up"
           :type :session
-          :tools ["read" "bash" "edit" "write" "work-on"]
+          :tools ["read" "bash" "edit" "write"]
           :skills ["work-independently"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :source
                            :from {:step "review" :yield :text}}
                           {:type :template
-                           :text "Execute the newly added actionable follow-up items for the Munera task identified by {{input}}. Work independently. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Use the preloaded review result to understand what was added in the preceding review pass. Read the task's steps.md, implementation.md, design.md, and plan.md as needed. Complete the newly added unchecked steps when possible, updating task artifacts as you work. If a step is completed, mark it done in steps.md. If a step cannot yet be completed, leave it unchecked and record the blocking reason tersely in implementation.md. commit."
+                           :text "Execute the newly added actionable follow-up items for the Munera task at {{input}}. Work independently. Use the preloaded review result to understand what was added in the preceding review pass. Read the task's steps.md, implementation.md, design.md, and plan.md as needed. Complete the newly added unchecked steps when possible, updating task artifacts as you work. If a step is completed, mark it done in steps.md. If a step cannot yet be completed, leave it unchecked and record the blocking reason tersely in implementation.md. Commit."
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}}}]}
          {:name "review-status"
           :type :session
-          :tools ["read" "bash" "work-on"]
+          :tools ["read" "bash"]
           :contributions [{:type :source
                            :from :workflow-original}
                           {:type :source
@@ -36,34 +36,21 @@ description: Run a single named review skill against a Munera task, record terse
                           {:type :source
                            :from {:step "follow-up" :yield :text}}
                           {:type :template
-                           :text "Review the specific Munera task identified by {{input}} and decide whether the just-completed review cycle surfaced remaining new actionable follow-up work. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Independently inspect the task artifacts, especially steps.md, implementation.md, design.md, and plan.md when present. This is an internal control step. Respond with exactly one word: REPEAT or DONE. Return REPEAT if the identified task still has new actionable follow-up work to address. Return DONE only if the identified task has no remaining new actionable feedback from that cycle."
+                           :text "Review the Munera task at {{input}} and decide whether the just-completed review cycle surfaced remaining new actionable follow-up work. Independently inspect the task artifacts, especially steps.md, implementation.md, design.md, and plan.md when present. This is an internal control step. Respond with exactly one word: REPEAT or DONE. Return REPEAT if the task still has new actionable follow-up work to address. Return DONE if the task has no remaining new actionable feedback from that cycle."
                            :vars {"input" {:from :workflow-input
                                            :path [:input]}}}]
           :judge {:type :llm
                   :contributions [{:type :template
-                                   :text "Respond exactly with one word: REPEAT or DONE.\n\nUse the actor step context to identify the specific Munera task under review, especially the task identifier or `munera_task_path` if present. Then independently inspect that task's artifacts, especially `steps.md`, `implementation.md`, `design.md`, and `plan.md` when present, to determine whether the review cycle surfaced any new actionable feedback that still needs work.\n\nReturn REPEAT if the identified task still has new actionable follow-up work to address. Return DONE only if the identified task has no remaining new actionable feedback from that cycle.\n\nDo not re-review the repository generically. Judge the specific Munera task named by the actor output."
+                                   :text "Respond exactly with one word: REPEAT or DONE.\n\nUse the actor step context to identify the specific Munera task under review. Independently inspect that task's artifacts, especially `steps.md`, `implementation.md`, `design.md`, and `plan.md` when present, to determine whether the review cycle surfaced any new actionable feedback that still needs work.\n\nReturn REPEAT if the task still has new actionable follow-up work to address. Return DONE only if the task has no remaining new actionable feedback from that cycle.\n\nDo not re-review the repository generically. Judge the specific Munera task named by the actor output."
                                    :vars {}}]}
           :on {"REPEAT" {:goto "review"
                          :max-iterations 6}
-               "DONE"   {:goto "final-summary"}}}
-         {:name "final-summary"
-          :type :session
-          :tools ["read" "bash" "work-on"]
-          :contributions [{:type :source
-                           :from :workflow-original}
-                          {:type :source
-                           :from {:step "review" :yield :text}}
-                          {:type :source
-                           :from {:step "follow-up" :yield :text}}
-                          {:type :template
-                           :text "Produce the user-facing final result for the Munera task identified by {{input}}. First extract `worktree_path:` from the handoff data in `{{input}}` and call `work-on <worktree_path>` before reading any task artifacts. Independently inspect that specific task's artifacts, especially steps.md, implementation.md, design.md, and plan.md when present, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the review loop completed cleanly\n- the key issues found and resolved in this run using the {{skill}} skill\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior."
-                           :vars {"input" {:from :workflow-input
-                                           :path [:input]}
-                                  "skill" {:from :workflow-input
-                                           :path [:skill]}}}]}]}
+               "DONE"   {:goto :done}}}]}
 
 Run a single named review skill against a Munera task. The review pass records terse notes in `implementation.md` and adds follow-up checklist items to `steps.md`. The follow-up pass executes the newly added work. A judge step decides REPEAT or DONE; the loop repeats up to 6 times until a full pass produces no new actionable feedback.
 
-Input shape: `{:input "upstream-handoff-report-containing-worktree_path-and-munera_task_path" :skill "skill-name"}`
+Input shape: `{:input "munera/open/003-foo" :skill "skill-name"}`
 
 The skill is resolved at runtime by reading `.psi/skills/<skill>/SKILL.md`. Any skill available in the project can be named.
+
+Child sessions inherit the invoking session's worktree — no worktree setup is needed.


### PR DESCRIPTION
## Problem

Recent changes to `review-implementation` added worktree extraction (`work-on`) calls and a `final-summary` step. Every step in `review-step` tried to extract `worktree_path:` from structured handoff data and call `work-on` — which breaks interactive use via `/delegate` where the user passes a plain task path.

## Solution

Split into two layers:

- **`review-implementation`** (inner) — four sequential `review-step` delegations, no worktree concern, no summary step. Input: `{:input "munera/open/003-foo"}`. Child sessions inherit the invoking session's worktree automatically.

- **`review-implementation-in-worktree`** (outer, new) — for pipeline use with structured handoff blobs. Step 1 extracts worktree and calls `work-on`. Step 2 delegates to `review-implementation`. Step 3 produces a user-facing summary.

`review-step` stripped of all `work-on` calls and worktree extraction. `final-summary` step removed (routes `DONE → :done` instead).

## Key insight

`child-session-base-state` already inherits `(:worktree-path parent-sd)` — child sessions get the parent's worktree for free. The per-step `work-on` calls were redundant.

## Files changed

| File | Change |
|---|---|
| `review-step.md` | Strip worktree logic, drop `work-on` tool, remove final-summary step |
| `review-implementation.md` | Revert to four review-step delegations only |
| `review-implementation-in-worktree.md` | New outer wrapper for pipeline use |
| `gh-issue-implement.md` | Target → `review-implementation-in-worktree` |

## Usage

Interactive: `/delegate review-implementation "munera/open/003-foo"`
Pipeline: `gh-issue-implement` → `review-implementation-in-worktree` → `review-implementation`