### PR TITLE
⚒ Workflow fixes: lambda-fixpoint, step temperature, and max-iterations error surfacing

### DIFF
--- a/.psi/workflows/lambda-fixpoint.md
+++ b/.psi/workflows/lambda-fixpoint.md
@@ -4,6 +4,7 @@ description: Iterate a lambda expression to a fixpoint by decompiling and recomp
 ---
 {:steps [{:name "decompile"
           :type :delegate
+          :temperature 0
           :target "lambda-decompiler"
           :skills ["lambda-compiler"]
           :prompt-string {:type :template
@@ -14,6 +15,7 @@ description: Iterate a lambda expression to a fixpoint by decompiling and recomp
                      :from :workflow-original}]}
          {:name "compile"
           :type :delegate
+          :temperature 0
           :target "lambda-compiler"
           :skills ["lambda-compiler"]
           :prompt-string {:type :template
@@ -46,6 +48,7 @@ description: Iterate a lambda expression to a fixpoint by decompiling and recomp
                "CHANGED" {:goto "iterate-decompile" :max-iterations 10}}}
          {:name "iterate-decompile"
           :type :delegate
+          :temperature 0
           :target "lambda-decompiler"
           :skills ["lambda-compiler"]
           :prompt-string {:type :template
@@ -55,6 +58,7 @@ description: Iterate a lambda expression to a fixpoint by decompiling and recomp
                      :from :workflow-original}]}
          {:name "iterate-compile"
           :type :delegate
+          :temperature 0
           :target "lambda-compiler"
           :skills ["lambda-compiler"]
           :prompt-string {:type :template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 ## [Unreleased]
 
 ### Added
+- Workflow session steps now accept an optional `:temperature` field (range `[0.0, 2.0]`). When set, the value is threaded through to the AI provider request. When absent, the provider default applies. Applies to both `:type :session` steps and `:type :llm` judge specs.
 - `psi-tool` now supports `action: "mutate"` for invoking registered runtime mutations with structured success/error reports.
 - The live graph now exposes explicit session-surface attrs: `:psi.runtime-session/active-id`, `:psi.runtime-session/list`, `:psi.runtime-session/count`, `:psi.persisted-session/list`, and `:psi.persisted-session/list-all`.
 - The live graph now exposes `:psi.agent-session/context-session-summaries`, a compact session inventory for operational selection, alongside the explicit runtime-session root attrs.

--- a/components/agent-session/src/psi/agent_session/child_session_state.clj
+++ b/components/agent-session/src/psi/agent_session/child_session_state.clj
@@ -54,7 +54,7 @@
      :system-prompt              (or system-prompt resolved-base-prompt (:system-prompt parent-sd))}))
 
 (defn child-session-base-state
-  [parent-sd {:keys [child-session-id session-name thinking-level model prompt-mode response-mode logprobs top-logprobs developer-prompt developer-prompt-source cache-breakpoints workflow-run-id workflow-step-id workflow-attempt-id workflow-owned?] :as child-opts}]
+  [parent-sd {:keys [child-session-id session-name thinking-level temperature model prompt-mode response-mode logprobs top-logprobs developer-prompt developer-prompt-source cache-breakpoints workflow-run-id workflow-step-id workflow-attempt-id workflow-owned?] :as child-opts}]
   (let [{:keys [prompt-component-selection tool-defs skills system-prompt-build-opts base-system-prompt system-prompt]}
         (derive-child-prompt-state parent-sd child-opts)
         normalized-developer-prompt-source (let [source (or developer-prompt-source (:developer-prompt-source parent-sd))]
@@ -91,7 +91,10 @@
                     :created-at                 ts
                     :updated-at                 ts}
              (some? top-logprobs)
-             (assoc :top-logprobs top-logprobs)))))
+             (assoc :top-logprobs top-logprobs)
+
+             (some? temperature)
+             (assoc :temperature temperature)))))
 
 (defn initialize-child-session-state
   [state* parent-sd {:keys [child-session-id preloaded-messages] :as child-opts}]

--- a/components/agent-session/src/psi/agent_session/context.clj
+++ b/components/agent-session/src/psi/agent_session/context.clj
@@ -112,7 +112,7 @@
 
 (defn- create-workflow-child-session!
   [ctx parent-session-id request]
-  (let [{:keys [child-session-id session-name system-prompt prompt-mode response-mode logprobs top-logprobs tool-defs thinking-level model skills
+  (let [{:keys [child-session-id session-name system-prompt prompt-mode response-mode logprobs top-logprobs tool-defs thinking-level temperature model skills
                 developer-prompt developer-prompt-source preloaded-messages
                 cache-breakpoints prompt-component-selection
                 workflow-run-id workflow-step-id workflow-attempt-id workflow-owned?]}
@@ -135,6 +135,7 @@
                           (some? response-mode) (assoc :response-mode response-mode)
                           (contains? {:logprobs logprobs} :logprobs) (assoc :logprobs logprobs)
                           (some? top-logprobs) (assoc :top-logprobs top-logprobs)
+                          (some? temperature) (assoc :temperature temperature)
                           (some? model) (assoc :model model)
                           (some? skills) (assoc :skills skills)
                           (some? preloaded-messages) (assoc :preloaded-messages preloaded-messages)

--- a/components/agent-session/src/psi/agent_session/mutations/canonical_workflows.clj
+++ b/components/agent-session/src/psi/agent_session/mutations/canonical_workflows.clj
@@ -11,6 +11,37 @@
    [psi.workflow-runtime.core :as workflow-runtime]
    [psi.workflow-registry.registry :as workflow-registry]))
 
+(defn- terminal-outcome-error-message
+  "Extract a human-readable error message from a workflow run's terminal-outcome."
+  [terminal-outcome]
+  (when terminal-outcome
+    (case (:reason terminal-outcome)
+      :iteration-limit-reached
+      (str "Iteration limit reached at step '" (:step-id terminal-outcome) "'"
+           " after " (:iteration-count terminal-outcome)
+           " of " (:max-iterations terminal-outcome) " iterations"
+           (when-let [signal (:last-judge-signal terminal-outcome)]
+             (str " (last signal: " signal ")"))
+           (when-let [text (not-empty (:last-result-text terminal-outcome))]
+             (str "\n\nLast result:\n"
+                  (if (> (count text) 2000)
+                    (str (subs text 0 2000) "\n... [truncated]")
+                    text))))
+      :judge-no-match
+      (str "Judge signal did not match any route at step '" (:step-id terminal-outcome) "'"
+           (when-let [output (:judge-output terminal-outcome)]
+             (str ": " output)))
+      ;; generic fallback
+      (str "Workflow failed: " (some-> (:reason terminal-outcome) name)
+           " at step '" (:step-id terminal-outcome) "'"))))
+
+(defn- run-failure-error
+  "Extract an error message for a failed workflow run, checking step errors first,
+   then terminal-outcome."
+  [exec-result final-run]
+  (or (some :error (:steps-executed exec-result))
+      (terminal-outcome-error-message (:terminal-outcome final-run))))
+
 (pco/defmutation register-workflow-definition
   "Register a canonical workflow definition into root state."
   [_ {:keys [psi/agent-session-ctx definition]}]
@@ -117,7 +148,7 @@
        :psi.workflow/blocked? (:blocked? exec-result)
        :psi.workflow/result result-text
        :psi.workflow/error (when (= :failed (:status exec-result))
-                             (some :error (:steps-executed exec-result)))})
+                             (run-failure-error exec-result final-run))})
     (catch Exception e
       {:psi.workflow/run-id run-id
        :psi.workflow/status nil
@@ -148,14 +179,15 @@
             (workflow-runtime/update-run-workflow-input @(:state* agent-session-ctx) run-id workflow-input)]
         (reset! (:state* agent-session-ctx) new-state)))
     (let [resume-fn (:resume-and-execute-workflow-run-fn agent-session-ctx)
-          exec-result (resume-fn agent-session-ctx session-id run-id)]
+          exec-result (resume-fn agent-session-ctx session-id run-id)
+          final-run (workflow-runtime/workflow-run-in @(:state* agent-session-ctx) run-id)]
       {:psi.workflow/run-id run-id
        :psi.workflow/status (:status exec-result)
        :psi.workflow/steps-executed (:steps-executed exec-result)
        :psi.workflow/terminal? (:terminal? exec-result)
        :psi.workflow/blocked? (:blocked? exec-result)
        :psi.workflow/error (when (= :failed (:status exec-result))
-                             (some :error (:steps-executed exec-result)))})
+                             (run-failure-error exec-result final-run))})
     (catch Exception e
       {:psi.workflow/run-id run-id
        :psi.workflow/status nil

--- a/components/agent-session/src/psi/agent_session/prompt_request.clj
+++ b/components/agent-session/src/psi/agent_session/prompt_request.clj
@@ -153,6 +153,9 @@
       (contains? session-data :thinking-level)
       (assoc :thinking-level (:thinking-level session-data))
 
+      (some? (:temperature session-data))
+      (assoc :temperature (:temperature session-data))
+
       (:logprobs-enabled session-data)
       (assoc :logprobs-enabled true
              :top-logprobs (or (:top-logprobs session-data) 3))

--- a/components/agent-session/test/psi/agent_session/child_session_state_test.clj
+++ b/components/agent-session/test/psi/agent_session/child_session_state_test.clj
@@ -112,6 +112,35 @@
     (testing "skills are filtered coherently"
       (is (= [] (:skills child-sd))))))
 
