### PR TITLE
Fix library jar runtime packaging drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
           sudo apt-get install -y tmux
           tmux -V
 
+      - name: Install bbin
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://raw.githubusercontent.com/babashka/bbin/v0.2.5/bbin -o "$HOME/.local/bin/bbin"
+          chmod +x "$HOME/.local/bin/bbin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/bbin" version
+
       - name: Install psi launcher shim for integration tests
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -140,9 +148,11 @@ jobs:
           export BB="$BB_BIN"
           echo "BB=$BB_BIN" >> "$GITHUB_ENV"
           echo "PSI_LAUNCHER_POLICY=development" >> "$GITHUB_ENV"
+          echo "BBIN_REPO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
           cat > "$HOME/.local/bin/psi" <<EOF
           #!/usr/bin/env bash
           export PSI_LAUNCHER_POLICY=development
+          export BBIN_REPO_ROOT="$GITHUB_WORKSPACE"
           exec "$BB_BIN" bb/psi.clj -- "\$@"
           EOF
           chmod +x "$HOME/.local/bin/psi"
@@ -191,6 +201,14 @@ jobs:
           sudo apt-get install -y tmux
           tmux -V
 
+      - name: Install bbin
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://raw.githubusercontent.com/babashka/bbin/v0.2.5/bbin -o "$HOME/.local/bin/bbin"
+          chmod +x "$HOME/.local/bin/bbin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/bbin" version
+
       - name: Install psi launcher shim
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -198,9 +216,11 @@ jobs:
           export BB="$BB_BIN"
           echo "BB=$BB_BIN" >> "$GITHUB_ENV"
           echo "PSI_LAUNCHER_POLICY=development" >> "$GITHUB_ENV"
+          echo "BBIN_REPO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
           cat > "$HOME/.local/bin/psi" <<EOF
           #!/usr/bin/env bash
           export PSI_LAUNCHER_POLICY=development
+          export BBIN_REPO_ROOT="$GITHUB_WORKSPACE"
           exec "$BB_BIN" bb/psi.clj -- "\$@"
           EOF
           chmod +x "$HOME/.local/bin/psi"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,15 +121,25 @@ jobs:
           sudo apt-get install -y tmux
           tmux -V
 
+      - name: Install bbin
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://raw.githubusercontent.com/babashka/bbin/v0.2.5/bbin -o "$HOME/.local/bin/bbin"
+          chmod +x "$HOME/.local/bin/bbin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/bbin" version
+
       - name: Install psi launcher shim
         run: |
           mkdir -p "$HOME/.local/bin"
           BB_BIN="$(command -v bb)"
           echo "BB=$BB_BIN" >> "$GITHUB_ENV"
           echo "PSI_LAUNCHER_POLICY=development" >> "$GITHUB_ENV"
+          echo "BBIN_REPO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
           cat > "$HOME/.local/bin/psi" <<EOF
           #!/usr/bin/env bash
           export PSI_LAUNCHER_POLICY=development
+          export BBIN_REPO_ROOT="$GITHUB_WORKSPACE"
           exec "$BB_BIN" bb/psi.clj -- "\$@"
           EOF
           chmod +x "$HOME/.local/bin/psi"
@@ -178,15 +188,25 @@ jobs:
           sudo apt-get install -y tmux
           tmux -V
 
+      - name: Install bbin
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL https://raw.githubusercontent.com/babashka/bbin/v0.2.5/bbin -o "$HOME/.local/bin/bbin"
+          chmod +x "$HOME/.local/bin/bbin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/bbin" version
+
       - name: Install psi launcher shim
         run: |
           mkdir -p "$HOME/.local/bin"
           BB_BIN="$(command -v bb)"
           echo "BB=$BB_BIN" >> "$GITHUB_ENV"
           echo "PSI_LAUNCHER_POLICY=development" >> "$GITHUB_ENV"
+          echo "BBIN_REPO_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
           cat > "$HOME/.local/bin/psi" <<EOF
           #!/usr/bin/env bash
           export PSI_LAUNCHER_POLICY=development
+          export BBIN_REPO_ROOT="$GITHUB_WORKSPACE"
           exec "$BB_BIN" bb/psi.clj -- "\$@"
           EOF
           chmod +x "$HOME/.local/bin/psi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 
 ## [Unreleased]
 
+### Fixed
+- Library jar packaging now derives its bundled runtime source/resource paths from the authoritative `:psi` launcher alias, preventing installed `psi` releases from omitting extracted runtime components such as `state-kernel`.
+
 ## [0.1.2088] - 2026-05-18
 
 ### Added
