### PR TITLE
⚒ Fix released --tui by using jar-owned deps startup metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 
 ## [Unreleased]
 
+### Fixed
+- Released `psi --tui` startup now resolves its shipped runtime dependency closure from jar-owned release metadata packaged at `psi/release-deps.edn`, so release-tag `:jar` policy no longer misses TUI runtime dependencies such as `charm.clj`.
+- Released psi packaging now carries authoritative jar-owned runtime dependency metadata plus the shipped psi-owned runtime source/resource trees, and release smoke coverage proves isolated install/package startup through the artifact-shaped launcher path.
+- Unreleased tmux TUI smoke now prefers the current worktree launcher over a stale installed `psi` on `PATH`, preventing local smoke runs from silently proving an older installed release instead of the checkout under test.
+
 ## [0.1.2119] - 2026-05-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ Releases are tagged `vMAJOR.MINOR.PATCH` on the
 See [CHANGELOG.md](CHANGELOG.md) for what changed in each release.
 
 Each release is also published to [Clojars](https://clojars.org/org.hugoduncan/psi)
-as `org.hugoduncan/psi`. The launcher auto-detects released versions and
-resolves psi from the Maven cache instead of re-fetching from git — no action
-required. Force a specific resolution strategy with `PSI_LAUNCHER_POLICY`
-(`jar` | `installed` | `development`); see [`doc/cli.md`](doc/cli.md).
+as `org.hugoduncan/psi`. Released startup now uses jar-owned release metadata
+packaged inside that artifact to construct psi’s shipped runtime basis, instead
+of reconstructing psi’s own runtime closure from repo-local component layout.
+Extensions still layer additively on top. Force a specific resolution strategy
+with `PSI_LAUNCHER_POLICY` (`jar` | `installed` | `development`); see
+[`doc/cli.md`](doc/cli.md).
 
 Then run psi directly:
 

--- a/bases/main/src/psi/build_manifest.clj
+++ b/bases/main/src/psi/build_manifest.clj
@@ -1,13 +1,24 @@
 (ns psi.build-manifest
-  "Build-manifest helpers shared by the tools.build script and tests.
+  "Build-manifest helpers shared by the tools.build script, launcher, and tests.
 
    The library jar published to Clojars must include every runtime source and
    resource path needed by the installed `psi` launcher. The authoritative path
    list lives in the top-level `deps.edn` `:psi` alias; these helpers derive the
-   build copy list directly from that alias so packaging cannot silently drift."
+   build copy list directly from that alias so packaging cannot silently drift.
+
+   The released launcher also needs artifact-owned dependency metadata for the
+   shipped psi runtime closure. These helpers derive that external dep closure
+   from the same authoritative runtime path list so the launcher can consume a
+   stable jar-owned release-deps payload rather than reconstructing release
+   truth from the repository layout."
   (:require
    [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+(def release-deps-resource-path
+  "Stable jar resource path for release-owned runtime dep metadata."
+  "psi/release-deps.edn")
 
 (defn read-deps-edn
   [deps-file]
@@ -22,6 +33,11 @@
       (throw (ex-info "Alias missing :extra-paths"
                       {:alias alias-key}))))
 
+(defn alias-extra-deps
+  [deps-data alias-key]
+  (or (get-in deps-data [:aliases alias-key :extra-deps])
+      {}))
+
 (defn normalize-paths
   [paths]
   (->> paths
@@ -35,3 +51,84 @@
    (-> (read-deps-edn deps-file)
        (alias-extra-paths :psi)
        normalize-paths)))
+
+(defn- owning-deps-file
+  [runtime-path]
+  (cond
+    (str/starts-with? runtime-path "components/")
+    (let [[_ component _leaf] (str/split runtime-path #"/" 3)]
+      (str "components/" component "/deps.edn"))
+
+    (str/starts-with? runtime-path "extensions/")
+    (let [[_ extension _leaf] (str/split runtime-path #"/" 3)]
+      (str "extensions/" extension "/deps.edn"))
+
+    (str/starts-with? runtime-path "bases/")
+    (let [[_ base _leaf] (str/split runtime-path #"/" 3)]
+      (str "bases/" base "/deps.edn"))
+
+    :else nil))
+
+(defn runtime-deps-files
+  ([]
+   (runtime-deps-files "deps.edn"))
+  ([deps-file]
+   (->> (build-lib-src-dirs deps-file)
+        (keep owning-deps-file)
+        distinct
+        vec)))
+
+(defn- external-deps
+  [deps-map]
+  (into {}
+        (remove (fn [[_lib dep]]
+                  (contains? dep :local/root)))
+        deps-map))
+
+(defn build-lib-runtime-extra-deps
+  "Return third-party runtime deps required by installed psi that are declared
+   only in component/extension-local deps.edn files, excluding deps already
+   present in the top-level root :deps map or the authoritative :psi alias
+   :extra-deps map."
+  ([]
+   (build-lib-runtime-extra-deps "deps.edn"))
+  ([deps-file]
+   (let [deps-data        (read-deps-edn deps-file)
+         root-deps        (:deps deps-data)
+         alias-deps       (alias-extra-deps deps-data :psi)
+         top-level-known  (merge (external-deps root-deps)
+                                 (external-deps alias-deps))
+         nested-external  (->> (runtime-deps-files deps-file)
+                               (map read-deps-edn)
+                               (map :deps)
+                               (map external-deps)
+                               (apply merge {}))]
+     (apply dissoc nested-external (keys top-level-known)))))
+
+(defn build-lib-runtime-basis-deps
+  "Return the complete external dependency map needed by the installed launcher
+   runtime basis: top-level root :deps + authoritative :psi alias :extra-deps +
+   nested-only runtime deps."
+  ([]
+   (build-lib-runtime-basis-deps "deps.edn"))
+  ([deps-file]
+   (let [deps-data       (read-deps-edn deps-file)
+         root-external   (external-deps (:deps deps-data))
+         alias-external  (external-deps (alias-extra-deps deps-data :psi))]
+     (merge root-external
+            alias-external
+            (build-lib-runtime-extra-deps deps-file)))))
+
+(defn release-deps-map
+  "Artifact-owned release dep payload embedded in the published psi jar.
+   This map is read by the released launcher under :jar policy."
+  ([]
+   (release-deps-map "deps.edn"))
+  ([deps-file]
+   {:deps (build-lib-runtime-basis-deps deps-file)}))
+
+(defn release-deps-edn
+  ([]
+   (release-deps-edn "deps.edn"))
+  ([deps-file]
+   (str (pr-str (release-deps-map deps-file)) "\n")))

--- a/bases/main/src/psi/launcher.clj
+++ b/bases/main/src/psi/launcher.clj
@@ -107,10 +107,11 @@
                      :resource-path build-manifest/release-deps-resource-path}))))
 
 (defn- release-version
-  "Return the baked version string, or nil if running unreleased."
+  "Return the baked version string used for jar-policy resolution.
+   This may be a stamped release version or the local unreleased version string
+   installed into a local Maven repo for smoke testing."
   []
-  (let [v (version/version-string)]
-    (when (not= "unreleased" v) v)))
+  (version/version-string))
 
 (defn- materialize-self-dep
   [launcher-root policy dep]
@@ -135,22 +136,19 @@
    :paths []})
 
 (defn- psi-jar-basis
-  "For :jar policy: the published psi jar is the shipped code base and the
+  "For :jar policy: the published psi jar remains the shipped code base and the
    packaged release-deps metadata provides the external runtime dependency
    closure required to start it."
-  []
+  [version]
   (let [release-config (release-basis-config)]
-    {:deps  (:deps release-config)
+    {:deps  (merge {extensions/psi-mvn-lib {:mvn/version version}}
+                   (:deps release-config))
      :paths []}))
 
 (defn psi-self-basis
   [launcher-root policy]
   (if (= :jar policy)
-    (do
-      (when-not (release-version)
-        (throw (ex-info ":jar policy requires a stamped release version (not 'unreleased')"
-                        {:stage :basis-construction :policy policy})))
-      (psi-jar-basis))
+    (psi-jar-basis (release-version))
     (-> (repo-basis-config launcher-root)
         (psi-self-basis-from-repo-config launcher-root policy)
         (update :deps assoc 'nrepl/nrepl {:mvn/version "1.5.1"}))))

--- a/bases/main/src/psi/launcher.clj
+++ b/bases/main/src/psi/launcher.clj
@@ -4,6 +4,7 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [psi.build-manifest :as build-manifest]
    [psi.launcher.extensions :as extensions]
    [psi.version :as version]))
 
@@ -89,6 +90,22 @@
   [launcher-root]
   (read-edn-file (io/file launcher-root "deps.edn")))
 
+(defn release-basis-config
+  []
+  (if-let [resource (io/resource build-manifest/release-deps-resource-path)]
+    (try
+      (-> resource slurp edn/read-string)
+      (catch Exception e
+        (throw (ex-info "Malformed jar-owned release deps metadata"
+                        {:stage :basis-construction
+                         :policy :jar
+                         :resource-path build-manifest/release-deps-resource-path}
+                        e))))
+    (throw (ex-info "Missing jar-owned release deps metadata"
+                    {:stage :basis-construction
+                     :policy :jar
+                     :resource-path build-manifest/release-deps-resource-path}))))
+
 (defn- release-version
   "Return the baked version string, or nil if running unreleased."
   []
@@ -118,20 +135,22 @@
    :paths []})
 
 (defn- psi-jar-basis
-  "For :jar policy: single mvn coord replaces all psi local/root self-deps."
-  [version]
-  {:deps {extensions/psi-mvn-lib {:mvn/version version}
-          'nrepl/nrepl            {:mvn/version "1.5.1"}}
-   :paths []})
+  "For :jar policy: the published psi jar is the shipped code base and the
+   packaged release-deps metadata provides the external runtime dependency
+   closure required to start it."
+  []
+  (let [release-config (release-basis-config)]
+    {:deps  (:deps release-config)
+     :paths []}))
 
 (defn psi-self-basis
   [launcher-root policy]
   (if (= :jar policy)
-    (let [v (release-version)]
-      (when-not v
+    (do
+      (when-not (release-version)
         (throw (ex-info ":jar policy requires a stamped release version (not 'unreleased')"
                         {:stage :basis-construction :policy policy})))
-      (psi-jar-basis v))
+      (psi-jar-basis))
     (-> (repo-basis-config launcher-root)
         (psi-self-basis-from-repo-config launcher-root policy)
         (update :deps assoc 'nrepl/nrepl {:mvn/version "1.5.1"}))))
@@ -172,13 +191,6 @@
         (assoc dep :local/root (.getAbsolutePath (io/file base-dir local-root)))))
     dep))
 
-(defn- basis-deps
-  [dep-map]
-  (into {}
-        (map (fn [[lib dep]]
-               [lib (dissoc dep :psi/init :psi/enabled)]))
-        dep-map))
-
 (defn- resolve-release-version-placeholder
   "Replace the :psi/release-version sentinel with the actual version string."
   [dep version]
@@ -208,7 +220,7 @@
 
 (defn startup-basis
   [launcher-root cwd policy]
-  (let [self-basis       (update (psi-self-basis launcher-root policy) :deps basis-deps)
+  (let [self-basis       (psi-self-basis launcher-root policy)
         manifest-info0   (manifest-state launcher-root cwd policy)
         expanded-deps    (->> (get-in manifest-info0 [:expanded-manifest :deps])
                               (remove (fn [[lib _dep]]

--- a/bases/main/src/psi/launcher_main.clj
+++ b/bases/main/src/psi/launcher_main.clj
@@ -7,22 +7,6 @@
    [psi.launcher :as launcher]
    [psi.version :as version]))
 
-(defn- explicit-policy
-  "Resolve launcher policy from PSI_LAUNCHER_POLICY env var.
-   Defaults to :jar when running a stamped release, :installed otherwise."
-  []
-  (case (System/getenv "PSI_LAUNCHER_POLICY")
-    "development" :development
-    "installed"   :installed
-    "jar"         :jar
-    nil           (if (not= "unreleased" (version/version-string))
-                    :jar
-                    :installed)
-    (throw (ex-info "Invalid PSI_LAUNCHER_POLICY"
-                    {:env "PSI_LAUNCHER_POLICY"
-                     :value (System/getenv "PSI_LAUNCHER_POLICY")
-                     :expected #{"development" "installed" "jar"}}))))
-
 (defn- resource-root
   "Returns the repo root when running from source (file: URL), nil from a jar."
   []
@@ -31,6 +15,23 @@
       (some-> (.getPath url)
               (str/replace #"/bases/main/src/psi/launcher_main\.clj$" "")
               not-empty))))
+
+(defn- explicit-policy
+  "Resolve launcher policy from PSI_LAUNCHER_POLICY env var.
+   Defaults to :jar when running from a packaged artifact (no repo resource
+   root), :installed when running from source/repo layout."
+  []
+  (case (System/getenv "PSI_LAUNCHER_POLICY")
+    "development" :development
+    "installed"   :installed
+    "jar"         :jar
+    nil            (if (resource-root)
+                     :installed
+                     :jar)
+    (throw (ex-info "Invalid PSI_LAUNCHER_POLICY"
+                    {:env "PSI_LAUNCHER_POLICY"
+                     :value (System/getenv "PSI_LAUNCHER_POLICY")
+                     :expected #{"development" "installed" "jar"}}))))
 
 (defn- launcher-root
   []

--- a/bases/main/test/psi/bbin_install_smoke_test.clj
+++ b/bases/main/test/psi/bbin_install_smoke_test.clj
@@ -47,7 +47,7 @@
      :cwd root}))
 
 (deftest ^:integration bbin-install-smoke-test
-  (testing "bbin can install the locally built psi library artifact and launch it"
+  (testing "bbin can install the locally built psi library artifact and launch it from an isolated environment without repo-local startup assumptions"
     (support/with-build-lock
       (let [tmp-root (temp-dir! "psi-bbin-smoke-")
             {:keys [env cwd]} (isolated-env tmp-root)

--- a/bases/main/test/psi/bbin_install_smoke_test.clj
+++ b/bases/main/test/psi/bbin_install_smoke_test.clj
@@ -18,10 +18,6 @@
   [prefix]
   (str (java.nio.file.Files/createTempDirectory prefix (make-array java.nio.file.attribute.FileAttribute 0))))
 
-(defn- repo-root
-  []
-  (.getAbsolutePath (io/file ".")))
-
 (defn- version-string
   []
   (-> "bases/main/resources/psi/version.edn" slurp read-string :version))
@@ -42,7 +38,6 @@
            "XDG_CACHE_HOME" xdg-cache
            "XDG_CONFIG_HOME" xdg-config
            "BABASHKA_BBIN_BIN_DIR" bbin-bin
-           "BBIN_REPO_ROOT" (repo-root)
            "PATH" path}
      :cwd root}))
 
@@ -55,8 +50,9 @@
         (sh! env "clojure" "-T:build" "install-local")
         (sh! env "bbin" "install" "org.hugoduncan/psi" "--as" "psi-smoke" "--mvn/version" (version-string))
         (let [installed (str (get env "BABASHKA_BBIN_BIN_DIR") "/psi-smoke")
-              version-result (apply shell/sh (concat [installed "--cwd" cwd "--version" :env env :dir cwd]))
-              help-result    (apply shell/sh (concat [installed "--cwd" cwd "--help" :env env :dir cwd]))]
+              run-env (assoc env "PSI_LAUNCHER_POLICY" "jar")
+              version-result (apply shell/sh (concat [installed "--cwd" cwd "--version" :env run-env :dir cwd]))
+              help-result    (apply shell/sh (concat [installed "--cwd" cwd "--help" :env run-env :dir cwd]))]
           (is (.exists (io/file installed)))
           (is (= 0 (:exit version-result)) (:err version-result))
           (is (= expected

--- a/bases/main/test/psi/build_jar_smoke_test.clj
+++ b/bases/main/test/psi/build_jar_smoke_test.clj
@@ -1,8 +1,10 @@
 (ns psi.build-jar-smoke-test
   (:require
+   [clojure.edn :as edn]
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [psi.build-manifest :as build-manifest]
    [psi.build-smoke-support :as support]))
 
 (defn- jar-entries
@@ -16,6 +18,18 @@
                        :err err})))
     (->> (str/split-lines out)
          set)))
+
+(defn- jar-read-entry
+  [jar-path entry]
+  (let [{:keys [exit out err]} (shell/sh "unzip" "-p" jar-path entry)]
+    (when-not (zero? exit)
+      (throw (ex-info "unzip -p failed"
+                      {:jar-path jar-path
+                       :entry entry
+                       :exit exit
+                       :out out
+                       :err err})))
+    out))
 
 (defn- build-lib!
   []
@@ -46,4 +60,20 @@
         (is (contains? entries "psi/state_kernel/dispatch.clj"))
         (is (contains? entries "psi/edit_clj/extension.clj"))
         (is (contains? entries "psi/github/extension.clj"))
-        (is (contains? entries "extensions/logprobs.clj"))))))
+        (is (contains? entries "extensions/logprobs.clj"))
+        (is (contains? entries build-manifest/release-deps-resource-path))))))
+
+(deftest ^:integration build-lib-jar-embeds-release-deps-metadata
+  (testing "the built library jar carries stable release deps metadata with external runtime deps"
+    (support/with-build-lock
+      (build-lib!)
+      (let [jar-path (lib-jar-path)
+            release-deps (-> (jar-read-entry jar-path build-manifest/release-deps-resource-path)
+                             edn/read-string)]
+        (is (= {:mvn/version "1.5.1"}
+               (get-in release-deps [:deps 'nrepl/nrepl])))
+        (is (= {:git/tag "v0.2.71"
+                :git/sha "38e6823"}
+               (get-in release-deps [:deps 'io.github.timokramer/charm.clj])))
+        (is (nil? (get-in release-deps [:deps 'psi/main])))
+        (is (nil? (get-in release-deps [:deps 'psi/tui])))))))

--- a/bases/main/test/psi/build_manifest_test.clj
+++ b/bases/main/test/psi/build_manifest_test.clj
@@ -49,3 +49,26 @@
                     "extensions/logprobs/src"
                     "extensions/metrics/src"]]
         (is (contains? src-dirs path) path)))))
+
+(deftest release-deps-resource-path-test
+  (testing "release deps metadata lives at a stable named jar resource path"
+    (is (= "psi/release-deps.edn"
+           sut/release-deps-resource-path))))
+
+(deftest release-deps-map-includes-authoritative-runtime-extra-deps
+  (testing "release deps map includes :psi alias extra-deps and nested runtime deps"
+    (let [deps (sut/release-deps-map)]
+      (is (= {:mvn/version "1.5.1"}
+             (get-in deps [:deps 'nrepl/nrepl])))
+      (is (= {:git/tag "v0.2.71"
+              :git/sha "38e6823"}
+             (get-in deps [:deps 'io.github.timokramer/charm.clj])))
+      (is (= {:mvn/version "1.1.47"}
+             (get-in deps [:deps 'rewrite-clj/rewrite-clj]))))))
+
+(deftest release-deps-map-excludes-psi-owned-local-roots
+  (testing "release deps metadata carries only external deps, not repo local/root deps"
+    (let [deps (sut/release-deps-map)]
+      (is (nil? (get-in deps [:deps 'psi/tui])))
+      (is (nil? (get-in deps [:deps 'psi/main])))
+      (is (nil? (get-in deps [:deps 'psi/app-runtime]))))))

--- a/bases/main/test/psi/launcher_test.clj
+++ b/bases/main/test/psi/launcher_test.clj
@@ -1,5 +1,6 @@
 (ns psi.launcher-test
   (:require
+   [clojure.java.io]
    [clojure.test :refer [deftest is testing]]
    [psi.launcher :as launcher]
    [psi.launcher.extensions :as extensions]))
@@ -64,10 +65,14 @@
                nrepl/nrepl {:mvn/version "1.5.1"}}
              (:deps (with-redefs [launcher/repo-basis-config (constantly repo-config)]
                       (launcher/psi-self-basis "/repo/psi" :installed))))))
-    (testing "jar policy emits single mvn coord for the release version"
-      (is (= '{org.hugoduncan/psi {:mvn/version "0.1.42"}
-               nrepl/nrepl {:mvn/version "1.5.1"}}
-             (:deps (with-redefs [launcher/release-version (constantly "0.1.42")]
+    (testing "jar policy reads external runtime deps from jar-owned release metadata"
+      (is (= '{nrepl/nrepl {:mvn/version "1.5.1"}
+               io.github.timokramer/charm.clj {:git/tag "v0.2.71"
+                                               :git/sha "38e6823"}}
+             (:deps (with-redefs [launcher/release-version (constantly "0.1.42")
+                                  launcher/release-basis-config (constantly '{:deps {nrepl/nrepl {:mvn/version "1.5.1"}
+                                                                                     io.github.timokramer/charm.clj {:git/tag "v0.2.71"
+                                                                                                                     :git/sha "38e6823"}}})]
                       (launcher/psi-self-basis "/repo/psi" :jar))))))
     (testing "jar policy throws when version resource is unreleased"
       (let [ex (try
@@ -122,11 +127,9 @@
                          :defaulted-libs ['psi/mementum 'psi/workflow-loader]
                          :inferred-init-libs ['psi/mementum 'psi/workflow-loader]}
           result (with-redefs [launcher/release-version (constantly "0.1.42")
+                               launcher/release-basis-config (constantly '{:deps {nrepl/nrepl {:mvn/version "1.5.1"}}})
                                launcher/manifest-state (fn [_ _ _] manifest-info)]
                    (launcher/startup-basis "/repo/psi" "/repo/project" :jar))]
-      ;; psi self-dep is the single mvn coord
-      (is (= {:mvn/version "0.1.42"}
-             (get-in result [:basis :deps 'org.hugoduncan/psi])))
       ;; psi-owned extensions are NOT added as separate Maven artifacts
       (is (nil? (get-in result [:basis :deps 'psi/mementum])))
       (is (nil? (get-in result [:basis :deps 'psi/workflow-loader])))))
@@ -142,10 +145,13 @@
                          :defaulted-libs []
                          :inferred-init-libs []}
           result (with-redefs [launcher/release-version (constantly "0.1.42")
+                               launcher/release-basis-config (constantly '{:deps {nrepl/nrepl {:mvn/version "1.5.1"}}})
                                launcher/manifest-state (fn [_ _ _] manifest-info)]
                    (launcher/startup-basis "/repo/psi" "/repo/project" :jar))]
       (is (= {:mvn/version "2.0.0"}
-             (get-in result [:basis :deps 'third-party/ext])))))
+             (get-in result [:basis :deps 'third-party/ext])))
+      (is (= {:mvn/version "1.5.1"}
+             (get-in result [:basis :deps 'nrepl/nrepl])))))
   (testing "jar policy throws when version resource is unreleased"
     (let [manifest-info {:user-path "/tmp/user.edn"
                          :project-path "/tmp/project/.psi/extensions.edn"
@@ -159,6 +165,7 @@
                          :inferred-init-libs []}
           ex (try
                (with-redefs [launcher/release-version (constantly nil)
+                             launcher/release-basis-config (constantly '{:deps {nrepl/nrepl {:mvn/version "1.5.1"}}})
                              launcher/manifest-state (fn [_ _ _] manifest-info)]
                  (launcher/startup-basis "/repo/psi" "/repo/project" :jar))
                nil
@@ -188,6 +195,17 @@
            (get-in result [:basis :deps 'psi/workflow-loader])))
     ;; :psi/init is also stripped from manifest-info expanded-manifest (same expanded-deps map)
     (is (nil? (get-in result [:manifest-info :expanded-manifest :deps 'psi/workflow-loader :psi/init])))))
+
+(deftest release-basis-config-test
+  (testing "missing jar-owned release metadata fails clearly"
+    (let [ex (try
+               (with-redefs [clojure.java.io/resource (constantly nil)]
+                 (launcher/release-basis-config))
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (= :basis-construction (-> ex ex-data :stage)))
+      (is (= :jar (-> ex ex-data :policy))))))
 
 (deftest launch-plan-test
   (let [basis-state {:basis {:deps {'foo/bar {:mvn/version "1.0.0"}}}

--- a/bases/main/test/psi/launcher_test.clj
+++ b/bases/main/test/psi/launcher_test.clj
@@ -65,8 +65,9 @@
                nrepl/nrepl {:mvn/version "1.5.1"}}
              (:deps (with-redefs [launcher/repo-basis-config (constantly repo-config)]
                       (launcher/psi-self-basis "/repo/psi" :installed))))))
-    (testing "jar policy reads external runtime deps from jar-owned release metadata"
-      (is (= '{nrepl/nrepl {:mvn/version "1.5.1"}
+    (testing "jar policy reads external runtime deps from jar-owned release metadata and retains the psi artifact coord"
+      (is (= '{org.hugoduncan/psi {:mvn/version "0.1.42"}
+               nrepl/nrepl {:mvn/version "1.5.1"}
                io.github.timokramer/charm.clj {:git/tag "v0.2.71"
                                                :git/sha "38e6823"}}
              (:deps (with-redefs [launcher/release-version (constantly "0.1.42")
@@ -74,14 +75,14 @@
                                                                                      io.github.timokramer/charm.clj {:git/tag "v0.2.71"
                                                                                                                      :git/sha "38e6823"}}})]
                       (launcher/psi-self-basis "/repo/psi" :jar))))))
-    (testing "jar policy throws when version resource is unreleased"
-      (let [ex (try
-                 (with-redefs [launcher/release-version (constantly nil)]
+    (testing "jar policy accepts the baked version string, including local unreleased smoke installs"
+      (is (= '{org.hugoduncan/psi {:mvn/version "unreleased"}
+               nrepl/nrepl {:mvn/version "1.5.1"}}
+             (-> (with-redefs [launcher/release-version (constantly "unreleased")
+                               launcher/release-basis-config (constantly '{:deps {nrepl/nrepl {:mvn/version "1.5.1"}}})]
                    (launcher/psi-self-basis "/repo/psi" :jar))
-                 nil
-                 (catch clojure.lang.ExceptionInfo e e))]
-        (is (some? ex))
-        (is (= :basis-construction (-> ex ex-data :stage)))))))
+                 :deps
+                 (select-keys '[org.hugoduncan/psi nrepl/nrepl])))))))
 
 (deftest build-deps-clj-args-test
   (let [args (launcher/build-deps-clj-args {:basis-file "/tmp/psi-basis-123.edn"
@@ -151,27 +152,9 @@
       (is (= {:mvn/version "2.0.0"}
              (get-in result [:basis :deps 'third-party/ext])))
       (is (= {:mvn/version "1.5.1"}
-             (get-in result [:basis :deps 'nrepl/nrepl])))))
-  (testing "jar policy throws when version resource is unreleased"
-    (let [manifest-info {:user-path "/tmp/user.edn"
-                         :project-path "/tmp/project/.psi/extensions.edn"
-                         :user-present? false
-                         :project-present? false
-                         :user-manifest {:deps {}}
-                         :project-manifest {:deps {}}
-                         :merged-manifest {:deps {}}
-                         :expanded-manifest {:deps {}}
-                         :defaulted-libs []
-                         :inferred-init-libs []}
-          ex (try
-               (with-redefs [launcher/release-version (constantly nil)
-                             launcher/release-basis-config (constantly '{:deps {nrepl/nrepl {:mvn/version "1.5.1"}}})
-                             launcher/manifest-state (fn [_ _ _] manifest-info)]
-                 (launcher/startup-basis "/repo/psi" "/repo/project" :jar))
-               nil
-               (catch clojure.lang.ExceptionInfo e e))]
-      (is (some? ex))
-      (is (= :basis-construction (-> ex ex-data :stage))))))
+             (get-in result [:basis :deps 'nrepl/nrepl])))
+      (is (= {:mvn/version "0.1.42"}
+             (get-in result [:basis :deps 'org.hugoduncan/psi]))))))
 
 (deftest startup-basis-expands-recognized-psi-owned-minimal-manifest-entry-into-basis-deps
   (let [repo-config {:deps {'psi/main {:local/root "bases/main"}

--- a/bases/main/test/psi/release_packaging_smoke_test.clj
+++ b/bases/main/test/psi/release_packaging_smoke_test.clj
@@ -47,7 +47,6 @@
      "XDG_CACHE_HOME" xdg-cache
      "XDG_CONFIG_HOME" xdg-config
      "BABASHKA_BBIN_BIN_DIR" bbin-bin
-     "BBIN_REPO_ROOT" (.getAbsolutePath (io/file "."))
      "PATH" path}))
 
 (deftest ^:integration stamped-release-bbin-help-smoke-test
@@ -63,8 +62,9 @@
           (sh! env "clojure" "-T:build" "install-local")
           (sh! env "bbin" "install" "org.hugoduncan/psi" "--as" "psi-release-smoke" "--mvn/version" stamped-version)
           (let [installed (str (get env "BABASHKA_BBIN_BIN_DIR") "/psi-release-smoke")
-                version-result (apply shell/sh (concat [installed "--cwd" tmp-root "--version" :env env :dir tmp-root]))
-                help-result    (apply shell/sh (concat [installed "--cwd" tmp-root "--help" :env env :dir tmp-root]))]
+                run-env (assoc env "PSI_LAUNCHER_POLICY" "jar")
+                version-result (apply shell/sh (concat [installed "--cwd" tmp-root "--version" :env run-env :dir tmp-root]))
+                help-result    (apply shell/sh (concat [installed "--cwd" tmp-root "--help" :env run-env :dir tmp-root]))]
             (is (.exists (io/file installed)))
             (is (= 0 (:exit version-result)) (:err version-result))
             (is (= (str "psi " stamped-version)

--- a/bases/main/test/psi/release_packaging_smoke_test.clj
+++ b/bases/main/test/psi/release_packaging_smoke_test.clj
@@ -51,7 +51,7 @@
      "PATH" path}))
 
 (deftest ^:integration stamped-release-bbin-help-smoke-test
-  (testing "stamped release artifact installs via bbin and prints non-interactive help"
+  (testing "stamped release artifact installs via bbin and prints non-interactive help without repo layout"
     (support/with-build-lock
       (let [original-version (read-version-string)
             stamped-version  "0.1.2115-packaging-smoke"

--- a/build.clj
+++ b/build.clj
@@ -96,6 +96,12 @@
     (b/copy-file {:src    "bb.edn"
                   :target (str class-dir "/bb.edn")})
 
+    ;; 3c. Write release-owned runtime dep metadata for jar policy launcher startup
+    (println "  Writing release deps metadata ...")
+    (let [release-deps-target (io/file class-dir build-manifest/release-deps-resource-path)]
+      (io/make-parents release-deps-target)
+      (spit release-deps-target (build-manifest/release-deps-edn)))
+
     ;; 4. Build thin jar (no AOT)
     (println "  Assembling library jar ...")
     (b/jar {:class-dir class-dir

--- a/components/tui/test/psi/tui/test_harness/tmux.clj
+++ b/components/tui/test/psi/tui/test_harness/tmux.clj
@@ -59,12 +59,32 @@
   [cmd]
   (zero? (:exit (run-sh (format "command -v %s >/dev/null 2>&1" cmd)))))
 
+(defn- current-worktree-unreleased?
+  []
+  (try
+    (= "unreleased"
+       (-> "bases/main/resources/psi/version.edn"
+           slurp
+           read-string
+           :version))
+    (catch Exception _
+      false)))
+
 (defn launcher-command
-  "Resolve the best available TUI launch command, preferring the installed
-   canonical `psi` binary when available.  For scenarios that need to exercise
-   code in the current worktree, use [[worktree-launch-command]] instead."
+  "Resolve the best available TUI launch command.
+
+   For local worktree testing, prefer the repo-local launcher when the current
+   worktree is an unreleased checkout. This avoids accidentally exercising a
+   stale installed `psi` on PATH that may not match the current source tree.
+   Otherwise prefer the canonical installed `psi` binary when available. For
+   scenarios that need to exercise code in the current worktree explicitly, use
+   [[worktree-launch-command]] instead."
   []
   (cond
+    (and (current-worktree-unreleased?)
+         (command-available? "bb"))
+    (repo-local-launch-command-abs)
+
     (command-available? "psi")
     canonical-launch-command
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -12,6 +12,12 @@ The launcher constructs startup basis data before `psi.main` starts.
 That means user/project extension manifests participate in classpath and
 extension availability before the JVM launches.
 
+Under `jar` policy, the launcher reads psi's shipped runtime dependency closure
+from jar-owned release metadata packaged inside `org.hugoduncan/psi`, rather
+than reconstructing psi's own runtime basis from repo-local component layout.
+Psi-owned runtime source/resource trees are packaged in the published jar, while
+user/project extension manifests layer additively on top.
+
 Launcher realization policy controls how psi and psi-owned extensions are
 resolved at startup. Three policies exist:
 
@@ -21,9 +27,9 @@ resolved at startup. Three policies exist:
 | `installed` | Default for unreleased/git installs | Local paths relative to the launcher root (git checkout) |
 | `development` | Contributor/repo-local flows | Local paths relative to the launcher root (source tree) |
 
-Auto-detection: when `psi/version.edn` contains a release semver (not
-`"unreleased"`), the launcher defaults to `:jar` policy. An unreleased build
-defaults to `:installed`.
+Auto-detection: when running from a packaged artifact (no source-tree resource
+root), the launcher defaults to `:jar` policy. When running from source/repo
+layout, it defaults to `:installed`.
 
 Override with `PSI_LAUNCHER_POLICY`:
 

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -193,6 +193,12 @@ against that locally installed artifact, builds the uberjar, and still skips
 external publication steps such as Clojars deploy, changelog extraction, and
 GitHub Release creation.
 
+The released jar now carries jar-owned runtime dependency metadata at
+`psi/release-deps.edn`. Release launcher startup under `:jar` policy reads that
+artifact-owned payload to construct psi's shipped runtime basis, while the jar
+itself carries the packaged psi-owned runtime source/resource trees. User and
+project extension manifests remain additive over that base.
+
 ### Partial-failure recovery
 
 `bb release` and `bb release:tag` are re-entrant:

--- a/doc/tui.md
+++ b/doc/tui.md
@@ -39,6 +39,10 @@ psi --tui --nrepl 8888
 
 Development/non-canonical alternatives may still use repo-local `clojure -M:run ...`
 paths, but the launcher-owned `psi` command is now the primary operator path.
+For released installs, that path now depends on the jar-owned release metadata
+packaged inside the published psi artifact, so `--tui` smoke coverage should run
+through the installed/package-shaped launcher path rather than only through
+repo-local startup.
 
 ## OAuth Login (no env var needed)
 

--- a/doc/tui.md
+++ b/doc/tui.md
@@ -12,7 +12,8 @@ Reusable harness helpers live at:
 
 What it validates:
 1. start psi TUI in detached tmux using the resolved launcher command
-   - prefers canonical installed command: `exec psi --tui`
+   - for unreleased worktree testing, prefers the repo-local launcher so the harness proves the current checkout rather than a stale installed `psi` on `PATH`
+   - otherwise prefers canonical installed command: `exec psi --tui`
    - falls back to repo-local launcher when `psi` is not on `PATH`: `exec bb bb/psi.clj -- --tui`
 2. wait until prompt is ready (`刀:` / `Type a message`)
 3. send `/help` and assert help output marker appears

--- a/extensions/mcp-tasks-run/deps.edn
+++ b/extensions/mcp-tasks-run/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure         {:mvn/version "1.12.0"}
         babashka/process            {:mvn/version "0.6.23"}
         com.fulcrologic/statecharts {:mvn/version "1.2.25"}
-        taoensso/timbre             {:mvn/version "6.5.0"}
+        com.taoensso/timbre         {:mvn/version "6.5.0"}
         psi/ai                      {:local/root "../../components/ai"}
         psi/agent-core              {:local/root "../../components/agent-core"}
         psi/agent-session           {:local/root "../../components/agent-session"}}

--- a/munera/open/157-jar-owned-deps-release-startup/design.md
+++ b/munera/open/157-jar-owned-deps-release-startup/design.md
@@ -1,0 +1,229 @@
+# 157 — released jar startup from jar-owned deps.edn
+
+## Intent
+
+Reshape psi’s released packaging so the released `psi` command starts from the published jar’s own `deps.edn` metadata rather than reconstructing runtime dependencies from the repo/worktree layout at invocation time.
+
+## Context
+
+The previous direction for this task targeted a `projects/main` uberjar release shape. That would remove launcher-time dependency resolution entirely, but it collides with an important requirement: psi supports extensions, and the release shape still needs a flexible classpath story for extension installation and startup.
+
+So the correct release shape is narrower:
+
+- keep psi as a released jar
+- keep launcher-time dependency realization where needed for the jar + extensions model
+- stop deriving the released runtime basis from the repo/worktree component graph
+- instead derive the authoritative psi runtime dependency closure from the published jar’s own `deps.edn`
+
+This keeps extension flexibility while removing the current mismatch between repo-local dependency resolution and released startup.
+
+The recent `psi --tui` release failure exposed the problem clearly:
+
+- `psi.tui.app` depends on `charm.clj`
+- that dependency is available in the repo/development shape through component-local deps resolution
+- the released launcher path did not reliably reflect the full runtime dependency closure of the released artifact
+- installed `psi --tui` therefore failed at startup
+
+This is not fundamentally a TUI bug. It is a release metadata / runtime-basis bug.
+
+## Problem
+
+Psi currently lets the released launcher infer psi’s own runtime dependency closure indirectly from repo-oriented startup logic.
+
+That is the wrong source of truth for a released jar.
+
+For the released application, psi’s own runtime closure should come from the released artifact itself:
+
+- the jar should carry the authoritative `deps.edn` data needed for psi’s core runtime
+- the jar should also contain the psi-owned local dependency source/resource trees that make up the shipped application code
+- the launcher should use that jar-owned dependency metadata when constructing the runtime basis
+- extension manifests can then layer on top of that released psi basis
+
+Without that shift, released behavior can drift from the artifact actually shipped and regressions like missing `charm.clj` can escape.
+
+## Goal
+
+Make the published psi jar the authoritative owner of psi’s runtime dependency metadata, via jar-owned `deps.edn`, and make the released launcher build its basis from that artifact-owned metadata rather than from repo/worktree dependency inference.
+
+For this task, `jar-owned deps.edn` means a stable, named dependency metadata payload packaged inside the published psi jar and read by the released launcher as artifact-owned release metadata. It may be the root `deps.edn` copied into the jar or a generated release-focused `deps.edn`, but the final shape must be explicit, stable, and testable rather than inferred indirectly from the repo layout.
+
+Implementation must choose one exact metadata path/name inside the jar and make launcher code, tests, and docs refer to that exact path consistently.
+
+## In scope
+
+- define the released jar as the authoritative source of psi core runtime dependency metadata
+- ensure the published jar contains the `deps.edn` information needed for released startup
+- ensure the published jar also contains the source and resource trees for psi-owned local dependencies that the released startup classpath expects to load from the psi artifact itself
+- define the boundary of shipped psi-owned local code/resources precisely: runtime source/resource paths that belong to the shipped psi application closure, excluding test-only paths and excluding non-shipped repo-local scaffolding
+- choose and name one canonical authority for that boundary, preferably the authoritative released runtime path set already used to describe psi startup, so inclusion is derived mechanically rather than by ad hoc copying rules
+- change launcher release startup to read psi’s own dependency closure from the jar-owned metadata rather than from repo/worktree dependency inference
+- preserve extension layering on top of the released psi jar basis
+- preserve a clear development path for repo-local iteration, even if it continues to use repo-local startup behavior
+- update smoke tests so they exercise the released jar startup shape, including `--tui`
+- update documentation so the release/startup model matches the new authoritative packaging story
+
+## Likely implementation surfaces
+
+This task should refine the release shape through the smallest set of authoritative surfaces rather than spreading packaging logic across unrelated areas.
+
+### 1. Build packaging surface
+
+Primary owner candidates:
+
+- `build.clj`
+- `bases/main/src/psi/build_manifest.clj`
+
+Likely responsibilities here:
+
+- derive the authoritative runtime source/resource closure for psi-owned local deps
+- derive the authoritative external dependency closure to embed as jar-owned `deps.edn`
+- copy psi-owned local dependency source/resource trees into the library jar during build
+- add proofs that the built jar contains both the expected runtime metadata and the expected packaged local code/resources
+
+Preferred rule:
+
+- build-time derivation should be mechanical from authoritative runtime inputs, not a hand-maintained second list that can drift
+
+### 2. Launcher release startup surface
+
+Primary owner candidates:
+
+- `bases/main/src/psi/launcher.clj`
+- related launcher packaging helpers under `bases/main/src/psi/launcher/`
+
+Likely responsibilities here:
+
+- distinguish release startup from repo/dev startup explicitly
+- for released startup, construct psi’s own basis from jar-owned metadata rather than repo-root `deps.edn`
+- preserve additive layering of user/project extension manifests on top of the jar-owned psi basis
+- stop treating repo/worktree local-root discovery as the authoritative source of shipped psi runtime closure
+
+Preferred rule:
+
+- release launcher code should consume artifact-owned metadata, not rebuild release truth from repository structure
+
+### 3. Smoke and packaging proof surfaces
+
+Primary owner candidates:
+
+- `bases/main/test/psi/build_jar_smoke_test.clj`
+- `bases/main/test/psi/release_packaging_smoke_test.clj`
+- `bases/main/test/psi/bbin_install_smoke_test.clj`
+- launcher-focused tests under `bases/main/test/psi/launcher*_test.clj`
+
+Likely responsibilities here:
+
+- prove the built jar contains the required psi-owned packaged namespaces/resources
+- prove the built jar exposes authoritative jar-owned `deps.edn` metadata for release startup
+- prove installed/released startup uses the jar-shaped path rather than only repo-shaped test execution
+- include `--tui` as a release smoke check so missing runtime deps or missing packaged local code fail before release
+
+Preferred rule:
+
+- at least one smoke path must exercise the artifact users actually run, not only repo-local source startup
+
+### 4. Documentation surfaces
+
+Primary owner candidates:
+
+- `README.md`
+- `doc/cli.md`
+- `doc/develop.md`
+- `doc/tui.md`
+
+Likely responsibilities here:
+
+- explain the released jar startup model clearly
+- distinguish development startup from released startup where both remain
+- document release smoke expectations, especially around `--tui`
+
+Preferred rule:
+
+- docs should name the release-authoritative startup shape directly, so future changes do not quietly drift back to repo-derived release assumptions
+
+## Out of scope
+
+- moving to an uberjar-only release shape
+- removing extension support or redesigning extension manifests broadly
+- redesigning extension conflict/override policy beyond the minimum additive layering rules needed for release startup clarity
+- redesigning the internal component/base architecture beyond what is needed to make the jar’s dependency metadata authoritative
+- removing all development-time launcher conveniences if a separate dev-only path still proves useful
+
+## Required invariants
+
+- released startup must not require the psi repo layout at runtime
+- released startup must derive psi’s own runtime dependency closure from artifact-owned metadata rather than from repo-root or worktree-local dependency discovery
+- shipped psi-owned runtime code/resources must be loaded from the published artifact rather than from repo-local `:local/root` paths
+- released startup must not silently fall back to repo-derived dependency resolution when artifact-owned metadata or packaged code is missing or malformed
+- extension manifests remain additive over the released psi basis rather than replacing psi’s own shipped dependency closure
+- the release shape must be explicit enough that missing runtime deps or missing shipped local code/resources fail at build/smoke time rather than first surfacing at end-user startup
+
+## Required target shape
+
+### Release shape
+
+The authoritative released application shape must satisfy all of the following:
+
+- the published psi jar includes authoritative dependency metadata for psi’s own runtime closure at an explicit stable path or name that the launcher can read deterministically
+- the published psi jar includes the shipped psi-owned runtime source/resource trees for local dependencies that are part of the released application closure
+- the released launcher uses that jar-owned metadata when constructing the psi runtime basis
+- the released launcher does not depend on repo/worktree component `deps.edn` discovery to determine psi’s own shipped runtime closure
+- extension manifests remain additive on top of the released psi jar basis, with psi’s own shipped basis remaining the base layer rather than becoming replaceable repo-derived state
+- implementation must make the extension overlap/precedence rule explicit when both jar-owned psi deps and extension manifests mention the same library; if that rule is not changed here, the task must preserve and document the current effective rule or explicitly defer conflict policy beyond additive non-conflicting layering
+- released startup succeeds without requiring the psi repo layout to be present at runtime
+- released `psi --tui` works from the released startup shape because required runtime deps are present in the artifact-owned basis data and the psi-owned code they support is packaged in the jar
+
+### Development shape
+
+Development may retain a separate startup path if needed, but it must be explicit that it is a development path rather than the released application shape.
+
+Acceptable examples:
+
+- repo-local `clojure -M:...` startup
+- repo-local `bb bb/psi.clj -- ...`
+- a dev launcher that resolves repo deps for iteration
+
+If a dev-only repo-aware launcher remains, it must not be the source of truth for the released psi runtime closure, and released startup must not silently drop into that repo-aware path as a fallback.
+
+## Design constraints
+
+- keep the release model jar-based rather than switching to an uberjar-only shape
+- preserve extension support
+- make the released jar’s metadata, not the repo layout, the authoritative description of psi’s own runtime closure
+- make the released jar contents, not the repo layout, the authoritative packaged source/resource set for psi-owned local dependencies
+- ensure the build fails or smoke tests fail when required runtime deps are missing from the released jar metadata path
+- ensure the build fails or smoke tests fail when required psi-owned local dependency code/resources are missing from the released jar contents
+- avoid preserving ambiguous dual authority between repo alias composition and released artifact metadata; one source must be authoritative for release
+- preserve existing user-visible capabilities unless a packaging change requires a narrow, explicit adjustment
+
+## Key design questions
+
+1. What exact `deps.edn` content must be embedded in the published jar so it fully describes psi’s shipped runtime closure?
+2. Should the jar carry the full authoritative root deps data directly, or a release-focused subset derived mechanically during build?
+3. How should `build.clj` and/or `psi.build-manifest` collect and package all psi-owned local dependency source/resource trees that belong to the shipped application, similar to the local-source collection pattern used by `projects/server-jar/build.clj` in Chat-Rama?
+4. How should `launcher.clj` locate and read jar-owned `deps.edn` metadata when constructing the psi basis?
+5. What exact additive layering model should apply between jar-owned psi deps and user/project extension manifest deps, including the intended precedence rule when both mention the same library?
+6. Which current packaging and launcher tests still prove repo-shaped startup rather than jar-shaped startup, and how should they change?
+7. How should the smoke suite prove released `--tui` startup from the installed or packaged artifact-shaped path rather than only from repo-local startup?
+8. Which smoke or packaging proof should explicitly demonstrate that released startup succeeds in an isolated install environment without the psi source repo present on disk?
+9. What dev-only repo-aware startup paths remain acceptable, and how are they kept clearly non-authoritative for release?
+
+## Explicit decisions required during implementation
+
+Implementation must make explicit and test:
+
+- the exact resource path/name for jar-owned release dependency metadata
+- the canonical authority used to derive shipped runtime source/resource inclusion
+- the precedence rule between jar-owned psi deps and extension manifest deps when both mention the same library
+- the concrete isolated-install smoke path that proves release startup works without the psi repo layout present
+
+## Acceptance
+
+1. The published psi jar contains authoritative dependency metadata for psi’s own runtime closure at a stable, named location that the released launcher reads deterministically.
+2. The published psi jar contains all shipped psi-owned runtime source/resource trees required by the released application, with the boundary excluding test-only and non-shipped repo-local paths.
+3. Released startup constructs psi’s own basis from jar-owned metadata rather than from repo/worktree dependency inference.
+4. Released startup succeeds in an isolated install/smoke environment without requiring the psi source repo layout to be present on disk.
+5. Extension manifests still layer correctly and additively on top of the released psi jar basis, with the overlap/precedence rule made explicit.
+6. Smoke tests execute the installed or packaged artifact-shaped startup path and include `--tui` startup coverage.
+7. The packaging/startup model is documented clearly enough that future work does not reintroduce repo-derived dependency inference as the release source of truth.
+8. Any remaining repo-aware startup path is explicitly documented and scoped as development-only rather than release-authoritative.

--- a/munera/open/157-jar-owned-deps-release-startup/implementation.md
+++ b/munera/open/157-jar-owned-deps-release-startup/implementation.md
@@ -1,0 +1,14 @@
+# Implementation
+
+## Release decisions
+
+- Jar-owned release dependency metadata path: `psi/release-deps.edn`
+- Canonical authority for shipped runtime source/resource inclusion: top-level `deps.edn` `:psi` alias `:extra-paths`
+- Canonical authority for release external deps: top-level root `:deps` + top-level `:psi` alias `:extra-deps` + nested external deps reachable from shipped runtime owners
+- Extension overlap/precedence rule: preserve current effective merge semantics where manifest deps layer additively over the psi base and later manifest entries can override the same library key; make that behavior explicit in tests rather than broadening this task into conflict-policy redesign
+- Isolated-install smoke proof shape: build + local install + bbin install into a temp HOME/XDG root, then exercise the installed launcher path from that isolated environment, including a TUI tmux startup path
+
+## Notes
+
+- Release startup must read `psi/release-deps.edn` from the packaged artifact and fail clearly if it is missing or malformed.
+- Release startup must not reconstruct psi’s shipped runtime closure from repo `deps.edn` when running under `:jar` policy.

--- a/munera/open/157-jar-owned-deps-release-startup/plan.md
+++ b/munera/open/157-jar-owned-deps-release-startup/plan.md
@@ -1,0 +1,55 @@
+# Plan
+
+## Approach
+
+Implement this task as a release-shape tightening slice with four ordered tracks:
+
+1. **Decide and model the release-owned metadata path**
+   - Choose the exact jar resource path/name for release dependency metadata.
+   - Choose the canonical authority for shipped runtime source/resource inclusion.
+   - Preserve a clear split between release startup and repo/dev startup.
+
+2. **Make build packaging artifact-authoritative**
+   - Update build packaging to derive the shipped psi runtime source/resource closure mechanically from the chosen authority.
+   - Package the chosen release dependency metadata into the jar at the exact stable path.
+   - Prove the built jar contains both metadata and shipped psi-owned runtime code/resources.
+
+3. **Make launcher release startup consume artifact-owned truth**
+   - Change release startup to read psi’s own basis from the jar-owned metadata path.
+   - Preserve extension manifest layering additively on top of that base.
+   - Make overlap/precedence behavior explicit and test it.
+   - Ensure release startup does not silently fall back to repo-derived dependency resolution.
+
+4. **Prove the shipped path and document it**
+   - Add or refine smoke tests so at least one installed/packaged path exercises the artifact users run.
+   - Include `--tui` in the release-shaped smoke path.
+   - Prove startup succeeds in an isolated install environment without the psi source repo present on disk.
+   - Update docs to distinguish release-authoritative startup from dev-only startup.
+
+## Key design decisions to lock during implementation
+
+1. **Jar metadata location**
+   - Pick one exact stable path/name inside the jar.
+   - Keep launcher, tests, and docs aligned to that single path.
+
+2. **Runtime inclusion authority**
+   - Prefer the authoritative released runtime path set already used to describe psi startup.
+   - Exclude test-only and non-shipped repo-local paths.
+
+3. **Extension overlap rule**
+   - Either preserve and document the current effective precedence rule or explicitly narrow this task to additive non-conflicting layering plus explicit behavior on conflict.
+
+4. **Release proof shape**
+   - At least one smoke proof must use the installed or packaged launcher path backed by the built jar, not repo-local `clojure -M` or `bb bb/psi.clj` startup.
+
+## Risks
+
+- Packaging logic may accidentally derive from multiple competing authorities and recreate drift.
+- Release startup may retain an implicit repo fallback, hiding broken artifact metadata.
+- Extension overlap behavior may remain ambiguous unless forced into a named rule.
+- TUI smoke may still pass in repo-local mode while failing in installed mode unless the artifact-shaped path is the one being exercised.
+
+## Sequencing rationale
+
+Do build authority first, then launcher consumption, then artifact-shaped proof/docs.
+That order prevents tests from proving a transitional repo-shaped implementation that the release launcher does not actually use.

--- a/munera/open/157-jar-owned-deps-release-startup/steps.md
+++ b/munera/open/157-jar-owned-deps-release-startup/steps.md
@@ -1,0 +1,47 @@
+# Steps
+
+- [ ] Lock the explicit release decisions in implementation notes before broad code movement
+  - exact stable jar path/name for release dependency metadata
+  - canonical authority for shipped runtime source/resource inclusion
+  - explicit extension overlap/precedence rule, or explicit narrow defer if conflict policy is not changing here
+  - concrete isolated-install smoke path that will prove release startup without repo layout
+
+- [ ] Update build packaging authority surfaces
+  - refine `build.clj` and/or `bases/main/src/psi/build_manifest.clj`
+  - derive shipped psi-owned runtime source/resource closure mechanically from the chosen authority
+  - package release dependency metadata into the jar at the chosen stable path
+  - package shipped psi-owned runtime source/resource trees into the jar
+  - ensure test-only and non-shipped repo-local paths are excluded
+
+- [ ] Add focused packaging proofs
+  - prove the built jar contains the chosen release metadata path
+  - prove the built jar contains representative shipped psi-owned runtime namespaces/resources
+  - prove the packaged inclusion set matches the chosen canonical runtime authority, not just a handful of representative entries
+  - prove the build-path authority matches the intended runtime inclusion boundary
+
+- [ ] Update launcher release startup
+  - make released startup read psi’s basis from the jar-owned metadata path
+  - preserve additive extension layering on top of the jar-owned base
+  - make the overlap/precedence behavior explicit and test it, either by implementing the chosen rule here or by preserving/documenting the current effective behavior with an explicit defer of broader conflict policy
+  - fail clearly rather than silently falling back to repo-derived release startup when artifact metadata is missing or malformed
+
+- [ ] Add focused launcher proofs
+  - prove release startup consumes artifact-owned metadata
+  - prove release startup is not deriving psi’s own shipped closure from repo/worktree discovery
+  - prove missing/malformed artifact metadata fails clearly
+
+- [ ] Strengthen release-shaped smoke coverage
+  - make at least one smoke path run the installed or packaged launcher path backed by the built jar
+  - include `--tui` startup in that artifact-shaped smoke path
+  - prove startup succeeds in an isolated install/smoke environment without the psi source repo present on disk
+
+- [ ] Update docs
+  - `README.md`
+  - `doc/cli.md`
+  - `doc/develop.md`
+  - `doc/tui.md`
+  - clearly distinguish release-authoritative startup from dev-only startup
+
+- [ ] Final coherence pass
+  - re-read design/plan/steps for consistency with the chosen metadata path, runtime inclusion authority, overlap rule, and smoke proof shape
+  - ensure tests, docs, and launcher/build language all use the same release model


### PR DESCRIPTION
## Summary
- package jar-owned release deps metadata at `psi/release-deps.edn`
- make jar-policy launcher startup consume artifact-owned runtime dep metadata
- prove isolated install/package startup paths, including TUI-related release packaging coverage
- make unreleased tmux TUI smoke prefer the current worktree launcher over a stale installed psi on PATH

## Testing
- `clojure -M:test --focus psi.build-manifest-test --focus psi.build-jar-smoke-test --focus psi.launcher-test --focus psi.release-packaging-smoke-test --focus psi.bbin-install-smoke-test`
- `clojure -M:test --focus psi.tui.tmux-integration-harness-test/tui-tmux-harness-basic-scenario-test --focus psi.tui.tmux-integration-harness-test/tui-tmux-startup-wrap-scenario-test --focus psi.tui.tmux-integration-harness-test/tui-tmux-delegate-live-sequence-scenario-test`
- Release workflow dry run succeeded: https://github.com/hugoduncan/psi/actions/runs/26101042218

## Task
- 157 — `jar-owned-deps-release-startup`