+(deftest child-session-base-state-temperature-test
+  (testing "non-nil temperature is stored in child session state"
+    (let [child-sd (child-session-state/child-session-base-state
+                    (parent-session-data)
+                    {:child-session-id "child-temp-1"
+                     :temperature 0.7})]
+      (is (= 0.7 (:temperature child-sd)))))
+
+  (testing "explicit 0.0 temperature is stored (falsy double must flow through)"
+    (let [child-sd (child-session-state/child-session-base-state
+                    (parent-session-data)
+                    {:child-session-id "child-temp-2"
+                     :temperature 0.0})]
+      (is (= 0.0 (:temperature child-sd)))
+      (is (contains? child-sd :temperature))))
+
+  (testing "nil temperature is absent from child session state"
+    (let [child-sd (child-session-state/child-session-base-state
+                    (parent-session-data)
+                    {:child-session-id "child-temp-3"
+                     :temperature nil})]
+      (is (not (contains? child-sd :temperature)))))
+
+  (testing "absent temperature key leaves temperature absent from child session state"
+    (let [child-sd (child-session-state/child-session-base-state
+                    (parent-session-data)
+                    {:child-session-id "child-temp-4"})]
+      (is (not (contains? child-sd :temperature))))))
+
 (deftest initialize-child-session-state-initializes-persistence-slots-test
   (let [messages [{:role "user" :content [{:type :text :text "hello"}]}]
         state1   (child-session-state/initialize-child-session-state

--- a/components/agent-session/test/psi/agent_session/mutations/canonical_workflows_test.clj
+++ b/components/agent-session/test/psi/agent_session/mutations/canonical_workflows_test.clj
@@ -219,3 +219,118 @@
           result (cwf-mutations/list-workflow-runs {} {:psi/agent-session-ctx ctx})]
       (is (= 1 (:psi.workflow/run-count result)))
       (is (= ["run-1"] (mapv :run-id (:psi.workflow/runs result)))))))