@@ -14,7 +17,6 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 - The live graph now exposes explicit session-surface attrs: `:psi.runtime-session/active-id`, `:psi.runtime-session/list`, `:psi.runtime-session/count`, `:psi.persisted-session/list`, and `:psi.persisted-session/list-all`.
 - The live graph now exposes `:psi.agent-session/context-session-summaries`, a compact session inventory for operational selection, alongside the explicit runtime-session root attrs.
 - New `edit-clj` extension and tool: structural Clojure/EDN form replacement by S-expression equality, preserving surrounding file formatting and supporting optional line-range filtering.
-- Library jar packaging now derives its bundled runtime source/resource paths from the authoritative `:psi` launcher alias, preventing installed `psi` releases from omitting extracted runtime components such as `state-kernel`.
 
 ### Fixed
 - `psi-tool` mutation execution now preserves an explicitly supplied business `:session-id` for session-scoped mutations like `psi.extension/close-session`, instead of silently retargeting them to the invoking session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 - The live graph now exposes explicit session-surface attrs: `:psi.runtime-session/active-id`, `:psi.runtime-session/list`, `:psi.runtime-session/count`, `:psi.persisted-session/list`, and `:psi.persisted-session/list-all`.
 - The live graph now exposes `:psi.agent-session/context-session-summaries`, a compact session inventory for operational selection, alongside the explicit runtime-session root attrs.
 - New `edit-clj` extension and tool: structural Clojure/EDN form replacement by S-expression equality, preserving surrounding file formatting and supporting optional line-range filtering.
+- Library jar packaging now derives its bundled runtime source/resource paths from the authoritative `:psi` launcher alias, preventing installed `psi` releases from omitting extracted runtime components such as `state-kernel`.
 
 ### Fixed
 - `psi-tool` mutation execution now preserves an explicitly supplied business `:session-id` for session-scoped mutations like `psi.extension/close-session`, instead of silently retargeting them to the invoking session.

--- a/bases/main/src/psi/build_manifest.clj
+++ b/bases/main/src/psi/build_manifest.clj
@@ -1,0 +1,37 @@
+(ns psi.build-manifest
+  "Build-manifest helpers shared by the tools.build script and tests.
+
+   The library jar published to Clojars must include every runtime source and
+   resource path needed by the installed `psi` launcher. The authoritative path
+   list lives in the top-level `deps.edn` `:psi` alias; these helpers derive the
+   build copy list directly from that alias so packaging cannot silently drift."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(defn read-deps-edn
+  [deps-file]
+  (-> deps-file
+      io/file
+      slurp
+      edn/read-string))
+
+(defn alias-extra-paths
+  [deps-data alias-key]
+  (or (get-in deps-data [:aliases alias-key :extra-paths])
+      (throw (ex-info "Alias missing :extra-paths"
+                      {:alias alias-key}))))
+
+(defn normalize-paths
+  [paths]
+  (->> paths
+       (remove nil?)
+       vec))
+
+(defn build-lib-src-dirs
+  ([]
+   (build-lib-src-dirs "deps.edn"))
+  ([deps-file]
+   (-> (read-deps-edn deps-file)
+       (alias-extra-paths :psi)
+       normalize-paths)))

--- a/bases/main/test/psi/bbin_install_smoke_test.clj
+++ b/bases/main/test/psi/bbin_install_smoke_test.clj
@@ -1,0 +1,60 @@
+(ns psi.bbin-install-smoke-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]))
+
+(defn- sh!
+  [env & args]
+  (let [{:keys [exit out err]} (apply shell/sh (concat args [:env env]))]
+    (when-not (zero? exit)
+      (throw (ex-info "subprocess failed"
+                      {:args args :exit exit :out out :err err})))
+    {:out out :err err}))
+
+(defn- temp-dir!
+  [prefix]
+  (str (java.nio.file.Files/createTempDirectory prefix (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(defn- repo-root
+  []
+  (.getAbsolutePath (io/file ".")))
+
+(defn- version-string
+  []
+  (-> "bases/main/resources/psi/version.edn" slurp read-string :version))
+
+(defn- isolated-env
+  [root]
+  (let [home (str root "/home")
+        xdg-data (str root "/data")
+        xdg-cache (str root "/cache")
+        xdg-config (str root "/config")
+        bbin-bin (str root "/bin")
+        path (str bbin-bin java.io.File/pathSeparator (System/getenv "PATH"))]
+    (doseq [dir [home xdg-data xdg-cache xdg-config bbin-bin]]
+      (.mkdirs (io/file dir)))
+    (spit (str root "/deps.edn") "{:paths []}\n")
+    {:env {"HOME" home
+           "XDG_DATA_HOME" xdg-data
+           "XDG_CACHE_HOME" xdg-cache
+           "XDG_CONFIG_HOME" xdg-config
+           "BABASHKA_BBIN_BIN_DIR" bbin-bin
+           "BBIN_REPO_ROOT" (repo-root)
+           "PATH" path}
+     :cwd root}))
+
+(deftest ^:integration bbin-install-smoke-test
+  (testing "bbin can install the locally built psi library artifact and launch it"
+    (let [tmp-root (temp-dir! "psi-bbin-smoke-")
+          {:keys [env cwd]} (isolated-env tmp-root)
+          expected (str "psi " (version-string))]
+      (sh! env "clojure" "-T:build" "install-local")
+      (sh! env "bbin" "install" "org.hugoduncan/psi" "--as" "psi-smoke" "--mvn/version" (version-string))
+      (let [installed (str (get env "BABASHKA_BBIN_BIN_DIR") "/psi-smoke")
+            {:keys [exit out err]} (apply shell/sh (concat [installed "--cwd" cwd "--version" :env env :dir cwd]))]
+        (is (.exists (io/file installed)))
+        (is (= 0 exit) err)
+        (is (= expected
+               (str/trim out)))))))

--- a/bases/main/test/psi/build_jar_smoke_test.clj
+++ b/bases/main/test/psi/build_jar_smoke_test.clj
@@ -1,0 +1,39 @@
+(ns psi.build-jar-smoke-test
+  (:require
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]))
+
+(defn- jar-entries
+  [jar-path]
+  (let [{:keys [exit out err]} (shell/sh "jar" "tf" jar-path)]
+    (when-not (zero? exit)
+      (throw (ex-info "jar tf failed"
+                      {:jar-path jar-path
+                       :exit exit
+                       :out out
+                       :err err})))
+    (->> (str/split-lines out)
+         set)))
+
+(defn- build-lib!
+  []
+  (let [{:keys [exit out err]} (shell/sh "clojure" "-T:build" "lib")]
+    (when-not (zero? exit)
+      (throw (ex-info "clojure -T:build lib failed"
+                      {:exit exit
+                       :out out
+                       :err err})))
+    {:out out :err err}))
+
+(deftest ^:integration build-lib-jar-includes-runtime-packaging-regression-entries
+  (testing "the built library jar contains runtime namespaces required by installed psi"
+    (build-lib!)
+    (let [entries (jar-entries "target/psi-unreleased.jar")]
+      (is (contains? entries "psi/main.clj"))
+      (is (contains? entries "hugoduncan/psi.clj"))
+      (is (contains? entries "psi/agent_session/dispatch.clj"))
+      (is (contains? entries "psi/state_kernel/dispatch.clj"))
+      (is (contains? entries "psi/edit_clj/extension.clj"))
+      (is (contains? entries "psi/github/extension.clj"))
+      (is (contains? entries "extensions/logprobs.clj")))))

--- a/bases/main/test/psi/build_manifest_test.clj
+++ b/bases/main/test/psi/build_manifest_test.clj
@@ -1,0 +1,32 @@
+(ns psi.build-manifest-test
+  (:require
+   [clojure.edn :as edn]
+   [clojure.test :refer [deftest is testing]]
+   [psi.build-manifest :as sut]))
+
+(deftest build-lib-src-dirs-match-psi-alias-exactly
+  (testing "library build source dirs are derived from the authoritative :psi alias"
+    (let [deps-data (edn/read-string (slurp "deps.edn"))
+          expected (get-in deps-data [:aliases :psi :extra-paths])]
+      (is (= expected
+             (sut/build-lib-src-dirs))))))
+
+(deftest build-lib-src-dirs-include-state-kernel-and-runtime-extracted-components
+  (testing "recent runtime component extractions stay packaged in the library jar"
+    (let [src-dirs (set (sut/build-lib-src-dirs))]
+      (is (contains? src-dirs "components/state-kernel/src"))
+      (is (contains? src-dirs "components/provider-auth/src"))
+      (is (contains? src-dirs "components/turn-statechart/src"))
+      (is (contains? src-dirs "components/turn-runtime/src"))
+      (is (contains? src-dirs "components/tool-runtime/src"))
+      (is (contains? src-dirs "components/session-journal/src"))
+      (is (contains? src-dirs "components/session-persistence/src"))
+      (is (contains? src-dirs "components/shared-config/src"))
+      (is (contains? src-dirs "components/project-nrepl/src"))
+      (is (contains? src-dirs "components/workflow-loader/src"))
+      (is (contains? src-dirs "components/workflow-step-materialization/src"))
+      (is (contains? src-dirs "components/workflow-step-session-config/src"))
+      (is (contains? src-dirs "extensions/github/src"))
+      (is (contains? src-dirs "extensions/edit-clj/src"))
+      (is (contains? src-dirs "extensions/logprobs/src"))
+      (is (contains? src-dirs "extensions/metrics/src")))))

--- a/bb.edn
+++ b/bb.edn
@@ -399,6 +399,10 @@
   {:doc  "Build target/psi.jar and target/psi wrapper script via tools.build."
    :task (shell "clojure -T:build uber")}
 
+  build:install-local
+  {:doc  "Build target/psi-VERSION.jar and install it into the current local Maven repo via tools.build."
+   :task (shell "clojure -T:build install-local")}
+
   deploy
   {:doc  "Deploy library jar to Clojars. Requires CLOJARS_USERNAME and CLOJARS_PASSWORD."
    :task (shell "clojure -T:deploy deploy")}

--- a/build.clj
+++ b/build.clj
@@ -10,7 +10,8 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.tools.build.api :as b]))
+   [clojure.tools.build.api :as b]
+   [psi.build-manifest :as build-manifest]))
 
 ;; ---------------------------------------------------------------------------
 ;; Config