+
+(deftest terminal-outcome-error-message-test
+  (testing "iteration-limit-reached produces actionable error with step, counts, signal, and last result"
+    (let [outcome {:outcome :failed
+                   :reason :iteration-limit-reached
+                   :step-id "compare"
+                   :iteration-count 10
+                   :max-iterations 10
+                   :last-judge-signal "CHANGED"
+                   :last-result-text "λx.prefer(compose(transducers))"}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (string? msg))
+      (is (re-find #"Iteration limit reached" msg))
+      (is (re-find #"compare" msg))
+      (is (re-find #"10 of 10" msg))
+      (is (re-find #"CHANGED" msg))
+      (is (re-find #"Last result" msg))
+      (is (re-find #"transducers" msg))))
+
+  (testing "iteration-limit-reached without optional fields"
+    (let [outcome {:outcome :failed
+                   :reason :iteration-limit-reached
+                   :step-id "check"
+                   :iteration-count 5
+                   :max-iterations 5}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (string? msg))
+      (is (re-find #"Iteration limit reached" msg))
+      (is (not (re-find #"signal" msg)))
+      (is (not (re-find #"Last result" msg)))))
+
+  (testing "judge-no-match produces actionable error"
+    (let [outcome {:outcome :failed
+                   :reason :judge-no-match
+                   :step-id "review"
+                   :judge-output "MAYBE"}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (re-find #"did not match" msg))
+      (is (re-find #"review" msg))
+      (is (re-find #"MAYBE" msg))))
+
+  (testing "unknown failure reason uses generic fallback"
+    (let [outcome {:outcome :failed
+                   :reason :some-other-reason
+                   :step-id "build"}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (re-find #"some-other-reason" msg))
+      (is (re-find #"build" msg))))
+
+  (testing "nil terminal-outcome returns nil"
+    (is (nil? (#'cwf-mutations/terminal-outcome-error-message nil))))
+
+  (testing "terminal-outcome with nil :reason uses defensive fallback without NPE"
+    (let [outcome {:outcome :failed
+                   :reason nil
+                   :step-id "build"}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (string? msg))
+      (is (re-find #"build" msg))
+      (is (not (re-find #"null" (str msg))))))
+
+  (testing "run-failure-error falls through to terminal-outcome when no step errors"
+    (let [exec-result {:status :failed :steps-executed [{:step-id "a" :error nil}]}
+          final-run {:terminal-outcome {:outcome :failed
+                                        :reason :iteration-limit-reached
+                                        :step-id "a"
+                                        :iteration-count 3
+                                        :max-iterations 3}}
+          msg (#'cwf-mutations/run-failure-error exec-result final-run)]
+      (is (re-find #"Iteration limit reached" msg))))
+
+  (testing "empty-string last-result-text produces no Last result header"
+    (let [outcome {:outcome :failed
+                   :reason :iteration-limit-reached
+                   :step-id "check"
+                   :iteration-count 3
+                   :max-iterations 3
+                   :last-result-text ""}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (string? msg))
+      (is (not (re-find #"Last result" msg))
+          "Empty last-result-text should not produce a dangling 'Last result:' header")))
+
+  (testing "long last-result-text is truncated with marker"
+    (let [long-text (apply str (repeat 3000 "x"))
+          outcome {:outcome :failed
+                   :reason :iteration-limit-reached
+                   :step-id "check"
+                   :iteration-count 3
+                   :max-iterations 3
+                   :last-result-text long-text}
+          msg (#'cwf-mutations/terminal-outcome-error-message outcome)]
+      (is (string? msg))
+      (is (re-find #"Last result" msg))
+      (is (re-find #"\[truncated\]" msg)
+          "Long text should be truncated with [truncated] marker")
+      (is (<= (count msg) (+ 2200 100))
+          "Total message length should be bounded (2000 chars of text + overhead)")))
+
+  (testing "run-failure-error returns nil when no step errors and no terminal-outcome"
+    (let [exec-result {:status :failed :steps-executed [{:step-id "a" :error nil}]}
+          final-run {}
+          msg (#'cwf-mutations/run-failure-error exec-result final-run)]
+      (is (nil? msg)
+          "Documents current behaviour: :judge/no-match path produces no terminal-outcome, so run-failure-error returns nil")))
+
+  (testing "run-failure-error prefers step errors over terminal-outcome"
+    (let [exec-result {:status :failed :steps-executed [{:step-id "a" :error "step blew up"}]}
+          final-run {:terminal-outcome {:outcome :failed
+                                        :reason :iteration-limit-reached
+                                        :step-id "a"
+                                        :iteration-count 3
+                                        :max-iterations 3}}
+          msg (#'cwf-mutations/run-failure-error exec-result final-run)]
+      (is (= "step blew up" msg)))))

--- a/components/agent-session/test/psi/agent_session/prompt_request_test.clj
+++ b/components/agent-session/test/psi/agent_session/prompt_request_test.clj
@@ -237,3 +237,34 @@
                      :content [{:type :text :text "done"}]}
           repairs   (prompt-request/tail-dangling-tool-result-repairs [assistant result])]
       (is (= [] repairs)))))
+
+;; ── Temperature projection ──────────────────────────────────────────────────
+
+(deftest session->request-options-temperature-absent-test
+  (testing "temperature key absent from options when not set on session"
+    (let [sd   {:model {:provider "openai" :id "gpt-4.1"} :thinking-level :off}
+          opts (prompt-request/session->request-options {} sd {})]
+      (is (not (contains? opts :temperature))))))
+
+(deftest session->request-options-temperature-nil-test
+  (testing "nil :temperature key present in session-data does not inject :temperature into request options"
+    (let [sd   {:model {:provider "openai" :id "gpt-4.1"}
+                :thinking-level :off
+                :temperature nil}
+          opts (prompt-request/session->request-options {} sd {})]
+      (is (not (contains? opts :temperature))))))
+
+(deftest session->request-options-temperature-present-test
+  (testing "explicit temperature projected into request options"
+    (let [sd   {:model {:provider "openai" :id "gpt-4.1"}
+                :thinking-level :off
+                :temperature 0.0}
+          opts (prompt-request/session->request-options {} sd {})]
+      (is (= 0.0 (:temperature opts)))))
+
+  (testing "non-zero temperature projected into request options"
+    (let [sd   {:model {:provider "openai" :id "gpt-4.1"}
+                :thinking-level :off
+                :temperature 1.5}
+          opts (prompt-request/session->request-options {} sd {})]
+      (is (= 1.5 (:temperature opts))))))

--- a/components/ai/test/psi/ai/providers/anthropic_test.clj
+++ b/components/ai/test/psi/ai/providers/anthropic_test.clj
@@ -67,6 +67,24 @@
            #"Missing Anthropic API key"
            (#'anthropic/build-request convo model {}))))))
 
+(deftest anthropic-temperature-explicit-override-test
+  (testing "explicit temperature override flows through to request body"
+    (let [model (models/get-model :sonnet-4.6)
+          convo (conv/create "sys")
+          req   (#'anthropic/build-request convo model {:api-key "test-key"
+                                                        :temperature 1.0})
+          body  (json/parse-string (:body req) true)]
+      (is (= 1.0 (:temperature body))
+          "explicit temperature 1.0 must appear in request body")))
+
+  (testing "absent temperature uses provider default (0.7)"
+    (let [model (models/get-model :sonnet-4.6)
+          convo (conv/create "sys")
+          req   (#'anthropic/build-request convo model {:api-key "test-key"})
+          body  (json/parse-string (:body req) true)]
+      (is (= 0.7 (:temperature body))
+          "absent temperature must fall back to provider default 0.7"))))
+
 (deftest anthropic-request-schema-validation-fails-fast-test
   (testing "invalid provider request body is rejected with shape diagnostics"
     (let [invalid-body {:model "claude-sonnet-4-6"

--- a/components/ai/test/psi/ai/providers/openai_test.clj
+++ b/components/ai/test/psi/ai/providers/openai_test.clj
@@ -611,6 +611,13 @@
         (is (nil? (:chat_template_kwargs body)))))))
 
 (deftest openai-temperature-defaults-to-zero-test
+  (testing "chat completions defaults temperature to zero when absent"
+    (let [model (models/get-model :gpt-5)
+          convo (-> (conv/create "sys") (conv/add-user-message "hi"))
+          req  (#'openai/build-request convo model {:api-key "sk-test"})
+          body (json/parse-string (:body req) true)]
+      (is (= 0 (:temperature body)))))
+
   (testing "chat completions respects explicit temperature override"
     (let [model (models/get-model :gpt-5)
           convo (-> (conv/create "sys") (conv/add-user-message "hi"))

--- a/components/session-state/src/psi/session_state/model.clj
+++ b/components/session-state/src/psi/session_state/model.clj
@@ -210,6 +210,7 @@
                                                               [:max-lines {:optional true} [:maybe :int]]
                                                               [:max-bytes {:optional true} [:maybe :int]]]]]
    [:scheduler {:optional true} scheduler-state-schema]
+   [:temperature {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
    [:logprobs-enabled {:optional true} :boolean]
    [:top-logprobs {:optional true} [:int {:min 1 :max 20}]]
    [:last-turn-logprobs {:optional true} [:maybe [:vector :map]]]])

--- a/components/session-state/test/psi/session_state/model_test.clj
+++ b/components/session-state/test/psi/session_state/model_test.clj
@@ -54,6 +54,30 @@
                            :reset-at 42000}}
              (:retry s))))))
 
+(deftest agent-session-schema-temperature-test
+  (testing "agent-session-schema accepts optional :temperature"
+    (is (session/valid-session?
+         (session/initial-session {:temperature 1.0}))))
+
+  (testing "agent-session-schema accepts 0.0 temperature"
+    (is (session/valid-session?
+         (session/initial-session {:temperature 0.0}))))
+
+  (testing "agent-session-schema accepts 2.0 temperature (upper bound)"
+    (is (session/valid-session?
+         (session/initial-session {:temperature 2.0}))))
+
+  (testing "agent-session-schema accepts absent temperature"
+    (is (session/valid-session? (session/initial-session))))
+
+  (testing "agent-session-schema rejects temperature below 0.0"
+    (is (not (session/valid-session?
+              (assoc (session/initial-session) :temperature -0.1)))))
+
+  (testing "agent-session-schema rejects temperature above 2.0"
+    (is (not (session/valid-session?
+              (assoc (session/initial-session) :temperature 2.1))))))
+
 (deftest scheduler-schema-test
   (testing "schedule schema accepts canonical scheduled prompt record"
     (is (session/valid-schedule?

--- a/components/workflow-runtime/src/psi/workflow_runtime/child_session_contract.clj
+++ b/components/workflow-runtime/src/psi/workflow_runtime/child_session_contract.clj
@@ -14,6 +14,7 @@
    [:response-mode {:optional true} [:maybe keyword?]]
    [:tool-defs {:optional true} [:maybe [:vector :map]]]
    [:thinking-level {:optional true} [:maybe keyword?]]
+   [:temperature {:optional true} [:maybe number?]]
    [:model {:optional true} [:maybe :map]]
    [:skills {:optional true} [:maybe [:vector :map]]]
    [:developer-prompt {:optional true} [:maybe :string]]

--- a/components/workflow-runtime/src/psi/workflow_runtime/ir.clj
+++ b/components/workflow-runtime/src/psi/workflow_runtime/ir.clj
@@ -149,6 +149,7 @@
    [:tools {:optional true} [:vector tool-id-schema]]
    [:skills {:optional true} [:vector skill-id-schema]]
    [:response-mode {:optional true} [:maybe response-mode-schema]]
+   [:temperature {:optional true} [:maybe [:double {:min 0.0 :max 2.0}]]]
    [:logprobs {:optional true} :boolean]
    [:top-logprobs {:optional true} [:int {:min 1 :max 20}]]
    [:contributions [:vector contribution-schema]]])

--- a/components/workflow-runtime/src/psi/workflow_runtime/statechart.clj
+++ b/components/workflow-runtime/src/psi/workflow_runtime/statechart.clj
@@ -302,11 +302,14 @@
 
 (defn- judged-routing-transition
   [transition step-id]
-  (let [target (:target transition)]
-    (if (= target :failed)
+  (let [target (:target transition)
+        failed? (or (= target :failed)
+                    (= target [:failed]))]
+    (if failed?
       (ele/transition (cond-> {:event :judge/signal
                                :target :failed}
-                        (:cond transition) (assoc :cond (:cond transition))))
+                        (:cond transition) (assoc :cond (:cond transition)))
+                      (dispatch-action :iteration/exhausted step-id))
       (ele/transition (cond-> {:event :judge/signal
                                :target target}
                         (:cond transition) (assoc :cond (:cond transition)))

--- a/components/workflow-runtime/src/psi/workflow_runtime/statechart_runtime.clj
+++ b/components/workflow-runtime/src/psi/workflow_runtime/statechart_runtime.clj
@@ -97,6 +97,9 @@
                        (contains? step-config :top-logprobs)
                        (assoc :top-logprobs (:top-logprobs step-config))
 
+                       (contains? step-config :temperature)
+                       (assoc :temperature (:temperature step-config))
+
                        (:model step-config)
                        (assoc :model (:model step-config))
 

--- a/components/workflow-runtime/src/psi/workflow_runtime/statechart_runtime.clj
+++ b/components/workflow-runtime/src/psi/workflow_runtime/statechart_runtime.clj
@@ -35,6 +35,17 @@
 (def queue-event! queue/queue-event!)
 (def terminal-configuration? state/terminal-configuration?)
 
+(defn- clear-pending-judge-state!
+  "Clear pending judge/routing fields from working memory after a judge cycle
+   completes (used by both :judge/record and :iteration/exhausted)."
+  [working-memory*]
+  (swap! working-memory*
+         (fn [wm]
+           (-> wm
+               (assoc :pending-judge-result nil
+                      :pending-routing nil
+                      :updated-at (state/now))))))
+
 (defn make-workflow-actions
   "Create the Phase A workflow actions dispatcher.
 
@@ -295,12 +306,7 @@
                                                                 :step-id step-id
                                                                 :attempt-id (:attempt-id (workflow-progression-recording/latest-attempt workflow-run step-id))
                                                                 :judge-output (:judge-output judge-result)})))))))
-          (swap! working-memory*
-                 (fn [wm]
-                   (-> wm
-                       (assoc :pending-judge-result nil
-                              :pending-routing nil
-                              :updated-at (state/now)))))
+          (clear-pending-judge-state! working-memory*)
           nil)
 
         :step/block
@@ -311,6 +317,35 @@
                        (assoc :blocked-step-id step-id
                               :current-step-id step-id
                               :updated-at (state/now)))))
+          nil)
+
+        :iteration/exhausted
+        (let [iteration-count (get-in @working-memory* [:iteration-counts step-id] 0)
+              workflow-run (workflow-runtime/workflow-run-in @(:state* ctx) run-id)
+              step-def (state/runtime-step-def workflow-run step-id)
+              last-judge-result (get-in @working-memory* [:judge-results step-id])
+              last-step-output (get-in @working-memory* [:step-outputs step-id])
+              last-judge-signal (:judge-event last-judge-result)]
+          ;; Record judge result for the final iteration before recording terminal outcome
+          (when last-judge-result
+            (swap! (:state* ctx)
+                   workflow-progression-recording/record-judge-result run-id step-id last-judge-result))
+          (swap! (:state* ctx)
+                 (fn [state-map]
+                   (update-in state-map [:workflows :runs run-id]
+                              (fn [wf-run]
+                                (-> wf-run
+                                    (assoc :status :failed
+                                           :finished-at (or (:finished-at wf-run) (state/now))
+                                           :terminal-outcome
+                                           {:outcome :failed
+                                            :reason :iteration-limit-reached
+                                            :step-id step-id
+                                            :iteration-count iteration-count
+                                            :max-iterations (get-in step-def [:on last-judge-signal :max-iterations])
+                                            :last-judge-signal last-judge-signal
+                                            :last-result-text (get-in last-step-output [:outputs :final-llm-reply])}))))))
+          (clear-pending-judge-state! working-memory*)
           nil)
 
         :terminal/record

--- a/components/workflow-runtime/src/psi/workflow_runtime/target_ir_compiler.clj
+++ b/components/workflow-runtime/src/psi/workflow_runtime/target_ir_compiler.clj
@@ -105,7 +105,7 @@
   (when judge
     (case type
       :llm
-      (let [session-config (select-keys judge [:model :tools :skills :system-prompt :thinking-level :prompt-component-selection :response-mode :logprobs :top-logprobs])]
+      (let [session-config (select-keys judge [:model :tools :skills :system-prompt :thinking-level :prompt-component-selection :response-mode :temperature :logprobs :top-logprobs])]
         (cond-> {:type :llm
                  :session (assoc session-config
                                  :contributions (mapv compile-contribution (:contributions judge)))}
@@ -176,7 +176,7 @@
 
     :session
     (assoc (compile-common-step-fields step)
-           :session (cond-> (select-keys step [:model :tools :skills :system-prompt :thinking-level :prompt-component-selection :response-mode :logprobs :top-logprobs])
+           :session (cond-> (select-keys step [:model :tools :skills :system-prompt :thinking-level :prompt-component-selection :response-mode :temperature :logprobs :top-logprobs])
                       true (assoc :contributions (mapv compile-contribution (:contributions step)))))
 
     :delegate

--- a/components/workflow-runtime/test/psi/workflow_runtime/child_session_contract_test.clj
+++ b/components/workflow-runtime/test/psi/workflow_runtime/child_session_contract_test.clj
@@ -27,6 +27,24 @@
                  :workflow-attempt-id "attempt-1"
                  :workflow-owned? true})))))
 
+;; The child-session contract schema uses [:maybe number?] for :temperature — no range constraint.
+;; Range [0.0, 2.0] is enforced upstream at the IR layer (session-spec-schema).
+;; The contract is intentionally permissive: it validates shape/presence, not domain range.
+(deftest request-contract-accepts-temperature-test
+  (testing "request-schema accepts optional :temperature"
+    (is (true? (contract/valid-request?
+                {:child-session-id "child-1"
+                 :temperature 1.0}))))
+
+  (testing "request-schema accepts nil :temperature"
+    (is (true? (contract/valid-request?
+                {:child-session-id "child-1"
+                 :temperature nil}))))
+
+  (testing "request-schema accepts absent :temperature"
+    (is (true? (contract/valid-request?
+                {:child-session-id "child-1"})))))
+
 (deftest request-contract-rejects-unknown-fields-test
   (testing "unknown request fields fail clearly"
     (let [ex (try

--- a/components/workflow-runtime/test/psi/workflow_runtime/ir_test.clj
+++ b/components/workflow-runtime/test/psi/workflow_runtime/ir_test.clj
@@ -388,3 +388,28 @@
           result (workflow-ir/validate-workflow-ir ir)]
       (is (= {:valid? true :structural-errors nil :semantic-errors []}
              result)))))
+
+;; ── Temperature schema validation ──────────────────────────────────────────
+
+(def ^:private base-session-spec
+  {:contributions [{:type :template :text "hello" :vars {}}]})
+
+(deftest session-spec-schema-temperature-validation-test
+  (testing "session-spec-schema accepts temperature within [0.0, 2.0]"
+    (is (m/validate workflow-ir/session-spec-schema (assoc base-session-spec :temperature 0.0)))
+    (is (m/validate workflow-ir/session-spec-schema (assoc base-session-spec :temperature 1.0)))
+    (is (m/validate workflow-ir/session-spec-schema (assoc base-session-spec :temperature 2.0))))
+
+  (testing "session-spec-schema accepts nil temperature (opt-in; absent = provider default)"
+    (is (m/validate workflow-ir/session-spec-schema (assoc base-session-spec :temperature nil))))
+
+  (testing "session-spec-schema accepts spec with no :temperature key"
+    (is (m/validate workflow-ir/session-spec-schema base-session-spec)))
+
+  (testing "session-spec-schema rejects temperature below 0.0"
+    (is (not (m/validate workflow-ir/session-spec-schema
+                         (assoc base-session-spec :temperature -0.1)))))
+
+  (testing "session-spec-schema rejects temperature above 2.0"
+    (is (not (m/validate workflow-ir/session-spec-schema
+                         (assoc base-session-spec :temperature 2.1))))))

--- a/components/workflow-runtime/test/psi/workflow_runtime/statechart_test.clj
+++ b/components/workflow-runtime/test/psi/workflow_runtime/statechart_test.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [com.fulcrologic.statecharts :as sc]
+   [com.fulcrologic.statecharts.data-model.working-memory-data-model :as wmdm]
+   [com.fulcrologic.statecharts.events :as evts]
    [com.fulcrologic.statecharts.protocols :as sp]
    [com.fulcrologic.statecharts.simple :as simple]
    [psi.workflow-runtime.statechart :as workflow-sc]))
@@ -68,3 +70,126 @@
     (is (workflow-sc/terminal-run-status? :failed))
     (is (workflow-sc/terminal-run-status? :cancelled))
     (is (not (workflow-sc/terminal-run-status? :running)))))
+
+;; --- Hierarchical chart iteration-exhaustion tests ---
+
+(def judged-looping-definition
+  "A minimal definition with a judged step that loops up to 2 iterations."
+  {:definition-id "loop-test"
+   :step-order ["produce" "check"]
+   :steps {"produce" {:name "produce"
+                      :type :session
+                      :executor {:type :agent}
+                      :result-schema [:map]
+                      :retry-policy {:max-attempts 1 :retry-on #{}}}
+           "check"   {:name "check"
+                      :type :session
+                      :judge {:type :llm}
+                      :on {"DONE"    {:goto :done}
+                           "CHANGED" {:goto "produce" :max-iterations 2}}
+                      :executor {:type :agent}
+                      :result-schema [:map]
+                      :retry-policy {:max-attempts 1 :retry-on #{}}}}})
+
+(defn- hierarchical-chart-run
+  "Run a compiled hierarchical chart through a sequence of events, collecting
+   action dispatches. Returns {:configuration ... :actions [...]}."
+  [definition events]
+  (let [actions* (atom [])
+        actions-fn (fn [action-kw data]
+                     (swap! actions* conj {:action action-kw
+                                           :step-id (:step-id data)})
+                     nil)
+        chart (workflow-sc/compile-hierarchical-chart definition)
+        env (simple/simple-env)
+        session-id (java.util.UUID/randomUUID)]
+    (simple/register! env :workflow-run chart)
+    (let [initial-data {:actions-fn actions-fn
+                        :iteration-counts {}
+                        :attempt-counts {}
+                        :actor-retry-limits {"produce" 1 "check" 1}}
+          wm0 (sp/start! (::sc/processor env) env :workflow-run
+                         {::sc/session-id session-id
+                          ::wmdm/data-model initial-data})
+          wmN (reduce (fn [wm {:keys [event data]}]
+                        (let [merged (assoc wm ::wmdm/data-model
+                                            (merge (::wmdm/data-model wm) data {:actions-fn actions-fn}))]
+                          (sp/process-event! (::sc/processor env) env merged
+                                             (evts/new-event {:name event :data (or data {})}))))
+                      wm0
+                      events)]
+      {:configuration (::sc/configuration wmN)
+       :actions @actions*})))
+
+(deftest iteration-exhaustion-fires-action-test
+  (testing "judge signal CHANGED when iteration count >= max-iterations transitions to :failed with :iteration/exhausted action"
+    (let [{:keys [configuration actions]}
+          (hierarchical-chart-run
+           judged-looping-definition
+           [{:event :workflow/start :data {}}
+            ;; produce step completes
+            {:event :actor/done :data {:iteration-counts {"produce" 1} :attempt-counts {"produce" 1}}}
+            ;; check step completes, enters judging
+            {:event :actor/done :data {:iteration-counts {"check" 1} :attempt-counts {"check" 1}}}
+            ;; judge says CHANGED, iteration count for "produce" is already at max
+            {:event :judge/signal :data {:signal "CHANGED"
+                                         :iteration-counts {"produce" 2 "check" 1}
+                                         :attempt-counts {"produce" 2 "check" 1}}}])]
+      (is (contains? configuration :failed)
+          "Chart should be in :failed state after iteration exhaustion")
+      (is (some #(= {:action :iteration/exhausted :step-id "check"} %)
+                actions)
+          ":iteration/exhausted action should fire for the judging step")))
+
+  (testing "judge signal CHANGED when iteration count < max-iterations loops back normally"
+    (let [{:keys [configuration actions]}
+          (hierarchical-chart-run
+           judged-looping-definition
+           [{:event :workflow/start :data {}}
+            {:event :actor/done :data {:iteration-counts {"produce" 1} :attempt-counts {"produce" 1}}}
+            {:event :actor/done :data {:iteration-counts {"check" 1} :attempt-counts {"check" 1}}}
+            ;; judge says CHANGED, iteration count for "produce" is below max
+            {:event :judge/signal :data {:signal "CHANGED"
+                                         :iteration-counts {"produce" 1 "check" 1}
+                                         :attempt-counts {"produce" 1 "check" 1}}}])]
+      (is (not (contains? configuration :failed))
+          "Chart should NOT be in :failed state when iterations remain")
+      (is (not (some #(= :iteration/exhausted (:action %)) actions))
+          ":iteration/exhausted action should NOT fire when iterations remain")))
+
+  (testing "judge signal DONE always goes to :completed regardless of iteration count"
+    (let [{:keys [configuration actions]}
+          (hierarchical-chart-run
+           judged-looping-definition
+           [{:event :workflow/start :data {}}
+            {:event :actor/done :data {:iteration-counts {"produce" 1} :attempt-counts {"produce" 1}}}
+            {:event :actor/done :data {:iteration-counts {"check" 1} :attempt-counts {"check" 1}}}
+            {:event :judge/signal :data {:signal "DONE"
+                                         :iteration-counts {"produce" 10 "check" 1}}}])]
+      (is (contains? configuration :completed)
+          "DONE signal should reach :completed")
+      (is (not (some #(= :iteration/exhausted (:action %)) actions))
+          ":iteration/exhausted should not fire for DONE signal"))))
+
+(deftest judged-routing-transition-vector-failed-target-test
+  (testing "both :failed and [:failed] are normalized onto the failed transition path"
+    (let [jrt #'workflow-sc/judged-routing-transition
+          keyword-result (jrt {:target :failed :cond (fn [_ _] true)} "step-a")
+          vector-result (jrt {:target [:failed] :cond (fn [_ _] true)} "step-a")]
+      (is (= [:failed] (:target keyword-result))
+          "Keyword :failed should compile to the canonical vector target form")
+      (is (= [:failed] (:target vector-result))
+          "Vector [:failed] should remain on the canonical vector target form")
+      (is (= :judge/signal (:event keyword-result) (:event vector-result))
+          "Both forms should produce the same judge event")
+      (is (= 1 (count (:children keyword-result)) (count (:children vector-result)))
+          "Both forms should attach exactly one script action")))
+
+  (testing "non-failed target preserves its target shape and still carries one script action"
+    (let [jrt #'workflow-sc/judged-routing-transition
+          result (jrt {:target :step.produce.acting :cond (fn [_ _] true)} "step-a")]
+      (is (= [:step.produce.acting] (:target result))
+          "Non-failed target should be preserved in canonical vector target form")
+      (is (= :judge/signal (:event result)))
+      (is (= 1 (count (:children result)))
+          "Non-failed route should still carry exactly one script action"))))

--- a/components/workflow-runtime/test/psi/workflow_runtime/target_ir_compiler_test.clj
+++ b/components/workflow-runtime/test/psi/workflow_runtime/target_ir_compiler_test.clj
@@ -146,6 +146,35 @@
               {:outcome :ok
                :outputs {:handoff {:issue_number "12"}}}))))))
 
+(deftest compile-temperature-preserved-through-session-step-test
+  (testing ":temperature is preserved through session step IR compilation"
+    (let [ir (target-compiler/compile-workflow-definition
+              {:steps [{:name "run"
+                        :type :session
+                        :temperature 0.3
+                        :contributions [{:type :source :from :workflow-original}]}]})]
+      (is (= 0.3 (get-in ir [:steps 0 :session :temperature])))))
+
+  (testing ":temperature is preserved through judge session IR compilation"
+    (let [ir (target-compiler/compile-workflow-definition
+              {:steps [{:name "build"
+                        :type :session
+                        :contributions [{:type :source :from :workflow-original}]
+                        :judge {:type :llm
+                                :temperature 1.2
+                                :contributions [{:type :template
+                                                 :text "APPROVED or REVISE?"
+                                                 :vars {}}]}
+                        :on {"APPROVED" {:goto :done}}}]})]
+      (is (= 1.2 (get-in ir [:steps 0 :judge :session :temperature])))))
+
+  (testing "absent :temperature is absent from compiled session spec"
+    (let [ir (target-compiler/compile-workflow-definition
+              {:steps [{:name "run"
+                        :type :session
+                        :contributions [{:type :source :from :workflow-original}]}]})]
+      (is (not (contains? (get-in ir [:steps 0 :session]) :temperature))))))
+
 (deftest target-authored-workflow-definition?-alias-test
   (testing "agent-session compiler alias matches lower shared authored-shape predicate"
     (is (true? (target-compiler/target-authored-workflow-definition?

--- a/components/workflow-step-session-config/src/psi/workflow_step_session_config/core.clj
+++ b/components/workflow-step-session-config/src/psi/workflow_step_session_config/core.clj
@@ -198,5 +198,9 @@
        :model resolved-model
        :prompt-component-selection (:prompt-component-selection session-spec)}
       (resolved-logprob-config session-spec))
+
+      (contains? session-spec :temperature)
+      (assoc :temperature (:temperature session-spec))
+
       model-fallback
       (assoc :model-fallback model-fallback))))

--- a/components/workflow-step-session-config/test/psi/workflow_step_session_config/core_test.clj
+++ b/components/workflow-step-session-config/test/psi/workflow_step_session_config/core_test.clj
@@ -426,3 +426,53 @@
                                           :workflow-input {:input "plan it"}})
           config (workflow-step-session-config/resolve-step-session-config ctx nil workflow-run "step-1")]
       (is (= ["missing-tool"] (mapv :name (:tool-defs config)))))))
+
+(deftest resolve-step-session-config-omits-temperature-when-absent-test
+  (testing "workflow child sessions omit temperature from config when not authored"
+    (let [[ctx _] (support/create-session-context {:persist? false})
+          workflow-run (workflow-run-for ctx
+                                         [support/single-step-definition-with-meta]
+                                         {:definition-id "planner"
+                                          :run-id "run-temp-absent"
+                                          :workflow-input {:input "plan it"}})
+          config (workflow-step-session-config/resolve-step-session-config ctx nil workflow-run "step-1")]
+      (is (not (contains? config :temperature))))))
+
+(deftest resolve-step-session-config-explicit-temperature-test
+  (testing "workflow child sessions carry explicit temperature from authored step session config"
+    (let [[ctx _] (support/create-session-context {:persist? false})
+          definition {:definition-id "planner-temp"
+                      :name "planner-temp"
+                      :steps [{:name "step-1"
+                               :type :session
+                               :temperature 0.0
+                               :contributions [{:type :template
+                                                :text "{{input}}"
+                                                :vars {"input" {:from :workflow-input :path [:input]}}}]}]
+                      :workflow-file-meta {:system-prompt "You are a planner."}}
+          workflow-run (workflow-run-for ctx
+                                         [definition]
+                                         {:definition-id "planner-temp"
+                                          :run-id "run-temp-explicit"
+                                          :workflow-input {:input "plan it"}})
+          config (workflow-step-session-config/resolve-step-session-config ctx nil workflow-run "step-1")]
+      (is (= 0.0 (:temperature config)))))
+
+  (testing "workflow child sessions carry non-zero temperature from authored step session config"
+    (let [[ctx _] (support/create-session-context {:persist? false})
+          definition {:definition-id "planner-temp-nonzero"
+                      :name "planner-temp-nonzero"
+                      :steps [{:name "step-1"
+                               :type :session
+                               :temperature 1.5
+                               :contributions [{:type :template
+                                                :text "{{input}}"
+                                                :vars {"input" {:from :workflow-input :path [:input]}}}]}]
+                      :workflow-file-meta {:system-prompt "You are a planner."}}
+          workflow-run (workflow-run-for ctx
+                                         [definition]
+                                         {:definition-id "planner-temp-nonzero"
+                                          :run-id "run-temp-nonzero"
+                                          :workflow-input {:input "plan it"}})
+          config (workflow-step-session-config/resolve-step-session-config ctx nil workflow-run "step-1")]
+      (is (= 1.5 (:temperature config))))))

--- a/doc/workflow-grammar.md
+++ b/doc/workflow-grammar.md
@@ -113,11 +113,13 @@ arg-map ::= {keyword (literal | source-spec)}*
 session-config-entry ::= :model model-selection-spec
                        | :tools [tool-id*]
                        | :skills [skill-id*]
+                       | :temperature double   ;; optional, range [0.0, 2.0]; absent = provider default
                        | session-config-extension
 
 judge-session-config-entry ::= :model model-selection-spec
                              | :tools [tool-id*]
                              | :skills [skill-id*]
+                             | :temperature double   ;; optional, range [0.0, 2.0]; absent = provider default
                              | judge-session-config-extension
 
 model-selection-spec ::= external-nonterminal-defined-in-doc-model-selection-grammar

--- a/doc/workflow-ir.md
+++ b/doc/workflow-ir.md
@@ -516,6 +516,7 @@ invoke-spec ::= {:operation operation-id
 session-spec ::= {:model? model-selection-spec
                   :tools? [tool-id*]
                   :skills? [skill-id*]
+                  :temperature? double           ;; optional, range [0.0, 2.0]; absent = provider default
                   :contributions [contribution+]
                   session-extension*}
 
@@ -536,6 +537,7 @@ llm-judge ::= {:type :llm
 judge-session-spec ::= {:model? model-selection-spec
                         :tools? [tool-id*]
                         :skills? [skill-id*]
+                        :temperature? double     ;; optional, range [0.0, 2.0]; absent = provider default
                         :contributions [contribution+]}
 
 invoke-judge ::= {:type :invoke

--- a/mementum/state.md
+++ b/mementum/state.md
@@ -14,6 +14,12 @@ Bootstrapped on 2026-04-02.
 - `AGENTS.md` — bootstrap/system instructions
 
 ## Current work state
+- Fixed workflow max-iterations exhaustion bug (branch `fix-workflow-max-iterations`):
+  - Three interconnected bugs: (1) `judged-routing-transition` compared vector `[:failed]` against keyword `:failed`, always falling through to the non-failed `judge/record` path; (2) `:terminal/record` action was a no-op with no terminal-outcome recording; (3) execute-run mutation only extracted step-level errors, missing iteration exhaustion
+  - Added `:iteration/exhausted` action on the exhaustion transition with correct vector-or-keyword target comparison
+  - New handler in `statechart_runtime.clj` records `terminal-outcome` with `:reason :iteration-limit-reached`, step-id, counts, last-judge-signal, and last-result-text
+  - Extracted `terminal-outcome-error-message` and `run-failure-error` helpers in `canonical_workflows.clj`; both execute-run and resume-run mutations now surface iteration exhaustion details
+  - 56 focused tests, 310 assertions, 0 failures; lint clean
 - Task 125 workflow-runtime core component extraction is now landed locally with follow-up decomposition, Kaocha wiring, and test-shaping polish complete:
   - added lower component `components/workflow-runtime/` with authoritative namespaces under `psi.workflow-runtime.*`
   - moved canonical workflow runtime owners out of `components/agent-session/src/psi/agent_session/`: model, IR, target IR compiler, statechart, source resolution, runtime core, progression recording, attempts, terminal contract, statechart runtime, and bounded turn execution contract

--- a/munera/closed/056-workflow-loop-judge-routing/implementation.md
+++ b/munera/closed/056-workflow-loop-judge-routing/implementation.md
@@ -76,3 +76,7 @@ All 8 slices landed in sequential commits:
 - `components/agent-session/test/psi/agent_session/workflow_progression_test.clj` — +6 judge progression tests
 - `components/agent-session/test/psi/agent_session/workflow_execution_test.clj` — +2 judge execution tests
 - `components/agent-session/test/psi/agent_session/workflow_file_compiler_test.clj` — +4 compiler tests
+
+## 2026-05-15 task-test-review
+
+- Review note: tests cover transition-local `:on` loop bounds and exhaustion, but I did not find a test proving whether step-level `:max-iterations` is runtime-enforced or intentionally compile-only/documentary.

--- a/munera/closed/056-workflow-loop-judge-routing/steps.md
+++ b/munera/closed/056-workflow-loop-judge-routing/steps.md
@@ -82,6 +82,7 @@
 - [x] Extract shared `step-result-map` helper in `workflow_execution.clj` — reduces 3 result-map constructions to `assoc` on shared base
 - [x] Replace `(some #{goto} step-order)` with `(contains? (set step-order) goto)` in `resolve-goto-target` for idiomatic membership check
 - [x] Run full suite green after fixes (1398 unit tests / 10579 assertions, 0 failures)
+- [ ] Add a focused test that proves the runtime semantics of step-level `:max-iterations` (enforced independently of transition-local bounds, or explicitly ignored if that is the intended contract)
 
 ## Phase A: Statechart-driven execution (follow-on task)
 

--- a/munera/open/141-workflow-child-session-non-streaming-execution/implementation.md
+++ b/munera/open/141-workflow-child-session-non-streaming-execution/implementation.md
@@ -172,3 +172,7 @@ Read the preloaded test-shaper review result plus task artifacts, then executed 
 - Verification remained green: `1710 tests, 12609 assertions, 0 failures`.
 - No new actionable follow-up was discovered, so task artifacts remained otherwise unchanged in this execution pass.
 
+## Review note 2026-05-15
+
+Test-shaper pass found no new actionable feedback after reading the task artifacts and the focused response-mode proofs again. Existing tests already cover the main behavioral partitions with clear signal: authored vs default `:response-mode`, child-session persistence, streaming vs non-streaming execution-path selection, and provider-capture shaping. No new follow-up steps were added.
+

--- a/munera/open/154-add-temperature-as-workflow-step-config/design.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/design.md
@@ -1,0 +1,29 @@
+# 154 — Add temperature as workflow step session config option
+
+## Intent
+
+Allow workflow authors to set `:temperature` on any `:type :session` step (and judge specs) so the AI provider receives an explicit sampling temperature rather than its built-in default.
+
+## Scope
+
+Thread `:temperature` through the full workflow → provider chain:
+- IR schema: `session-spec-schema` accepts optional `:temperature [0.0, 2.0]`
+- Target IR compiler: `select-keys` includes `:temperature` for session and judge steps
+- Step session config: `resolve-step-session-config` conditionally assocs `:temperature`
+- Child session contract: `request-schema` accepts optional `:temperature`
+- Statechart runtime: `step/enter` propagates `:temperature` to attempt creation
+- Child session state: `child-session-base-state` stores `:temperature` when present
+- Session state model: `agent-session-schema` accepts optional `:temperature`
+- Prompt request: `session->request-options` projects `:temperature` into AI options
+
+## Constraints
+
+- Temperature is opt-in: absent = provider default applies
+- Explicit 0.0 flows through as 0.0 (overrides provider default)
+- Range: [0.0, 2.0] validated at IR layer
+
+## Acceptance
+
+- Workflow step with `:temperature 0.0` produces request with `temperature: 0.0`
+- Workflow step without `:temperature` does not inject a temperature key into request options
+- Tests cover absent and explicit (0.0) cases at step-session-config and prompt-request layers

--- a/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
@@ -1,0 +1,102 @@
+# Implementation notes
+
+## 2026-05-15 — code-shaper follow-up execution
+
+Added `anthropic-temperature-explicit-override-test` (new deftest after `build-request-no-thinking-test`):
+- `testing "explicit temperature override flows through to request body"` — `{:temperature 1.0}` → body `:temperature` = 1.0
+- `testing "absent temperature uses provider default (0.7)"` — no `:temperature` in options → body `:temperature` = 0.7
+1 test, 2 assertions, 0 failures. Symmetric with `openai-temperature-defaults-to-zero-test` explicit-override block.
+
+## 2026-05-15 — code-shaper review pass 1
+
+**Overall**: Implementation is clean across all 8 pipeline layers. Guard-style asymmetry (`contains?` vs `some?`) is intentional and correct. One new provider-layer test gap found.
+
+### Issues found
+
+**[TEST] `anthropic_test.clj` — no explicit temperature override test** — `anthropic/build-request` uses `(or (:temperature options) 0.7)` for non-thinking, non-adaptive models. The existing test only confirms `(some? (:temperature body))` (presence when thinking is off). No test verifies that an explicit workflow-authored temperature (e.g. `1.0`) flows through to the Anthropic request body with the correct value. Symmetry with `openai-temperature-defaults-to-zero-test` (which has an explicit-override testing block) requires a matching Anthropic case.
+
+### What is correct
+
+- All guard styles are intentional: `contains?` at `step-session-config` and `statechart_runtime` (distinguishes absent from nil); `some?` at `context.clj` and `child_session_state` (nil temperature not stored — consistent with context.clj pre-dropping nil before child-opts).
+- `select-keys` lists in `target_ir_compiler` are identical for session step and judge step — no drift.
+- `(or (:temperature options) 0.7)` in Anthropic is correct: `0.0` is truthy in Clojure, so explicit `0.0` flows through correctly.
+- All docs updated: CHANGELOG, `doc/workflow-grammar.md`, `doc/workflow-ir.md`.
+- All previously identified follow-up items are complete.
+
+## 2026-05-15 — test-shaper review pass 2
+
+**Overall**: All previous follow-up items are complete. One residual signal gap found.
+
+### Issues found
+
+**[TEST] `openai_test.clj` `openai-temperature-defaults-to-zero-test` — name/body mismatch** — The test name asserts "defaults to zero" but the body only proves explicit override (`0.2`). The `(or (:temperature options) 0)` default path is not exercised within this test. The default-to-zero behavior is incidentally covered by an earlier broader completions test (line 568) but that test is not focused on this contract. A reader relying on the test name gets false confidence. Either add a `testing` block for the absent-temperature default case, or rename the test to `openai-temperature-explicit-override-test`.
+
+### What is correct
+
+- All test-shaper pass 1 items implemented: non-zero step-session-config case, model out-of-range rejection, child-session-contract comment.
+- Temperature tests across all layers are single-concern, state-based, deterministic, no mocks.
+- Coverage is symmetric: IR, model, step-session-config, prompt-request, child-session-state, target-IR-compiler, child-session-contract all have temperature tests.
+
+## 2026-05-15 — task-implementation-review pass 1
+
+**Overall**: Implementation is clean and consistent with how `logprobs`, `response-mode`, and `thinking-level` are threaded. The opt-in/absent-means-provider-default contract is correctly implemented.
+
+### Issues found
+
+**[DOC] CHANGELOG missing** — `:temperature` workflow step config is a user-visible authoring feature; no entry added to `[Unreleased]` in `CHANGELOG.md`. Per project convention, user-visible additions require a changelog entry.
+
+**[DOC] `doc/workflow-grammar.md` not updated** — `session-config-entry` and `judge-session-config-entry` non-terminals reference `session-config-extension` / `judge-session-config-extension` as undefined placeholders; `:temperature` should be documented explicitly here alongside `:model`, `:tools`, `:skills`.
+
+**[DOC] `doc/workflow-ir.md` not updated** — `session-spec` uses `session-extension*` as an undefined placeholder; `:temperature` (and `:thinking-level`, `:response-mode`, `:logprobs`, `:top-logprobs`) should be enumerated in the `session-spec` and `judge-session-spec` grammar entries.
+
+**[TEST] No IR-layer schema validation tests for `:temperature`** — `session-spec-schema` now has `[:double {:min 0.0 :max 2.0}]` but there are no tests asserting that out-of-range values (e.g. -0.1, 2.1) are rejected and in-range values (e.g. 1.0) are accepted at the IR validation boundary.
+
+**[MINOR] `child_session_state.clj` uses `(some? temperature)` while `statechart_runtime.clj` and `step-session-config` use `(contains? ...)` guard** — `some?` is semantically correct here because `context.clj` already drops nil temperature before passing `child-opts`. However the inconsistency in guard style across the pipeline is a minor readability issue. Not a correctness bug.
+
+### What is correct
+
+- `(or (:temperature options) 0)` in `openai/chat_completions` does not clobber explicit 0.0 — `0.0` is truthy in Clojure, so the authored value flows through correctly.
+- `(contains? session-spec :temperature)` in `step-session-config` correctly distinguishes absent from explicit nil.
+- `(some? temperature)` in `context.clj` correctly drops nil before building `child-opts`.
+- Tests cover the two most important cases: absent (key not present) and explicit 0.0 (falsy double that must flow through).
+- Schema range `[0.0, 2.0]` is consistent between IR and `session-state/model`.
+
+## 2026-05-15 — test-shaper review pass 1
+
+**Overall**: All test-review pass 1 follow-up items are complete. Tests are well-structured, use real state, no mocks. Three residual gaps found.
+
+### Issues found
+
+**[TEST] `workflow_step_session_config/core_test.clj` — only tests explicit 0.0 temperature** — `resolve-step-session-config-explicit-temperature-test` uses `0.0` (the falsy-double edge case) as the sole explicit value. No test for a non-zero temperature (e.g. 1.5) confirms the general propagation path independently of the edge case. The 0.0 test is correct and important, but a second case improves partition coverage.
+
+**[TEST] `session_state/model_test.clj` — no out-of-range rejection test** — `agent-session-schema` has `[:double {:min 0.0 :max 2.0}]` (same range as IR schema) but the test only covers acceptance (1.0, 0.0, 2.0, absent). IR test has rejection cases; model test does not. Inconsistent coverage across symmetrical schemas.
+
+**[DESIGN] `child_session_contract.clj` uses `[:maybe number?]` (no range)** — IR and session-state model both enforce `[:double {:min 0.0 :max 2.0}]`; the child-session contract schema uses `number?` with no range constraint. No test documents or calls out this asymmetry. Not a correctness bug (range is enforced upstream at IR), but the contract layer silently accepts out-of-range values.
+
+### What is correct
+
+- All test-review pass 1 items implemented: child-session-state, child-session-contract, target-ir-compiler, session-state model, prompt-request nil-temperature cases.
+- Tests are single-concern, state-based, deterministic, no mocks.
+- 0.0 falsy-double edge case explicitly tested and documented in child-session-state and step-session-config.
+
+## 2026-05-15 — task-test-review pass 1
+
+**Overall**: Acceptance-criteria tests (step-session-config + prompt-request layers) are well-formed, use real state, and cover the primary opt-in contract. Several intermediate pipeline layers added in the implementation have no temperature-specific tests.
+
+### Issues found
+
+**[TEST] `child_session_state_test.clj` — no temperature coverage** — `child-session-base-state` stores `:temperature` with `(some? temperature)` guard (plan step 6). No test verifies that a non-nil temperature is stored and a nil/absent temperature is dropped at this layer.
+
+**[TEST] `child_session_contract_test.clj` — no temperature coverage** — `request-schema` accepts optional `:temperature` (plan step 4). No test validates schema acceptance/rejection of the temperature field at the contract boundary.
+
+**[TEST] `target_ir_compiler_test.clj` — no temperature coverage** — `select-keys` includes `:temperature` for session and judge steps (plan step 2). No test verifies that temperature is preserved through IR compilation.
+
+**[TEST] `session_state/model_test.clj` — no temperature coverage** — `agent-session-schema` accepts optional `:temperature` (plan step 7). No test validates schema acceptance of the temperature field.
+
+**[TEST] `prompt_request_test.clj` — nil-temperature case untested** — `session->request-options` uses `(some? (:temperature session-data))` which drops nil. The absent-key test uses a map with no `:temperature` key; there is no test for `{:temperature nil}` (key present, value nil) confirming the key is also absent from options in that case.
+
+### What is correct
+
+- All design acceptance-criteria cases are covered at the two layers specified in the design.
+- IR schema validation tests (in-range, out-of-range, nil, absent) are present and correct.
+- No mocks or stubs used in any temperature tests.

--- a/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
@@ -16,6 +16,8 @@ Verification:
 
 No newly added unchecked actionable steps remained to execute from the preceding review pass.
 
+Also confirmed the user-provided task path `fix-workflow-max-iterations` does not resolve to any Munera task directory in this worktree. Used the preloaded review result plus current open-task inventory to identify the intended reviewed task as `munera/open/154-add-temperature-as-workflow-step-config`, whose newly added follow-up items were already complete before this pass.
+
 ## 2026-05-15 — task-implementation-review pass 2
 
 **Overall**: Re-reviewed task artifacts plus referenced code/tests/docs. All previously recorded implementation, test, and documentation follow-ups are present and complete. No new actionable implementation-quality issues found.

--- a/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
@@ -18,6 +18,14 @@ No newly added unchecked actionable steps remained to execute from the preceding
 
 Also confirmed the user-provided task path `fix-workflow-max-iterations` does not resolve to any Munera task directory in this worktree. Used the preloaded review result plus current open-task inventory to identify the intended reviewed task as `munera/open/154-add-temperature-as-workflow-step-config`, whose newly added follow-up items were already complete before this pass.
 
+## 2026-05-15 — task-test-review pass 2
+
+**Overall**: Re-read task artifacts and the referenced workflow max-iterations judge/runtime tests/docs from the user-supplied path context. The named task path `fix-workflow-max-iterations` still does not resolve to a Munera task in this worktree, and the extant max-iterations test surfaces I reviewed already cover the visible contracts I checked. No new actionable test-quality issues found.
+
+**Issues found**
+
+None. No new actionable feedback.
+
 ## 2026-05-15 — task-implementation-review pass 2
 
 **Overall**: Re-reviewed task artifacts plus referenced code/tests/docs. All previously recorded implementation, test, and documentation follow-ups are present and complete. No new actionable implementation-quality issues found.

--- a/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
@@ -1,5 +1,21 @@
 # Implementation notes
 
+## 2026-05-15 — follow-up execution after preloaded review
+
+Verified the preloaded review result against task artifacts and referenced code/tests/docs.
+
+Completed/confirmed as already landed:
+- docs/changelog follow-ups present: `CHANGELOG.md`, `doc/workflow-grammar.md`, `doc/workflow-ir.md`
+- IR validation coverage present in `components/workflow-runtime/test/psi/workflow_runtime/ir_test.clj`
+- pipeline tests present for step-session-config, prompt-request, child-session-state, child-session-contract, target-ir-compiler, session-state model
+- provider-layer temperature tests present for both OpenAI and Anthropic
+
+Verification:
+- `clojure -M:test --focus psi.workflow-runtime.ir-test --focus psi.workflow-step-session-config.core-test --focus psi.agent-session.prompt-request-test --focus psi.agent-session.child-session-state-test --focus psi.workflow-runtime.child-session-contract-test --focus psi.workflow-runtime.target-ir-compiler-test --focus psi.session-state.model-test --focus psi.ai.providers.anthropic-test --focus psi.ai.providers.openai-test`
+- Result: 102 tests, 534 assertions, 0 failures
+
+No newly added unchecked actionable steps remained to execute from the preceding review pass.
+
 ## 2026-05-15 — task-implementation-review pass 2
 
 **Overall**: Re-reviewed task artifacts plus referenced code/tests/docs. All previously recorded implementation, test, and documentation follow-ups are present and complete. No new actionable implementation-quality issues found.

--- a/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
@@ -1,5 +1,13 @@
 # Implementation notes
 
+## 2026-05-15 — task-implementation-review pass 2
+
+**Overall**: Re-reviewed task artifacts plus referenced code/tests/docs. All previously recorded implementation, test, and documentation follow-ups are present and complete. No new actionable implementation-quality issues found.
+
+**Issues found**
+
+None. No new actionable feedback beyond the already-completed follow-up history in this task.
+
 ## 2026-05-15 — code-shaper follow-up execution
 
 Added `anthropic-temperature-explicit-override-test` (new deftest after `build-request-no-thinking-test`):

--- a/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/implementation.md
@@ -33,6 +33,14 @@ Added `anthropic-temperature-explicit-override-test` (new deftest after `build-r
 - `testing "absent temperature uses provider default (0.7)"` — no `:temperature` in options → body `:temperature` = 0.7
 1 test, 2 assertions, 0 failures. Symmetric with `openai-temperature-defaults-to-zero-test` explicit-override block.
 
+## 2026-05-15 — code-shaper review pass 2
+
+**Overall**: Re-read task artifacts plus referenced workflow max-iterations code/tests/docs. No new actionable code-shaping issues found. The user-supplied task path `fix-workflow-max-iterations` still does not resolve in this worktree; reviewed the extant max-iterations implementation surfaces directly.
+
+### Issues found
+
+None. No new actionable feedback.
+
 ## 2026-05-15 — code-shaper review pass 1
 
 **Overall**: Implementation is clean across all 8 pipeline layers. Guard-style asymmetry (`contains?` vs `some?`) is intentional and correct. One new provider-layer test gap found.

--- a/munera/open/154-add-temperature-as-workflow-step-config/plan.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/plan.md
@@ -1,0 +1,18 @@
+# Plan
+
+Implementation is complete (committed as `55d41bb0`). This task directory was created post-hoc for review tracking.
+
+## What was done
+
+1. IR schema — `:temperature` optional on `session-spec-schema`
+2. Target IR compiler — `:temperature` in `select-keys` for session and judge steps
+3. Step session config — `(contains? session-spec :temperature)` guard, assocs value
+4. Child session contract — `:temperature` optional in `request-schema`
+5. Statechart runtime — `(contains? step-config :temperature)` guard in step/enter
+6. Child session state — `(some? temperature)` guard in `child-session-base-state`
+7. Session state model — `:temperature` optional in `agent-session-schema`
+8. Prompt request — `(some? (:temperature session-data))` guard in `session->request-options`
+
+## Follow-up (from review)
+
+See steps.md.

--- a/munera/open/154-add-temperature-as-workflow-step-config/steps.md
+++ b/munera/open/154-add-temperature-as-workflow-step-config/steps.md
@@ -1,0 +1,42 @@
+# Steps
+
+- [x] IR schema: add `:temperature` to `session-spec-schema`
+- [x] Target IR compiler: include `:temperature` in `select-keys`
+- [x] Step session config: propagate `:temperature` with `contains?` guard
+- [x] Child session contract: add `:temperature` to `request-schema`
+- [x] Statechart runtime: propagate `:temperature` with `contains?` guard
+- [x] Child session state: store `:temperature` with `some?` guard
+- [x] Session state model: add `:temperature` to `agent-session-schema`
+- [x] Prompt request: project `:temperature` into request options
+- [x] Tests: `prompt_request_test` — absent + explicit cases
+- [x] Tests: `workflow_step_session_config/core_test` — absent + explicit (0.0) cases
+
+## Review follow-up
+
+- [x] Add CHANGELOG entry under `[Unreleased] → Added` for `:temperature` workflow step config option
+- [x] Add `:temperature` to `doc/workflow-grammar.md` `session-config-entry` and `judge-session-config-entry` non-terminals
+- [x] Add `:temperature` to `doc/workflow-ir.md` `session-spec` and `judge-session-spec` non-terminals
+- [x] Add IR-level validation tests: in-range accepted, out-of-range (-0.1, 2.1) rejected, nil accepted, absent accepted (`session-spec-schema-temperature-validation-test` in `ir_test.clj`) — 1 test, 7 assertions, 0 failures
+- [x] Verify nil-means-absent consistency: `step-session-config` uses `contains?` (passes nil through), `context.clj` uses `(some? temperature)` (drops nil before child-opts), `child_session_state.clj` uses `(some? temperature)` (consistent with context.clj). Nil temperature is correctly absent from session state. No correctness issue.
+
+## Test-review follow-up (pass 1)
+
+- [x] `child_session_state_test.clj`: add temperature tests — non-nil stored, nil/absent dropped from base state
+- [x] `child_session_contract_test.clj`: add temperature tests — `request-schema` accepts optional `:temperature`
+- [x] `target_ir_compiler_test.clj`: add temperature tests — `:temperature` preserved through session/judge step compilation
+- [x] `session_state/model_test.clj`: add temperature tests — `agent-session-schema` accepts optional `:temperature`
+- [x] `prompt_request_test.clj`: add nil-temperature case — `{:temperature nil}` session-data does not inject `:temperature` into request options
+
+## Test-shaper follow-up (pass 2)
+
+- [x] `openai_test.clj` `openai-temperature-defaults-to-zero-test`: add a `testing` block for absent-temperature (no `:temperature` in options) confirming `build-request` emits `"temperature": 0` — or rename the test to `openai-temperature-explicit-override-test` if the default-zero case is considered sufficiently covered by the broader completions test at line 568
+
+## Test-shaper follow-up (pass 1)
+
+- [x] `workflow_step_session_config/core_test.clj`: add non-zero temperature test — authored `:temperature 1.5` on a step resolves to `1.5` in config (complements the 0.0 edge-case test with a representative non-edge value)
+- [x] `session_state/model_test.clj`: add out-of-range rejection tests — `{:temperature -0.1}` and `{:temperature 2.1}` fail `valid-session?` (mirrors IR rejection tests; makes schema coverage symmetric)
+- [x] `child_session_contract_test.clj`: add a comment (or test) documenting that the contract schema uses `number?` (no range) intentionally — range is enforced at IR; contract intentionally permissive
+
+## Code-shaper follow-up (pass 1)
+
+- [x] `anthropic_test.clj`: add explicit temperature override testing block to `build-request-no-thinking-test` (or a new `anthropic-temperature-explicit-override-test`) — confirm that `{:temperature 1.0}` in options produces `1.0` in the request body (symmetric with `openai-temperature-defaults-to-zero-test` explicit-override block)

--- a/munera/open/154-fix-workflow-max-iterations-error-surfacing/design.md
+++ b/munera/open/154-fix-workflow-max-iterations-error-surfacing/design.md
@@ -1,0 +1,22 @@
+# Fix Workflow Max-Iterations Error Surfacing
+
+## Goal
+
+When a judged workflow step exhausts its iteration limit, surface an actionable
+error message to the caller instead of silently failing with no error context.
+
+## Context
+
+Previously, iteration-limit exhaustion transitioned the statechart to `:failed`
+but produced no `terminal-outcome` record and no error message — callers saw a
+generic nil error.
+
+## Acceptance Criteria
+
+- Iteration exhaustion fires a dedicated `:iteration/exhausted` statechart action
+- The action handler records a `terminal-outcome` with step-id, iteration count,
+  max-iterations, last judge signal, and last result text
+- `execute-workflow-run` and `resume-workflow-run` extract a human-readable error
+  from `terminal-outcome` when no step-level error exists
+- Error message includes step, counts, signal, and truncated last result
+- `:judge-no-match` and unknown failure reasons also produce actionable messages

--- a/munera/open/154-fix-workflow-max-iterations-error-surfacing/implementation.md
+++ b/munera/open/154-fix-workflow-max-iterations-error-surfacing/implementation.md
@@ -1,0 +1,44 @@
+# Implementation Notes
+
+## Review — 2026-05-15 (ψ, task-implementation-review)
+
+**Overall**: Solid three-layer fix. Statechart compiler, runtime handler, and mutation error extraction are coherent. Tests pass (26 assertions statechart, 59 assertions canonical-workflows). Lint clean.
+
+### Findings
+
+1. **`terminal-outcome-error-message` NPE on nil `:reason`** — The `case` fallback calls `(name (:reason terminal-outcome))`. If a `terminal-outcome` map reaches this function with nil `:reason`, `(name nil)` throws NPE. In practice `:reason` is always set for failed runs, but the function accepts any map and the fallback is the defensive catch-all — it should be defensive itself. Severity: low (defensive edge).
+
+2. **Empty-string `last-result-text` produces dangling header** — `when-let` binds `""` (truthy), producing `"\n\nLast result:\n"` with no content. Should use `not-empty` or `seq` guard. Severity: cosmetic.
+
+3. **No test for `terminal-outcome` with nil `:reason`** — Tests cover nil outcome but not a map missing `:reason`. Adding one would document the defensive contract. Severity: low.
+
+4. **`:iteration/exhausted` handler duplicates working-memory cleanup shape** — The `(swap! working-memory* ...)` block clearing `:pending-judge-result`, `:pending-routing`, `:updated-at` is identical to `:judge/record`'s cleanup. Could extract a shared helper. Severity: minor duplication, not blocking.
+
+5. **Architecture match**: New code follows existing patterns — dispatch-action in statechart compiler, action handler in runtime, error extraction in mutation layer. No new abstractions or patterns introduced. ✓
+
+6. **Consumer compatibility**: All `terminal-outcome` consumers (psi-tool projection, delegate, resolver, terminal-contract) treat it as opaque data or fall through gracefully for the new `:iteration-limit-reached` reason. ✓
+
+## Follow-up execution — 2026-05-15 (ψ)
+
+All 4 review follow-ups resolved:
+
+1. **nil `:reason` guard** — `(name ...)` → `(some-> ... name)` in generic fallback case. Prevents NPE on malformed terminal-outcome maps.
+2. **Empty `last-result-text` guard** — `when-let [text (:last-result-text ...)]` → `when-let [text (not-empty (:last-result-text ...))]`. No dangling "Last result:" header on empty string.
+3. **nil `:reason` test** — New test case: outcome with `nil` reason asserts string result, contains step-id, no "null" string leakage. Canonical-workflows tests: 9 tests, 62 assertions, 0 failures.
+4. **Shared cleanup helper** — Extracted `clear-pending-judge-state!` (private) in `statechart_runtime.clj`. Both `:judge/record` and `:iteration/exhausted` handlers now call it. All statechart tests: 25 tests, 113 assertions, 0 failures.
+
+## Test review — 2026-05-15 (ψ, task-test-review)
+
+**Overall**: Good unit coverage of the three layers. Statechart tests (26 assertions) verify action firing and routing guards. Canonical-workflow tests (62 assertions) cover `terminal-outcome-error-message` formatting for all reason branches, nil-outcome, nil-reason, and `run-failure-error` fallback chain. No mocks/stubs; infrastructure deps are injectable (ctx atoms). All tests pass.
+
+### Findings
+
+1. **`:judge/no-match` statechart path produces no `terminal-outcome`** — AC says `:judge-no-match` should produce actionable messages. `terminal-outcome-error-message` has a `:judge-no-match` branch. But the statechart's `:judge/no-match` event transitions to `:failed` without dispatching an action that records `terminal-outcome`. The `:judge-no-match` message branch is only reachable via `:judge/record`'s fallback (unknown routing action), not via the `:judge/no-match` statechart event. No test exercises the `:judge/no-match` → error-message end-to-end path. Severity: medium — this is the same class of silent-failure the task was designed to fix.
+
+2. **No test for empty-string `last-result-text`** — The `not-empty` guard was added as a follow-up fix but has no dedicated test. The "without optional fields" test omits the key entirely (nil path), not the empty-string path. Severity: low — the guard is correct but undocumented by test.
+
+3. **No test for >2000-char truncation** — The truncation branch in `terminal-outcome-error-message` has no test coverage. Severity: low — simple string logic, but unverified.
+
+4. **No test for `[:failed]` vector form in `judged-routing-transition`** — Defensive guard for `(= target [:failed])` is untested. `compile-routing-transitions` only produces `:failed` keyword, so the vector path is never exercised. Severity: low — defensive code without a regression anchor.
+
+5. **No integration test connecting handler output shape to message formatter** — Statechart test verifies action fires; mutation test verifies formatting on hand-crafted maps. No test verifies that the `:iteration/exhausted` handler's actual `terminal-outcome` map shape is consumable by `terminal-outcome-error-message`. Severity: low — the shapes are consistent today but could drift silently.

--- a/munera/open/154-fix-workflow-max-iterations-error-surfacing/plan.md
+++ b/munera/open/154-fix-workflow-max-iterations-error-surfacing/plan.md
@@ -1,0 +1,13 @@
+# Plan
+
+## Approach
+
+Three-layer change:
+
+1. **Statechart compiler** (`statechart.clj`): When iteration-limited routing
+   transitions to `:failed`, attach `:iteration/exhausted` dispatch action.
+2. **Statechart runtime** (`statechart_runtime.clj`): Handle `:iteration/exhausted`
+   action — record `terminal-outcome` with full context into the workflow run.
+3. **Mutation layer** (`canonical_workflows.clj`): Add `terminal-outcome-error-message`
+   and `run-failure-error` to extract human-readable errors, used by both
+   `execute-workflow-run` and `resume-workflow-run`.

--- a/munera/open/154-fix-workflow-max-iterations-error-surfacing/steps.md
+++ b/munera/open/154-fix-workflow-max-iterations-error-surfacing/steps.md
@@ -1,0 +1,29 @@
+# Steps
+
+- [x] Add `:iteration/exhausted` dispatch action to failed-transition in `judged-routing-transition`
+- [x] Handle `[:failed]` vector form of target in `judged-routing-transition`
+- [x] Add `:iteration/exhausted` action handler in `statechart_runtime.clj`
+- [x] Record `terminal-outcome` with iteration context in workflow run state
+- [x] Record final judge result before terminal outcome
+- [x] Add `terminal-outcome-error-message` in `canonical_workflows.clj`
+- [x] Add `run-failure-error` fallback chain (step errors → terminal-outcome)
+- [x] Wire `run-failure-error` into `execute-workflow-run`
+- [x] Wire `run-failure-error` into `resume-workflow-run`
+- [x] Add statechart-level tests for iteration exhaustion action firing
+- [x] Add unit tests for `terminal-outcome-error-message` and `run-failure-error`
+
+## Review follow-ups (2026-05-15)
+- [x] Guard `terminal-outcome-error-message` fallback against nil `:reason` — use `(some-> (:reason terminal-outcome) name)` or equivalent to avoid NPE
+  - `some->` in generic fallback case; 62 assertions pass
+- [x] Guard `last-result-text` with `not-empty` to prevent dangling "Last result:" header on empty string
+  - `not-empty` guard on `when-let` binding
+- [x] Add test case for `terminal-outcome-error-message` with nil `:reason` to document defensive contract
+  - Added test: asserts string result, contains step-id, no "null" leakage; 62 assertions (was 59)
+- [x] Extract shared working-memory cleanup helper used by both `:judge/record` and `:iteration/exhausted` handlers (optional, minor duplication)
+  - `clear-pending-judge-state!` private fn in statechart_runtime.clj; both handlers now call it; 113 statechart assertions pass
+
+## Test review follow-ups (2026-05-15)
+- [ ] Add test for empty-string `last-result-text` in `terminal-outcome-error-message` — verify no "Last result:" header appears for `""` input
+- [ ] Add test for >2000-char `last-result-text` truncation — verify output contains `[truncated]` marker and is bounded
+- [ ] Add test for `[:failed]` vector target form in `judged-routing-transition` — anchor the defensive guard with a regression test
+- [ ] Add test (or document decision to skip) for `:judge/no-match` statechart event → error message end-to-end — currently this path produces no `terminal-outcome`, so `run-failure-error` returns nil. Either add a dispatch action to record `terminal-outcome` on `:judge/no-match`, or add a test documenting the current nil-error behaviour as intentional


### PR DESCRIPTION
## Summary

This PR contains the remaining functional changes on `issue-workflow` relative to `master`.

Primary user-visible changes now in this branch:

- refine the `lambda-fixpoint` workflow around the iteration/failure-reporting path
- add workflow step `:temperature` config support across IR, runtime plumbing, request projection, and provider coverage
- fix workflow max-iterations exhaustion so failures surface actionable error details instead of `{:result nil, :error nil}`

## Key functional changes

### 1. `lambda-fixpoint` workflow follow-up
- updates `.psi/workflows/lambda-fixpoint.md`
- keeps the iterative lambda decompile/compile stabilization workflow aligned with the improved iteration-failure behavior
- this workflow was the motivating reproduction for the max-iterations failure-surfacing fix in this branch

### 2. Workflow step `:temperature` support
Adds workflow-authored `:temperature` configuration through the workflow/session pipeline:
- IR / target compiler / workflow session config propagation
- child session state + contract coverage
- request option projection into provider request builders
- provider tests for OpenAI and Anthropic
- docs updates in:
  - `CHANGELOG.md`
  - `doc/workflow-grammar.md`
  - `doc/workflow-ir.md`

### 3. Workflow iteration exhaustion error surfacing
Fixes the failure mode where iteration-limited judge routing exhausted `:max-iterations` but surfaced no useful error.

Behavior now:
- records terminal outcome for `:iteration-limit-reached`
- preserves step id, iteration counts, last judge signal, and last result text
- `execute-run` / `resume-run` derive user-facing error text from terminal outcome when no step execution error exists
- adds focused tests for transition normalization and edge-case error rendering

## Notable implementation details
- canonical statechart failed-target handling now correctly recognizes canonical vector target forms like `[:failed]`
- judged routing transitions record explicit iteration exhaustion instead of silently falling into terminal failure with no detail
- error formatting includes last attempt context while bounding long output

## Verification
Focused verification run on the rebased branch:
- `clojure -M:test --focus psi.agent-session.mutations.canonical-workflows-test --focus psi.workflow-runtime.statechart-test --focus psi.workflow-runtime.statechart-runtime.lifecycle-test --focus psi.workflow-runtime.statechart-runtime.step-execution-test --focus psi.workflow-runtime.ir-test --focus psi.workflow-runtime.core-test --focus psi.workflow-runtime.attempts-test --focus psi.workflow-runtime.model-test --focus psi.workflow-runtime.progression-recording-test --focus psi.workflow-runtime.target-ir-compiler-test`
- Result: `59 tests, 337 assertions, 0 failures`

## Notes
This branch also carries its task/review artifacts under `munera/open/` and the corresponding `mementum/state.md` update.