@@ -37,28 +38,11 @@
       (or "unreleased")))
 
 ;; ---------------------------------------------------------------------------
-;; Source paths — mirror :run alias exactly
+;; Source paths — derive from the authoritative runtime alias
 ;; ---------------------------------------------------------------------------
 
 (def src-dirs
-  ["bases/main/src"
-   "bases/main/resources"
-   "components/app-runtime/src"
-   "components/agent-session/src"
-   "components/agent-core/src"
-   "components/ai/src"
-   "components/engine/src"
-   "components/query/src"
-   "components/tui/src"
-   "components/rpc/src"
-   "extensions/auto-session-name/src"
-   "extensions/commit-checks/src"
-   "extensions/hello-ext/src"
-   "extensions/mcp-tasks-run/src"
-   "extensions/mementum/src"
-   "extensions/munera/src"
-   "extensions/plan-state-learning/src"
-   "extensions/work-on/src"])
+  (build-manifest/build-lib-src-dirs))
 
 ;; ---------------------------------------------------------------------------
 ;; Tasks

--- a/build.clj
+++ b/build.clj
@@ -106,6 +106,24 @@
     (println (str "       " class-dir "/META-INF/maven/" (namespace psi-lib) "/" (name psi-lib) "/pom.xml"))
     jar))
 
+(defn install-local
+  "Build the library jar and install it into the current local Maven repo.
+   Intended for local/CI smoke tests that exercise bbin installation against an
+   isolated HOME/XDG environment."
+  [opts]
+  (let [version (version-string)
+        jar     (lib-jar-file version)]
+    (when-not (.exists (io/file jar))
+      (println (str "Library jar not found — building first ..."))
+      (lib opts))
+    (println (str "Installing " jar " to local Maven repo as " psi-lib " " version " ..."))
+    (b/install {:class-dir class-dir
+                :lib       psi-lib
+                :version   version
+                :basis     @basis
+                :jar-file  jar})
+    (println "Done.")))
+
 (defn deploy
   "Deploy the library jar to Clojars.
    Builds the library jar first if it is not already present.

--- a/deps.edn
+++ b/deps.edn
@@ -347,11 +347,13 @@
                         rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}}
           :jvm-opts    ["--enable-native-access=ALL-UNNAMED"]
           :main-opts   ["-m" "kaocha.runner"]}
-  :build {:deps      {io.github.clojure/tools.build {:mvn/version "0.10.12"}}
-          :ns-default build}
-  :deploy {:deps      {io.github.clojure/tools.build {:mvn/version "0.10.12"}
-                       slipset/deps-deploy            {:mvn/version "0.2.2"}}
-           :ns-default build}
+  :build {:extra-paths ["bases/main/src"]
+          :deps        {io.github.clojure/tools.build {:mvn/version "0.10.12"}}
+          :ns-default  build}
+  :deploy {:extra-paths ["bases/main/src"]
+           :deps        {io.github.clojure/tools.build {:mvn/version "0.10.12"}
+                         slipset/deps-deploy            {:mvn/version "0.2.2"}}
+           :ns-default  build}
   :coverage {:extra-deps {lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}}}
   :debug-test {:extra-paths ["test"
                              "components/ai/test"


### PR DESCRIPTION
## Summary
- derive library jar source/resource paths from the authoritative `:psi` launcher alias
- add regression tests proving packaged build paths stay aligned with the runtime alias
- add a build smoke test that inspects the built library jar for required runtime namespaces

## Problem
`org.hugoduncan/psi 0.1.2088` omitted extracted runtime components such as `components/state-kernel/src` from the published library jar because `build.clj` maintained a stale hardcoded `src-dirs` list. Installed `psi` via `bbin` then failed at startup with `Could not locate psi/state_kernel/dispatch`.

## Verification
- `clojure -M:test --focus psi.build-manifest-test --focus psi.build-jar-smoke-test`
- `clojure -M:test --focus unit --focus psi.build-manifest-test --focus psi.build-jar-smoke-test`