### PR TITLE
Fix test session persistence garbage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Version scheme: `MAJOR.MINOR.PATCH` where PATCH = `git rev-list HEAD --count` at
 
 ## [Unreleased]
 
+### Fixed
+- Project test runs no longer leak temporary persisted session artifacts into the default `~/.psi/agent/sessions/` store; non-persistence is now explicit at shared test/runtime seams and persistence tests use isolated temporary session roots.
+
 ## [0.1.2123] - 2026-05-19
 
 ### Fixed

--- a/components/agent-session/src/psi/agent_session/context.clj
+++ b/components/agent-session/src/psi/agent_session/context.clj
@@ -234,7 +234,7 @@
    :all-mutations mutations
    :all-mutations-atom (atom mutations)})
 
-(defn- create-context* [{:keys [session-defaults compaction-fn branch-summary-fn agent-initial config cwd persist? event-queue oauth-ctx recursion-ctx nrepl-runtime-atom ui-type mutations
+(defn- create-context* [{:keys [session-defaults compaction-fn branch-summary-fn agent-initial config cwd persist? session-root event-queue oauth-ctx recursion-ctx nrepl-runtime-atom ui-type mutations
                                 create-workflow-child-session-fn execute-workflow-run-fn resume-and-execute-workflow-run-fn
                                 get-session-data-fn list-context-sessions-fn find-skill-fn
                                 resolve-workflow-step-session-config-fn materialize-workflow-step-session-conversation-fn
@@ -261,6 +261,7 @@
                      :event-queue event-queue
                      :cwd resolved-cwd
                      :persist? persist?
+                     :session-root session-root
                      :oauth-ctx oauth-ctx
                      :recursion-ctx recursion-ctx
                      :compaction-fn (or compaction-fn compaction/stub-compaction-fn)

--- a/components/agent-session/src/psi/agent_session/session_lifecycle.clj
+++ b/components/agent-session/src/psi/agent_session/session_lifecycle.clj
@@ -21,7 +21,7 @@
                            (:worktree-path (:session-defaults ctx))
                            (:cwd ctx))
         session-file   (when (:persist? ctx)
-                         (let [session-dir (journal-store/session-dir-for worktree-path)
+                         (let [session-dir (journal-store/session-dir-for (:session-root ctx) worktree-path)
                                file        (journal-store/new-session-file-path session-dir new-session-id)]
                            (str file)))]
     (dispatch/dispatch! ctx
@@ -210,7 +210,8 @@
           branch-entries      (fork-branch-entries ctx parent-session-id entry-id)
           messages            (compaction/rebuild-messages-from-journal-entries branch-entries)
           session-file        (when (:persist? ctx)
-                                (let [session-dir (journal-store/session-dir-for (session/session-worktree-path-in ctx parent-session-id))
+                                (let [session-dir (journal-store/session-dir-for (:session-root ctx)
+                                                                                 (session/session-worktree-path-in ctx parent-session-id))
                                       file        (journal-store/new-session-file-path session-dir new-session-id)]
                                   (str file)))]
       (dispatch/dispatch! ctx

--- a/components/agent-session/test/psi/agent_session/model_dispatch_test.clj
+++ b/components/agent-session/test/psi/agent_session/model_dispatch_test.clj
@@ -25,7 +25,7 @@
   ([]
    (create-session-context {}))
   ([opts]
-   (let [ctx (session/create-context (test-support/safe-context-opts opts))
+   (let [ctx (session/create-context (test-support/safe-context-opts (merge {:persist? false} opts)))
          sd  (session/new-session-in! ctx nil {})]
      [ctx (:session-id sd)])))
 

--- a/components/agent-session/test/psi/agent_session/session_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/session_lifecycle_test.clj
@@ -90,6 +90,29 @@
 
 ;; ── Session lifecycle ───────────────────────────────────────────────────────
 
+(deftest test-support-persistence-guardrails-test
+  (testing "with-temp-session-root cleans up the helper-owned temp root after the body returns"
+    (let [captured-root* (atom nil)
+          root-existed-in-body?* (atom false)]
+      (test-support/with-temp-session-root
+        (fn [session-root]
+          (reset! captured-root* session-root)
+          (reset! root-existed-in-body?* (.exists (java.io.File. session-root)))))
+      (is (true? @root-existed-in-body?*))
+      (is (string? @captured-root*))
+      (is (false? (.exists (java.io.File. @captured-root*))))))
+
+  (testing "create-test-session fails fast when persisted test use omits isolated session-root"
+    (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-create-test-session-" (java.util.UUID/randomUUID))]
+      (.mkdirs (java.io.File. cwd))
+      (try
+        (test-support/create-test-session {:cwd cwd :persist? true})
+        (is false "expected persisted create-test-session without :session-root to fail")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= "Unsafe persisted test context missing isolated :session-root" (ex-message e)))
+          (is (= true (get-in (ex-data e) [:opts :persist?])))
+          (is (nil? (get-in (ex-data e) [:opts :session-root]))))))))
+
 (deftest context-index-registry-test
   (testing "create-context starts with an empty context session index"
     (let [[ctx session-id] (create-session-context)]

--- a/components/agent-session/test/psi/agent_session/session_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/session_lifecycle_test.clj
@@ -22,7 +22,7 @@
   ([]
    (create-session-context {}))
   ([opts]
-   (let [ctx (session/create-context (test-support/safe-context-opts opts))
+   (let [ctx (session/create-context (test-support/safe-context-opts (merge {:persist? false} opts)))
          sd  (session/new-session-in! ctx nil {})]
      [ctx (:session-id sd)])))
 
@@ -108,25 +108,31 @@
       (is (contains? session-keys session-id))))
 
   (testing "ensure-session-loaded-in! resumes by context session id"
-    (let [cwd                (str (System/getProperty "java.io.tmpdir") "/psi-context-load-" (java.util.UUID/randomUUID))
-          _                  (.mkdirs (java.io.File. cwd))
-          [ctx _session-id] (create-session-context {:cwd cwd})
-          sd1                (session/new-session-in! ctx nil {})
-          sid1               (:session-id sd1)
-          path1              (:session-file sd1)
-          _                  (journal-store/flush-journal! (java.io.File. path1)
-                                                           sid1
-                                                           cwd
-                                                           nil
-                                                           nil
-                                                           [(persist/thinking-level-entry :off)])
-          sd2                (session/new-session-in! (retarget ctx sd1) sid1 {})
-          sid2               (:session-id sd2)
-          sd1*               (session/ensure-session-loaded-in! (retarget ctx sd2) sid2 sid1)
-          ctx                (retarget ctx sd1*)]
-      (is (not= sid1 sid2))
-      (is (= sid1 (:session-id (ss/get-session-data-in ctx sid1))))
-      (is (= sid1 (:session-id (ss/get-session-data-in ctx sid1))))))
+    (test-support/with-temp-session-root
+      (fn [session-root]
+        (let [cwd                (str (System/getProperty "java.io.tmpdir") "/psi-context-load-" (java.util.UUID/randomUUID))
+              _                  (.mkdirs (java.io.File. cwd))
+              [ctx _session-id] (let [ctx (session/create-context (test-support/safe-context-opts {:cwd cwd
+                                                                                                   :persist? true
+                                                                                                   :session-root session-root}))
+                                      sd  (session/new-session-in! ctx nil {})]
+                                  [ctx (:session-id sd)])
+              sd1                (session/new-session-in! ctx nil {})
+              sid1               (:session-id sd1)
+              path1              (:session-file sd1)
+              _                  (journal-store/flush-journal! (java.io.File. path1)
+                                                               sid1
+                                                               cwd
+                                                               nil
+                                                               nil
+                                                               [(persist/thinking-level-entry :off)])
+              sd2                (session/new-session-in! (retarget ctx sd1) sid1 {})
+              sid2               (:session-id sd2)
+              sd1*               (session/ensure-session-loaded-in! (retarget ctx sd2) sid2 sid1)
+              ctx                (retarget ctx sd1*)]
+          (is (not= sid1 sid2))
+          (is (= sid1 (:session-id (ss/get-session-data-in ctx sid1))))
+          (is (= sid1 (:session-id (ss/get-session-data-in ctx sid1))))))))
 
   (testing "explicit session-id selects the parent when creating another session"
     (let [[ctx session-id] (create-session-context)
@@ -272,35 +278,42 @@
       (is (nil? (:error agent-data))))))
 
 (deftest fork-session-persists-child-file-with-parent-lineage-test
-  (let [cwd                (str (System/getProperty "java.io.tmpdir") "/psi-fork-" (java.util.UUID/randomUUID))
-        _                  (.mkdirs (java.io.File. cwd))
-        [ctx _session-id] (create-session-context {:cwd cwd})
-        parent-sd          (session/new-session-in! ctx nil {})
-        parent-id          (:session-id parent-sd)
-        ctx                (retarget ctx parent-sd)
-        parent-file        (:session-file parent-sd)
-        entry-id           (:id (ss/append-journal-entry-in! ctx parent-id (persist/message-entry {:role "user"
-                                                                                                   :content [{:type :text :text "branch-here"}]
-                                                                                                   :timestamp (java.time.Instant/now)})))
-        _                  (ss/append-journal-entry-in! ctx parent-id (persist/message-entry {:role "assistant"
-                                                                                              :content [{:type :text :text "reply-here"}]
-                                                                                              :timestamp (java.time.Instant/now)}))
-        child-sd           (session/fork-session-in! ctx parent-id entry-id)
-        child-id           (:session-id child-sd)
-        ctx                (retarget ctx child-sd)
-        child-sd           (ss/get-session-data-in ctx child-id)
-        child-file         (:session-file child-sd)
-        loaded-child       (journal-store/load-session-file child-file)]
-    (is (string? child-file))
-    (is (.exists (java.io.File. child-file)))
-    (is (= parent-file (get-in loaded-child [:header :parent-session])))
-    (is (= parent-id (get-in loaded-child [:header :parent-session-id])))
-    (is (= child-id (get-in loaded-child [:header :id])))
-    (is (= (count (persist/all-entries-in ctx child-id)) (count (:entries loaded-child))))
-    (is (= ["user" "assistant"]
-           (->> (:entries loaded-child)
-                (filter #(= :message (:kind %)))
-                (mapv #(get-in % [:data :message :role])))))))
+  (test-support/with-temp-session-root
+    (fn [session-root]
+      (let [cwd                (str (System/getProperty "java.io.tmpdir") "/psi-fork-" (java.util.UUID/randomUUID))
+            _                  (.mkdirs (java.io.File. cwd))
+            [ctx _session-id] (let [ctx (session/create-context (test-support/safe-context-opts {:cwd cwd
+                                                                                                 :persist? true
+                                                                                                 :session-root session-root}))
+                                    sd  (session/new-session-in! ctx nil {})]
+                                [ctx (:session-id sd)])
+            parent-sd          (session/new-session-in! ctx nil {})
+            parent-id          (:session-id parent-sd)
+            ctx                (retarget ctx parent-sd)
+            parent-file        (:session-file parent-sd)
+            entry-id           (:id (ss/append-journal-entry-in! ctx parent-id (persist/message-entry {:role "user"
+                                                                                                       :content [{:type :text :text "branch-here"}]
+                                                                                                       :timestamp (java.time.Instant/now)})))
+            _                  (ss/append-journal-entry-in! ctx parent-id (persist/message-entry {:role "assistant"
+                                                                                                  :content [{:type :text :text "reply-here"}]
+                                                                                                  :timestamp (java.time.Instant/now)}))
+            child-sd           (session/fork-session-in! ctx parent-id entry-id)
+            child-id           (:session-id child-sd)
+            ctx                (retarget ctx child-sd)
+            child-sd           (ss/get-session-data-in ctx child-id)
+            child-file         (:session-file child-sd)
+            loaded-child       (journal-store/load-session-file child-file)]
+        (is (string? child-file))
+        (is (.exists (java.io.File. child-file)))
+        (is (.startsWith child-file session-root))
+        (is (= parent-file (get-in loaded-child [:header :parent-session])))
+        (is (= parent-id (get-in loaded-child [:header :parent-session-id])))
+        (is (= child-id (get-in loaded-child [:header :id])))
+        (is (= (count (persist/all-entries-in ctx child-id)) (count (:entries loaded-child))))
+        (is (= ["user" "assistant"]
+               (->> (:entries loaded-child)
+                    (filter #(= :message (:kind %)))
+                    (mapv #(get-in % [:data :message :role])))))))))
 
 (deftest fork-session-includes-selected-user-reply-turn-test
   (let [[ctx _session-id] (test-support/make-session-ctx {})

--- a/components/agent-session/test/psi/agent_session/session_lifecycle_test.clj
+++ b/components/agent-session/test/psi/agent_session/session_lifecycle_test.clj
@@ -90,28 +90,27 @@
 
 ;; ── Session lifecycle ───────────────────────────────────────────────────────
 
-(deftest test-support-persistence-guardrails-test
-  (testing "with-temp-session-root cleans up the helper-owned temp root after the body returns"
-    (let [captured-root* (atom nil)
-          root-existed-in-body?* (atom false)]
-      (test-support/with-temp-session-root
-        (fn [session-root]
-          (reset! captured-root* session-root)
-          (reset! root-existed-in-body?* (.exists (java.io.File. session-root)))))
-      (is (true? @root-existed-in-body?*))
-      (is (string? @captured-root*))
-      (is (false? (.exists (java.io.File. @captured-root*))))))
+(deftest with-temp-session-root-cleans-up-after-body-test
+  (let [root* (atom nil)
+        existed-during-body?* (atom false)]
+    (test-support/with-temp-session-root
+      (fn [session-root]
+        (reset! root* session-root)
+        (reset! existed-during-body?* (.exists (java.io.File. session-root)))))
+    (is (true? @existed-during-body?*))
+    (is (string? @root*))
+    (is (false? (.exists (java.io.File. @root*))))))
 
-  (testing "create-test-session fails fast when persisted test use omits isolated session-root"
-    (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-create-test-session-" (java.util.UUID/randomUUID))]
-      (.mkdirs (java.io.File. cwd))
-      (try
-        (test-support/create-test-session {:cwd cwd :persist? true})
-        (is false "expected persisted create-test-session without :session-root to fail")
-        (catch clojure.lang.ExceptionInfo e
-          (is (= "Unsafe persisted test context missing isolated :session-root" (ex-message e)))
-          (is (= true (get-in (ex-data e) [:opts :persist?])))
-          (is (nil? (get-in (ex-data e) [:opts :session-root]))))))))
+(deftest create-test-session-persisting-without-session-root-fails-fast-test
+  (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-create-test-session-" (java.util.UUID/randomUUID))]
+    (.mkdirs (java.io.File. cwd))
+    (try
+      (test-support/create-test-session {:cwd cwd :persist? true})
+      (is false "expected persisted create-test-session without :session-root to fail")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "Unsafe persisted test context missing isolated :session-root" (ex-message e)))
+        (is (= true (get-in (ex-data e) [:opts :persist?])))
+        (is (nil? (get-in (ex-data e) [:opts :session-root])))))))
 
 (deftest context-index-registry-test
   (testing "create-context starts with an empty context session index"

--- a/components/agent-session/test/psi/agent_session/test_support.clj
+++ b/components/agent-session/test/psi/agent_session/test_support.clj
@@ -44,18 +44,53 @@
     (.mkdirs (java.io.File. p))
     p))
 
+(defn temp-session-root []
+  (let [p (str (java.nio.file.Files/createTempDirectory
+                "psi-agent-session-store-"
+                (make-array java.nio.file.attribute.FileAttribute 0)))]
+    (.mkdirs (java.io.File. p))
+    p))
+
+(defn delete-recursively!
+  [path]
+  (let [f (java.io.File. (str path))]
+    (when (.exists f)
+      (doseq [child (reverse (file-seq f))]
+        (.delete ^java.io.File child)))))
+
+(defn with-temp-session-root
+  "Run f with a test-owned temporary session root. Cleans it up in finally.
+   Passes the root path string to f."
+  [f]
+  (let [root (temp-session-root)]
+    (try
+      (f root)
+      (finally
+        (delete-recursively! root)))))
+
 (defn safe-context-opts
   "Merge test-safe defaults into session/create-context opts and fail fast if
    the resolved cwd targets the repo root/user.dir. Tests may override :cwd,
-   but never to the process cwd."
+   but never to the process cwd.
+
+   When persistence is enabled, tests must also provide an explicit isolated
+   :session-root rather than falling through to the real default user-home
+   session store."
   [opts]
-  (let [opts*         (merge {:cwd (temp-cwd)} opts)
+  (let [opts*         (merge {:cwd (temp-cwd)
+                              :persist? false}
+                             opts)
         cwd-path      (.getCanonicalPath (java.io.File. (str (:cwd opts*))))
         user-dir-path (.getCanonicalPath (java.io.File. (System/getProperty "user.dir")))]
     (when (= cwd-path user-dir-path)
       (throw (ex-info "Unsafe test context cwd resolves to process user.dir"
                       {:cwd cwd-path
                        :user-dir user-dir-path
+                       :opts opts*})))
+    (when (and (not= false (:persist? opts*))
+               (nil? (:session-root opts*)))
+      (throw (ex-info "Unsafe persisted test context missing isolated :session-root"
+                      {:cwd cwd-path
                        :opts opts*})))
     opts*))
 
@@ -236,19 +271,10 @@
    Accepts the same options as `session/create-context`. The :session-defaults
    overrides flow through into the first real session.
 
-   Guard: when persistence is enabled, tests must not target process user.dir."
+   Guard: persisted tests must use `safe-context-opts` so they provide an
+   isolated :session-root rather than the real default user-home store."
   ([] (create-test-session {:persist? false}))
   ([opts]
-   (let [persist? (not= false (:persist? opts))
-         _        (when persist?
-                    (let [cwd-path      (.getCanonicalPath (java.io.File. (str (or (:cwd opts)
-                                                                                   (System/getProperty "user.dir")))))
-                          user-dir-path (.getCanonicalPath (java.io.File. (System/getProperty "user.dir")))]
-                      (when (= cwd-path user-dir-path)
-                        (throw (ex-info "Unsafe persisted test context cwd resolves to process user.dir"
-                                        {:cwd cwd-path
-                                         :user-dir user-dir-path
-                                         :opts opts})))))
-         ctx      (session-core/create-context opts)
-         sd       (session-core/new-session-in! ctx nil {})]
+   (let [ctx (session-core/create-context opts)
+         sd  (session-core/new-session-in! ctx nil {})]
      [ctx (:session-id sd)])))

--- a/components/agent-session/test/psi/agent_session/test_support.clj
+++ b/components/agent-session/test/psi/agent_session/test_support.clj
@@ -271,10 +271,10 @@
    Accepts the same options as `session/create-context`. The :session-defaults
    overrides flow through into the first real session.
 
-   Guard: persisted tests must use `safe-context-opts` so they provide an
-   isolated :session-root rather than the real default user-home store."
+   Persisted test usage is guardrailed here via `safe-context-opts`, so tests
+   cannot silently fall through to the real default user-home session store."
   ([] (create-test-session {:persist? false}))
   ([opts]
-   (let [ctx (session-core/create-context opts)
+   (let [ctx (session-core/create-context (safe-context-opts opts))
          sd  (session-core/new-session-in! ctx nil {})]
      [ctx (:session-id sd)])))

--- a/components/agent-session/test/psi/agent_session/test_support.clj
+++ b/components/agent-session/test/psi/agent_session/test_support.clj
@@ -73,6 +73,9 @@
    the resolved cwd targets the repo root/user.dir. Tests may override :cwd,
    but never to the process cwd.
 
+   This is the authoritative persisted-test guardrail seam shared by test
+   context helpers.
+
    When persistence is enabled, tests must also provide an explicit isolated
    :session-root rather than falling through to the real default user-home
    session store."

--- a/components/agent-session/test/psi/agent_session/workflow_reload_runtime_test.clj
+++ b/components/agent-session/test/psi/agent_session/workflow_reload_runtime_test.clj
@@ -21,7 +21,7 @@
   ([opts]
    (test-support/create-test-session
     (merge {:persist? false
-            :cwd (System/getProperty "user.dir")
+            :session-defaults {:worktree-path (System/getProperty "user.dir")}
             :mutations mutations/all-mutations}
            opts))))
 

--- a/components/app-runtime/src/psi/app_runtime.clj
+++ b/components/app-runtime/src/psi/app_runtime.clj
@@ -275,8 +275,10 @@ Available: " (str/join ", " (map name (keys all))))
    - :session-config optional session config overrides (merged with defaults)
    - :cwd optional cwd override (primarily for tests)
    - :ui-type runtime UI type hint (:console | :tui | :emacs)
-   - :thinking-level-override explicit thinking level (CLI/env); overrides config when set"
-  [ai-model {:keys [event-queue session-config cwd ui-type thinking-level-override]}]
+   - :thinking-level-override explicit thinking level (CLI/env); overrides config when set
+   - :persist? optional persistence toggle (defaults true; primarily for tests)
+   - :session-root optional explicit persisted session root (primarily for tests)"
+  [ai-model {:keys [event-queue session-config cwd ui-type thinking-level-override persist? session-root]}]
   (let [cwd                      (or cwd (System/getProperty "user.dir"))
         ;; Initialize model registry with user-global + project-local custom models
         _                        (model-registry/init!
@@ -305,6 +307,8 @@ Available: " (str/join ", " (map name (keys all))))
                                  :event-queue event-queue
                                  :oauth-ctx oauth-ctx
                                  :nrepl-runtime-atom nrepl-runtime
+                                 :persist? (if (some? persist?) persist? true)
+                                 :session-root session-root
                                  :ui-type ui-type
                                  :mutations mutations/all-mutations})
         recursion-ctx            (recursion/create-hosted-context ctx (ss/state-path :recursion))
@@ -446,6 +450,7 @@ Available: " (str/join ", " (map name (keys all))))
          {:keys [ctx oauth-ctx session-id]}
          (create-runtime-session-context ai-model {:session-config          session-config
                                                    :ui-type                 :console
+                                                   :persist?                false
                                                    :thinking-level-override (:thinking-level-override startup-opts)})
          {:keys [templates skills startup-rehydrate]}
          (bootstrap-runtime-session! ctx session-id ai-model {:memory-runtime-opts memory-runtime-opts})
@@ -487,6 +492,7 @@ Available: " (str/join ", " (map name (keys all))))
          (create-runtime-session-context ai-model {:event-queue             event-queue
                                                    :session-config          session-config
                                                    :ui-type                 :tui
+                                                   :persist?                false
                                                    :thinking-level-override (:thinking-level-override startup-opts)})
          nullable-execution-mode (some-> (System/getenv "PSI_NULLABLE_EXECUTION_MODE") str/trim not-empty)
          ctx (if (= "deterministic" nullable-execution-mode)

--- a/components/app-runtime/src/psi/app_runtime.clj
+++ b/components/app-runtime/src/psi/app_runtime.clj
@@ -335,7 +335,9 @@ Available: " (str/join ", " (map name (keys all))))
 
    Options:
    - :memory-runtime-opts optional memory/runtime sync opts
-   - :cwd optional cwd override (primarily for tests)"
+   - :cwd optional cwd override (primarily for tests)
+   - :persist? optional persistence toggle (primarily for tests)
+   - :session-root optional explicit persisted session root (primarily for tests)"
   ([x y]
    (if (:state* x)
      (bootstrap-runtime-session! x nil y {})
@@ -343,7 +345,9 @@ Available: " (str/join ", " (map name (keys all))))
            opts     y
            {:keys [ctx oauth-ctx cwd session-id]} (create-runtime-session-context ai-model {:cwd (:cwd opts)
                                                                                             :session-config (:session-config opts)
-                                                                                            :ui-type (or (:ui-type opts) :console)})
+                                                                                            :ui-type (or (:ui-type opts) :console)
+                                                                                            :persist? (:persist? opts)
+                                                                                            :session-root (:session-root opts)})
            result (bootstrap-runtime-session! ctx session-id ai-model opts)]
        (assoc result :ctx ctx :oauth-ctx oauth-ctx :cwd cwd :session-id session-id))))
   ([ctx session-id ai-model {:keys [memory-runtime-opts cwd]}]

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -746,32 +746,16 @@
 (deftest bootstrap-runtime-session-intentional-persisting-test-root-is-forwarded-test
   (test-support/with-temp-session-root
     (fn [session-root]
-      (with-redefs [oauth/create-context (fn [] nil)
-                    pt/discover-templates (fn [] [])
-                    skills/discover-skills (fn [] {:skills [] :diagnostics []})
-                    sys-prompt/discover-context-files (fn [_] [])
-                    sys-prompt/build-system-prompt (fn [_] "")
-                    ext/discover-extension-paths (fn [& _] [])
-                    introspection/register-resolvers! (fn [] nil)
-                    memory-runtime/sync-memory-layer! (fn [_] {:ok? true})
-                    bootstrap/bootstrap-in!
-                    (fn [_ctx _session-id _]
-                      {:extension-errors [] :extension-loaded-count 0})]
-        (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-bootstrap-persisting-" (java.util.UUID/randomUUID))
-              _   (.mkdirs (java.io.File. cwd))
-              {:keys [ctx]} (#'app-runtime/bootstrap-runtime-session!
-                             {:provider :anthropic
-                              :id "test-model"
-                              :name "Test Model"
-                              :supports-reasoning false}
-                             {:cwd cwd
-                              :persist? true
-                              :session-root session-root})
-              session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
-              sd         (ss/get-session-data-in ctx session-id)
-              session-file (:session-file sd)]
-          (is (string? session-file))
-          (is (.startsWith session-file session-root)))))))
+      (with-main-bootstrap-stubs
+        (fn []
+          (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-bootstrap-persisting-" (java.util.UUID/randomUUID))
+                _   (.mkdirs (java.io.File. cwd))
+                {:keys [ctx]} (#'app-runtime/bootstrap-runtime-session!
+                               {:provider :anthropic :id "test-model" :name "Test Model" :supports-reasoning false}
+                               {:cwd cwd :persist? true :session-root session-root})
+                session-file (some-> (ss/list-context-sessions-in ctx) first :session-id (ss/get-session-data-in ctx) :session-file)]
+            (is (string? session-file))
+            (is (.startsWith session-file session-root))))))))
 
 (deftest bootstrap-runtime-session-invalid-project-model-falls-back-test
   (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-main-project-prefs-" (java.util.UUID/randomUUID))

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -86,7 +86,8 @@
                                        :name               "Test Model"
                                        :supports-reasoning false
                                        :context-window     200000}
-                                      {:ui-type :emacs})
+                                      {:ui-type :emacs
+                                       :persist? false})
             sessions (ss/list-context-sessions-in ctx)]
         (is (= 1 (count sessions)))
         (is (= session-id (:session-id (first sessions))))))))
@@ -102,7 +103,8 @@
                                            :name               "Test Model"
                                            :supports-reasoning false
                                            :context-window     200000}
-                                          {:ui-type :tui})
+                                          {:ui-type :tui
+                                           :persist? false})
                 reg                    (:extension-registry ctx)
                 ext-path               "/ext/which-session"
                 runtime-fns*           (runtime-fns/make-extension-runtime-fns ctx session-id ext-path)
@@ -539,7 +541,7 @@
                           :id "test-model"
                           :name "Test Model"
                           :supports-reasoning false}
-                         {})
+                         {:persist? false})
           session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
           sd         (ss/get-session-data-in ctx session-id)
           sessions   (ss/get-sessions-map-in ctx)]
@@ -567,7 +569,8 @@
                             :id "test-model"
                             :name "Test Model"
                             :supports-reasoning false}
-                           {:memory-runtime-opts {:store-provider "in-memory"
+                           {:persist? false
+                            :memory-runtime-opts {:store-provider "in-memory"
                                                   :retention-snapshots 22
                                                   :retention-deltas 44}
                             :session-config {:llm-stream-idle-timeout-ms 54321}})]
@@ -593,7 +596,7 @@
                           :id "test-model"
                           :name "Test Model"
                           :supports-reasoning false}
-                         {})
+                         {:persist? false})
           sid    (-> (ss/list-context-sessions-in ctx) first :session-id)
           prompt (:psi.agent-session/system-prompt
                   (session/query-in ctx sid [:psi.agent-session/system-prompt]))]
@@ -623,7 +626,7 @@
                               :id "test-model"
                               :name "Test Model"
                               :supports-reasoning false}
-                             {})
+                             {:persist? false})
               result (session/query-in ctx [:psi.runtime/nrepl-host
                                             :psi.runtime/nrepl-port
                                             :psi.runtime/nrepl-endpoint])]
@@ -731,7 +734,8 @@
                             :id "claude-sonnet-4-6"
                             :name "Claude Sonnet 4.6"
                             :supports-reasoning true}
-                           {:cwd cwd})
+                           {:cwd cwd
+                            :persist? false})
             session-id      (-> (ss/list-context-sessions-in ctx) first :session-id)
             sd              (ss/get-session-data-in ctx session-id)]
         (is (= "openai" (get-in sd [:model :provider])))
@@ -762,9 +766,46 @@
                             :id "claude-sonnet-4-6"
                             :name "Claude Sonnet 4.6"
                             :supports-reasoning false}
-                           {:cwd cwd})
+                           {:cwd cwd
+                            :persist? false})
             session-id      (-> (ss/list-context-sessions-in ctx) first :session-id)
             sd              (ss/get-session-data-in ctx session-id)]
         (is (= "anthropic" (get-in sd [:model :provider])))
         (is (= "claude-sonnet-4-6" (get-in sd [:model :id])))
         (is (= :off (:thinking-level sd)))))))
+
+(deftest create-runtime-session-context-test-use-is-explicitly-non-persisting-test
+  (with-main-bootstrap-stubs
+    (fn []
+      (let [{:keys [ctx session-id]} (app-runtime/create-runtime-session-context
+                                      {:provider :anthropic
+                                       :id "test-model"
+                                       :name "Test Model"
+                                       :supports-reasoning false
+                                       :context-window 200000}
+                                      {:ui-type :console
+                                       :persist? false})
+            sd (ss/get-session-data-in ctx session-id)]
+        (is (nil? (:session-file sd)))))))
+
+(deftest bootstrap-runtime-session-test-use-is-explicitly-non-persisting-test
+  (with-redefs [oauth/create-context (fn [] nil)
+                pt/discover-templates (fn [] [])
+                skills/discover-skills (fn [] {:skills [] :diagnostics []})
+                sys-prompt/discover-context-files (fn [_] [])
+                sys-prompt/build-system-prompt (fn [_] "")
+                ext/discover-extension-paths (fn [& _] [])
+                introspection/register-resolvers! (fn [] nil)
+                memory-runtime/sync-memory-layer! (fn [_] {:ok? true})
+                bootstrap/bootstrap-in!
+                (fn [_ctx _session-id _]
+                  {:extension-errors [] :extension-loaded-count 0})]
+    (let [{:keys [ctx]} (#'app-runtime/bootstrap-runtime-session!
+                         {:provider :anthropic
+                          :id "test-model"
+                          :name "Test Model"
+                          :supports-reasoning false}
+                         {:persist? false})
+          session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
+          sd         (ss/get-session-data-in ctx session-id)]
+      (is (nil? (:session-file sd))))))

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -152,7 +152,7 @@
       (finally
         (reset! app-runtime/session-state orig-state)))))
 
-(deftest run-session-initializes-session-file-test
+(deftest run-session-starts-non-persisting-console-session-test
   (let [orig-state @app-runtime/session-state]
     (try
       (with-main-bootstrap-stubs
@@ -167,7 +167,7 @@
                   session-id (-> @app-runtime/session-state :ctx ss/list-context-sessions-in first :session-id)
                   sd         (ss/get-session-data-in ctx session-id)]
               (is (some? ctx))
-              (is (string? (:session-file sd)))
+              (is (nil? (:session-file sd)))
               (is (= :console (:ui-type sd)))))))
       (finally
         (reset! app-runtime/session-state orig-state)))))
@@ -205,7 +205,7 @@
                                   (reset! captured opts)
                                   :ok)]
             (is (= :ok (app-runtime/start-tui-runtime! mock-tui-start! :ignored {} {})))
-            (is (string? (:current-session-file @captured)))
+            (is (nil? (:current-session-file @captured)))
             (is (fn? (:dispatch-fn @captured)))
             (is (fn? (:on-interrupt-fn! @captured)))
             (let [ctx (:ctx @app-runtime/session-state)

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -14,6 +14,7 @@
    [psi.session-persistence.core :as persist]
    [psi.turn-runtime.core :as turn-runtime]
    [psi.agent-session.runtime :as runtime]
+   [psi.agent-session.test-support :as test-support]
    [psi.provider-auth.oauth.core :as oauth]
    [psi.prompt-assets.prompt-templates :as pt]
    [psi.shared-config.project :as project-prefs]
@@ -741,6 +742,36 @@
         (is (= "openai" (get-in sd [:model :provider])))
         (is (= "gpt-5.3-codex" (get-in sd [:model :id])))
         (is (= :high (:thinking-level sd)))))))
+
+(deftest bootstrap-runtime-session-intentional-persisting-test-root-is-forwarded-test
+  (test-support/with-temp-session-root
+    (fn [session-root]
+      (with-redefs [oauth/create-context (fn [] nil)
+                    pt/discover-templates (fn [] [])
+                    skills/discover-skills (fn [] {:skills [] :diagnostics []})
+                    sys-prompt/discover-context-files (fn [_] [])
+                    sys-prompt/build-system-prompt (fn [_] "")
+                    ext/discover-extension-paths (fn [& _] [])
+                    introspection/register-resolvers! (fn [] nil)
+                    memory-runtime/sync-memory-layer! (fn [_] {:ok? true})
+                    bootstrap/bootstrap-in!
+                    (fn [_ctx _session-id _]
+                      {:extension-errors [] :extension-loaded-count 0})]
+        (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-bootstrap-persisting-" (java.util.UUID/randomUUID))
+              _   (.mkdirs (java.io.File. cwd))
+              {:keys [ctx]} (#'app-runtime/bootstrap-runtime-session!
+                             {:provider :anthropic
+                              :id "test-model"
+                              :name "Test Model"
+                              :supports-reasoning false}
+                             {:cwd cwd
+                              :persist? true
+                              :session-root session-root})
+              session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
+              sd         (ss/get-session-data-in ctx session-id)
+              session-file (:session-file sd)]
+          (is (string? session-file))
+          (is (.startsWith session-file session-root)))))))
 
 (deftest bootstrap-runtime-session-invalid-project-model-falls-back-test
   (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-main-project-prefs-" (java.util.UUID/randomUUID))

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -774,38 +774,4 @@
         (is (= "claude-sonnet-4-6" (get-in sd [:model :id])))
         (is (= :off (:thinking-level sd)))))))
 
-(deftest create-runtime-session-context-test-use-is-explicitly-non-persisting-test
-  (with-main-bootstrap-stubs
-    (fn []
-      (let [{:keys [ctx session-id]} (app-runtime/create-runtime-session-context
-                                      {:provider :anthropic
-                                       :id "test-model"
-                                       :name "Test Model"
-                                       :supports-reasoning false
-                                       :context-window 200000}
-                                      {:ui-type :console
-                                       :persist? false})
-            sd (ss/get-session-data-in ctx session-id)]
-        (is (nil? (:session-file sd)))))))
 
-(deftest bootstrap-runtime-session-test-use-is-explicitly-non-persisting-test
-  (with-redefs [oauth/create-context (fn [] nil)
-                pt/discover-templates (fn [] [])
-                skills/discover-skills (fn [] {:skills [] :diagnostics []})
-                sys-prompt/discover-context-files (fn [_] [])
-                sys-prompt/build-system-prompt (fn [_] "")
-                ext/discover-extension-paths (fn [& _] [])
-                introspection/register-resolvers! (fn [] nil)
-                memory-runtime/sync-memory-layer! (fn [_] {:ok? true})
-                bootstrap/bootstrap-in!
-                (fn [_ctx _session-id _]
-                  {:extension-errors [] :extension-loaded-count 0})]
-    (let [{:keys [ctx]} (#'app-runtime/bootstrap-runtime-session!
-                         {:provider :anthropic
-                          :id "test-model"
-                          :name "Test Model"
-                          :supports-reasoning false}
-                         {:persist? false})
-          session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
-          sd         (ss/get-session-data-in ctx session-id)]
-      (is (nil? (:session-file sd))))))

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -307,6 +307,7 @@
                            :execution-result/stop-reason :stop})]
             (app-runtime/run-session :ignored)
             (let [ctx (:ctx @app-runtime/session-state)
+                  sync-calls-before (count @sync-calls)
                   session-id (-> @app-runtime/session-state
                                  :ctx
                                  ss/list-context-sessions-in
@@ -319,7 +320,7 @@
                "hello"
                nil
                {:sync-on-git-head-change? true})
-              (is (= [session-id] @sync-calls)
+              (is (= [session-id] (subvec (vec @sync-calls) sync-calls-before))
                   "submit-prompt-in! runs git-head sync once after a successful prompt turn")))))
       (finally
         (reset! app-runtime/session-state orig-state)))))

--- a/components/app-runtime/test/psi/app_runtime_test.clj
+++ b/components/app-runtime/test/psi/app_runtime_test.clj
@@ -753,9 +753,13 @@
                 {:keys [ctx]} (#'app-runtime/bootstrap-runtime-session!
                                {:provider :anthropic :id "test-model" :name "Test Model" :supports-reasoning false}
                                {:cwd cwd :persist? true :session-root session-root})
-                session-file (some-> (ss/list-context-sessions-in ctx) first :session-id (ss/get-session-data-in ctx) :session-file)]
-            (is (string? session-file))
-            (is (.startsWith session-file session-root))))))))
+                session-id   (-> (ss/list-context-sessions-in ctx) first :session-id)
+                session-file (:session-file (ss/get-session-data-in ctx session-id))]
+            (is (string? session-file) "intentional persisted bootstrap should allocate a session file")
+            (is (.startsWith session-file session-root)
+                (str "expected persisted bootstrap session-file under isolated session-root\n"
+                     "session-root: " session-root "\n"
+                     "session-file: " session-file))))))))
 
 (deftest bootstrap-runtime-session-invalid-project-model-falls-back-test
   (let [cwd (str (System/getProperty "java.io.tmpdir") "/psi-main-project-prefs-" (java.util.UUID/randomUUID))

--- a/components/rpc/test/psi/rpc_real_delegate_command_test.clj
+++ b/components/rpc/test/psi/rpc_real_delegate_command_test.clj
@@ -4,6 +4,7 @@
    [psi.app-runtime :as app]
    [psi.agent-session.context :as context]
    [psi.app-runtime.messages :as app-messages]
+   [psi.session-state.state :as ss]
    [psi.rpc :as rpc]
    [psi.rpc-test-support :as support]))
 
@@ -13,7 +14,8 @@
   ([execute-prepared-request-fn]
    (let [ai-model (app/resolve-model :gpt-5.4)
          {:keys [ctx session-id cwd]} (app/create-runtime-session-context ai-model {:event-queue (java.util.concurrent.LinkedBlockingQueue.)
-                                                                                    :ui-type :rpc})
+                                                                                    :ui-type :rpc
+                                                                                    :persist? false})
          ctx (cond-> ctx
                execute-prepared-request-fn (assoc :execute-prepared-request-fn execute-prepared-request-fn))]
      (app/bootstrap-runtime-session! ctx session-id ai-model {:memory-runtime-opts {} :cwd cwd})
@@ -166,4 +168,12 @@
           (future-cancel loop-future)
           (try (.close in-writer) (catch Exception _ nil))
           (try (.close in-reader) (catch Exception _ nil))
+          (context/shutdown-context! ctx))))))
+
+(deftest create-runtime-like-context-test-use-is-explicitly-non-persisting-test
+  (testing "rpc runtime-like test context does not allocate a persisted session file"
+    (let [[ctx session-id] (create-runtime-like-context)]
+      (try
+        (is (nil? (:session-file (ss/get-session-data-in ctx session-id))))
+        (finally
           (context/shutdown-context! ctx))))))

--- a/munera/open/158-test-persistence-session-garbage/design.md
+++ b/munera/open/158-test-persistence-session-garbage/design.md
@@ -1,0 +1,132 @@
+# Task 158 — Test persistence session garbage
+
+## Intent
+Stop automated tests from writing persisted session artifacts for temporary test worktrees into the user session store under `~/.psi/agent/sessions/`, especially directories derived from macOS temporary paths such as `--var-folders-*` and `--private-var-folders-*`.
+
+## Context
+Persisted session directories are keyed by encoded worktree path. The session journal store currently derives directory names from the session worktree path by replacing path separators with `-`, so a temporary test worktree like `/var/folders/...` becomes a persisted directory under `~/.psi/agent/sessions/--var-folders-...--`.
+
+This is correct for normal runtime behavior, but some tests still create real runtime or session contexts with temporary working directories while persistence remains enabled. Those tests unintentionally write session files into the developer’s real home-directory session store and leave local garbage behind.
+
+The system already has a `:persist? false` seam used by many test helpers. In particular:
+- `psi.agent-session.test-support/create-test-session` already defaults to `:persist? false`
+- many session-focused tests already route through safe helpers with temp cwd + persistence disabled
+- at least some runtime/bootstrap-oriented tests still bypass that discipline and call real runtime bootstrap with temp `:cwd` while leaving persistence enabled
+
+A likely current leak path is the app-runtime startup/bootstrap test seam, where helper code creates a real runtime session against a temp cwd in order to prove startup behavior but does not make non-persistence explicit.
+
+There is a second requirement for tests that *do* intentionally prove persistence behavior: they must not use the real default session root either. Explicit persistence tests should isolate their session storage under a test-owned temporary session root and clean that root up when the test completes, so persistence coverage remains real without leaking artifacts into the developer environment.
+
+## Definitions
+
+### Explicit persistence test
+An explicit persistence test is a test whose assertions require real on-disk session journal or session-file behavior.
+
+Examples include tests whose proof depends on one or more of:
+- creation of real session files on disk
+- journal append/flush behavior on disk
+- loading or resuming from a real persisted session file
+- fork behavior that depends on persisted parent/child session-file relationships
+
+A test is **not** an explicit persistence test merely because the runtime happens to create a session, or because a `:session-file` field exists in state, if the test’s actual acceptance does not depend on real on-disk persistence behavior.
+
+### Temporary session root
+A temporary session root is a test-owned filesystem root used in place of the default home-derived session storage location. It is the canonical isolation mechanism for tests that intentionally require persistence.
+
+### Real default session store
+The real default session store is the default home-derived session root used by normal runtime behavior, currently the location under the current `user.home` that resolves to `~/.psi/agent/sessions/` when no explicit test-owned override is configured.
+
+### Guardrail rule
+No test may persist into the real default session store.
+
+If a test does not require real on-disk persistence behavior, it must run with persistence disabled.
+
+If a test does require real on-disk persistence behavior, it must provide an explicit isolated temporary session root rather than falling through to the real default session store.
+
+## Problem statement
+The project needs a clear test-time rule:
+- tests proving persistence behavior may opt into persistence explicitly
+- all other tests that use temp worktrees or temp cwd must not write persisted sessions into the user’s real session store
+- tests that intentionally prove persistence must use isolated temporary session roots and clean them up
+
+The missing piece is enforcing that rule at the right seam so runtime/bootstrap tests do not silently regress and explicit persistence tests stay isolated.
+
+## Scope
+This task covers test-time behavior only.
+
+In scope:
+- identify test entrypoints/helpers that still allow incidental persisted session creation against temp test worktrees
+- tighten the shared test seam so non-persistence is the default for tests that do not explicitly prove persistence
+- patch runtime/bootstrap-oriented tests that currently create real persisted sessions incidentally
+- preserve explicit persistence tests and keep them clear about why persistence is enabled
+- ensure explicit persistence tests use isolated temporary session roots rather than the real default session store
+- ensure explicit persistence tests clean up their temporary session roots after themselves
+- ensure routine test execution no longer writes temp-worktree session directories into the real default session store
+
+Out of scope:
+- changing normal non-test runtime persistence behavior
+- redesigning the session journal storage layout or directory naming scheme
+- changing persistence semantics for tests whose purpose is to verify on-disk persistence or resume/fork behavior
+- adding automatic cleanup of historical garbage already present in a developer’s home directory
+- redirecting production persistence into a test-specific root during ordinary runtime use
+
+## Design choices to settle
+The task should refine and choose among these seams, preferring the narrowest shared seam that prevents recurrence:
+
+1. **Test helper defaulting**
+   - ensure app-runtime/runtime-bootstrap test helpers explicitly propagate `:persist? false`
+   - use the same discipline already present in `psi.agent-session.test-support`
+   - treat the app-runtime startup/bootstrap helper path as the first shared seam to converge unless inventory proves a better common seam
+
+2. **Guardrails for unsafe persisted test contexts**
+   - extend existing safety checks so tests that attempt persistence with a temp cwd must do so deliberately
+   - fail fast when a test attempts persisted session creation against the real default session store without explicit isolated test configuration
+   - prefer helper discipline plus a test-only hard guardrail over helper discipline alone
+
+3. **Explicit opt-in for true persistence tests**
+   - tests that verify session files, resume, fork, or journal persistence stay explicit about persistence being required
+   - those tests must also choose an isolated temporary session root explicitly rather than falling through to the real default session store
+
+4. **Persistence test isolation and cleanup**
+   - provide or standardize a helper for creating a temporary session root for persistence tests
+   - prefer per-test helper-owned temporary session roots unless inventory proves a broader fixture scope is necessary
+   - make helper-owned cleanup explicit so test-created temporary session roots are removed after the test lifecycle completes
+   - prefer one obvious helper/pattern over ad hoc local temp-dir handling spread across tests
+   - cleanup should be robust in the face of test failure, using helper-owned lifecycle control such as fixture or `try`/`finally` semantics rather than manual best-effort cleanup in each test body
+
+The preferred outcome is to fix shared test bootstrap seams first, then standardize isolated persistence-test helpers, and only patch individual tests directly where that is genuinely the clearest place.
+
+## Required decisions during implementation
+Implementation must make these decisions explicit in code and tests:
+- the exact seam used to select an isolated temporary session root for explicit persistence tests
+- the exact helper or lifecycle owner responsible for cleanup of that temporary session root
+- the exact condition that causes fail-fast when a test tries to persist into the real default session store
+- the first shared helper/namespace chosen to converge app-runtime/bootstrap tests onto non-persisting defaults
+
+## Acceptance
+- routine test runs that use temp worktrees or temp cwd do not create new `~/.psi/agent/sessions/--var-folders-*` or `--private-var-folders-*` directories as incidental side effects
+- app-runtime/bootstrap-oriented tests that do not prove persistence run with persistence disabled
+- session/runtime test helpers make the non-persisting default obvious and hard to bypass accidentally
+- tests that do require persistence remain explicit about that requirement and continue to verify the intended on-disk behavior
+- explicit persistence tests use isolated temporary session roots instead of the real default session store
+- explicit persistence tests may inspect files inside their isolated temporary session root during the test body when needed for assertions
+- explicit persistence tests clean up the temporary session roots they create after the test-owned lifecycle completes
+- the fix is enforced at shared seams that make future regressions less likely than one-off local test edits alone
+
+## Verification ideas
+Examples of acceptable verification approaches:
+- focused tests around the affected runtime/bootstrap helper seam showing that temp-cwd test bootstraps do not allocate persisted session files under the real default session store
+- a targeted regression test demonstrating that a temp-cwd startup/bootstrap path leaves session persistence disabled unless explicitly requested
+- focused proof that explicit persistence tests can still create session files when pointed at an isolated temporary session root
+- focused proof or helper-level test that temporary session roots created for tests are cleaned up by the helper-owned lifecycle after the test body finishes
+- focused proof that unsafe persisted test contexts targeting the real default session store fail fast
+- manual spot-check before/after against `~/.psi/agent/sessions/` during the focused test run may be used as exploratory confirmation, but it is not an acceptance requirement
+
+## Constraints
+- keep the fix narrowly focused on test persistence behavior
+- prefer fixing shared test helpers or bootstrap seams over scattered one-off test patches when that preserves clarity
+- do not weaken or remove coverage for real persistence behavior
+- avoid any change that redirects production persistence away from the real user session store during normal runtime use
+- preserve local comprehensibility: a future test author should be able to tell from the helper or call site whether persistence is intended and whether persistence is isolated
+- keep guardrails test-only: production runtime behavior must remain unchanged
+- prefer per-test isolated temporary session roots over namespace-scoped or suite-scoped roots unless a broader scope is required and justified

--- a/munera/open/158-test-persistence-session-garbage/implementation.md
+++ b/munera/open/158-test-persistence-session-garbage/implementation.md
@@ -7,3 +7,8 @@
 - Updated agent-session lifecycle persistence path creation to honor `(:session-root ctx)` for both new-session and fork-session persisted file creation.
 - Narrowed `session_lifecycle_test` helper default to `:persist? false`, then kept explicit persistence coverage by moving the fork persistence proof onto `with-temp-session-root` + `:persist? true` + explicit `:session-root`.
 - Updated app-runtime proof to assert non-persisting default (`:session-file nil`) for ordinary console runtime tests.
+- Broadened verification beyond the initial focused pair to cover representative app-runtime, rpc, system-bootstrap, workflow-runtime, and model-dispatch surfaces; observed `0` delta in real `~/.psi/agent/sessions/--var-folders-*` / `--private-var-folders-*` directory counts during that run.
+- Verification snapshot:
+  - focused lint: `clj-kondo --lint components/agent-session/src components/agent-session/test components/app-runtime/src components/app-runtime/test`
+  - focused tests: `30 tests, 191 assertions, 0 failures`
+  - broader representative test run: `69 tests, 477 assertions, 0 failures`, home-store temp-dir count delta `0`

--- a/munera/open/158-test-persistence-session-garbage/implementation.md
+++ b/munera/open/158-test-persistence-session-garbage/implementation.md
@@ -32,3 +32,7 @@
   - tightened cleanup proof local naming from broader capture names to shorter, intent-revealing bindings while preserving post-lifecycle verification
   - improved the intentional persisted bootstrap root-forwarding proof with explicit `session-id` / `session-file` bindings and clearer assertion messages for isolated-root failures
   - focused verification: `psi.agent-session.session-lifecycle-test`, `psi.app-runtime-test`, and `psi.rpc-real-delegate-command-test` green (`36 tests, 213 assertions, 0 failures`); focused lint clean
+- Code-shaper review note: code looks closure-ready. No substantive code-shaping gap remains; at most, future polish could add a brief doc cue that `safe-context-opts` is the authoritative persisted-test guardrail seam if this pattern grows.
+- Code-shaper follow-up implemented:
+  - added a brief doc cue on `safe-context-opts` marking it as the authoritative persisted-test guardrail seam shared by test context helpers
+  - verification: focused lint on `psi.agent-session.test-support` clean

--- a/munera/open/158-test-persistence-session-garbage/implementation.md
+++ b/munera/open/158-test-persistence-session-garbage/implementation.md
@@ -12,3 +12,11 @@
   - focused lint: `clj-kondo --lint components/agent-session/src components/agent-session/test components/app-runtime/src components/app-runtime/test`
   - focused tests: `30 tests, 191 assertions, 0 failures`
   - broader representative test run: `69 tests, 477 assertions, 0 failures`, home-store temp-dir count delta `0`
+- Review note: not ready to close. Remaining shared-seam gap: some app-runtime test/bootstrap entrypoints still default to real persistence when tests call `create-runtime-session-context` or the convenience `bootstrap-runtime-session!` path directly; `create-test-session` also documents but does not itself enforce the persisted-test guardrail.
+- Review follow-up implemented:
+  - tightened `psi.agent-session.test-support/create-test-session` to apply `safe-context-opts` itself, so persisted test use is guardrailed by code rather than docstring discipline alone
+  - patched remaining direct non-persisting test call sites using `psi.app-runtime/create-runtime-session-context` to pass `:persist? false`
+  - fixed the convenience two-arity `psi.app-runtime/bootstrap-runtime-session!` path to forward test-only `:persist?` and `:session-root` into runtime-session context creation instead of silently falling back to real persistence
+  - added focused proofs that direct app-runtime and rpc test seams now produce `:session-file nil` when used as non-persisting test contexts
+  - focused verification: `psi.app-runtime-test`, `psi.rpc-real-delegate-command-test`, `psi.agent-session.session-lifecycle-test` green (`35 tests, 207 assertions, 0 failures`); focused lint clean
+  - while re-running an unrelated broader namespace, observed pre-existing event-log sensitivity in `psi.agent-session.model-dispatch-test/projection-and-transition-helper-dispatch-test` (`:session/ui-clear-widget` noise before `:session/record-tool-output-stat`); unrelated to task 158 changes

--- a/munera/open/158-test-persistence-session-garbage/implementation.md
+++ b/munera/open/158-test-persistence-session-garbage/implementation.md
@@ -26,3 +26,9 @@
   - added focused regression proof that persisted `create-test-session` use without explicit isolated `:session-root` fails fast with the expected guardrail error and opts shape
   - added a narrow intentional-persisting bootstrap proof that the convenience two-arity `bootstrap-runtime-session!` seam forwards an explicit isolated `:session-root` when persistence is intentionally enabled
   - focused verification: `psi.agent-session.session-lifecycle-test`, `psi.app-runtime-test`, and `psi.rpc-real-delegate-command-test` green (`35 tests, 213 assertions, 0 failures`); focused lint clean
+- Test-shaper review note: no substantive coverage gap remains, but the newest persistence/guardrail tests could be shaped for clarity and signal: split the grouped helper/guardrail test into separate single-contract tests, tighten local naming in the cleanup proof, and make the bootstrap root-forwarding failure output slightly more explicit.
+- Test-shaper follow-up implemented:
+  - split the grouped helper/guardrail persistence review proof into separate single-contract tests for cleanup and fail-fast guardrails
+  - tightened cleanup proof local naming from broader capture names to shorter, intent-revealing bindings while preserving post-lifecycle verification
+  - improved the intentional persisted bootstrap root-forwarding proof with explicit `session-id` / `session-file` bindings and clearer assertion messages for isolated-root failures
+  - focused verification: `psi.agent-session.session-lifecycle-test`, `psi.app-runtime-test`, and `psi.rpc-real-delegate-command-test` green (`36 tests, 213 assertions, 0 failures`); focused lint clean

--- a/munera/open/158-test-persistence-session-garbage/implementation.md
+++ b/munera/open/158-test-persistence-session-garbage/implementation.md
@@ -20,3 +20,9 @@
   - added focused proofs that direct app-runtime and rpc test seams now produce `:session-file nil` when used as non-persisting test contexts
   - focused verification: `psi.app-runtime-test`, `psi.rpc-real-delegate-command-test`, `psi.agent-session.session-lifecycle-test` green (`35 tests, 207 assertions, 0 failures`); focused lint clean
   - while re-running an unrelated broader namespace, observed pre-existing event-log sensitivity in `psi.agent-session.model-dispatch-test/projection-and-transition-helper-dispatch-test` (`:session/ui-clear-widget` noise before `:session/record-tool-output-stat`); unrelated to task 158 changes
+- Test review note: tests are strong overall but not yet closure-complete. Remaining gaps: no focused proof that `with-temp-session-root` removes the temp root after the helper-owned lifecycle completes, and no focused regression proof that persisted `create-test-session` use without explicit isolated `:session-root` fails fast.
+- Test review follow-up implemented:
+  - added focused proof that `with-temp-session-root` exposes a real temp root during the body and removes it after the helper-owned lifecycle returns
+  - added focused regression proof that persisted `create-test-session` use without explicit isolated `:session-root` fails fast with the expected guardrail error and opts shape
+  - added a narrow intentional-persisting bootstrap proof that the convenience two-arity `bootstrap-runtime-session!` seam forwards an explicit isolated `:session-root` when persistence is intentionally enabled
+  - focused verification: `psi.agent-session.session-lifecycle-test`, `psi.app-runtime-test`, and `psi.rpc-real-delegate-command-test` green (`35 tests, 213 assertions, 0 failures`); focused lint clean

--- a/munera/open/158-test-persistence-session-garbage/implementation.md
+++ b/munera/open/158-test-persistence-session-garbage/implementation.md
@@ -1,0 +1,9 @@
+# Implementation log
+
+- Decided to use `:session-root` on the agent-session context as the explicit seam for isolated persisted test storage. Production callers keep default nil behavior, which still resolves to the normal user-home store.
+- Tightened `psi.agent-session.test-support/safe-context-opts` so persisted tests must provide an explicit isolated `:session-root`; otherwise helper-based test contexts fail fast before creating persisted session files.
+- Standardized helper-owned lifecycle for persistence tests with `with-temp-session-root`, which allocates a per-test temp root and deletes it in `finally`.
+- Chosen first shared seam for ordinary non-persisting runtime/bootstrap tests: `psi.app-runtime/create-runtime-session-context` callers in `run-session` and `start-tui-runtime!` now pass `:persist? false`, preventing incidental temp-cwd runtime tests from writing into the real default session store.
+- Updated agent-session lifecycle persistence path creation to honor `(:session-root ctx)` for both new-session and fork-session persisted file creation.
+- Narrowed `session_lifecycle_test` helper default to `:persist? false`, then kept explicit persistence coverage by moving the fork persistence proof onto `with-temp-session-root` + `:persist? true` + explicit `:session-root`.
+- Updated app-runtime proof to assert non-persisting default (`:session-file nil`) for ordinary console runtime tests.

--- a/munera/open/158-test-persistence-session-garbage/plan.md
+++ b/munera/open/158-test-persistence-session-garbage/plan.md
@@ -1,0 +1,63 @@
+# Plan
+
+Implement this as one test-isolation vertical slice: make non-persistence the default for non-persistence tests, standardize an explicit isolated temporary session root for persistence tests, and add guardrails so no test silently writes session artifacts into the developer’s real `~/.psi/agent/sessions/` store.
+
+## Review and follow-up surfaces
+
+- `implementation.md` is the append-only review/decision log for this task.
+- `design-steps.md` is the actionable ambiguity follow-up surface.
+- `steps.md` remains reserved for implementation execution work, not ambiguity-review follow-up capture.
+
+## Approach
+
+1. **Inventory the real leak seams and classify tests by persistence intent**
+   - identify helpers and direct call sites that still create persisted sessions from temp cwd/worktree paths
+   - separate them into:
+     - non-persistence tests that should run with `:persist? false`
+     - explicit persistence tests whose assertions require real journal/session-file behavior on disk
+   - confirm the most important shared seam(s), especially app-runtime/runtime-bootstrap test helpers
+
+2. **Converge shared non-persistence defaults for ordinary tests**
+   - update runtime/bootstrap test helpers so they explicitly propagate `:persist? false` when persistence is not the thing being tested
+   - align app-runtime-oriented helpers with the existing `psi.agent-session.test-support` discipline
+   - prefer one shared fix over scattered local per-test overrides when possible
+
+3. **Standardize isolated temporary session roots for explicit persistence tests**
+   - introduce or refine a shared helper/pattern for tests that intentionally need persistence
+   - make that helper allocate an isolated temporary session root rather than using the real default `~/.psi/agent/sessions/`
+   - prefer per-test helper-owned isolated temporary session roots unless inventory proves a broader fixture scope is necessary
+   - keep the persisted behavior real: session files and directories should still be written, just under a test-owned root
+   - ensure explicit persistence tests can inspect files in the isolated temporary session root during the test body before helper-owned cleanup runs
+
+4. **Add cleanup ownership for explicit persistence tests**
+   - make the persistence-test helper or pattern responsible for cleaning up the isolated temporary session root after the test lifecycle completes
+   - keep cleanup local and comprehensible so test authors can see the ownership model clearly
+   - avoid relying on manual cleanup or developer home-directory hygiene
+   - prefer helper-owned lifecycle control such as per-test fixture or `try`/`finally` semantics so cleanup remains robust on test failure
+
+5. **Add guardrails against unsafe persisted test contexts**
+   - no persisted test context may use the real default session store
+   - strengthen guardrails at the chosen test helper / test-support seam so unsafe persisted contexts fail fast
+   - preserve an explicit isolated opt-in path for true persistence tests, but require them to name an isolated temporary session root rather than falling through to the production default
+   - keep guardrails test-only and avoid affecting production runtime semantics
+
+6. **Record the explicit implementation decisions**
+   - make explicit in code/tests or implementation notes:
+     - the exact seam used to select an isolated temporary session root
+     - the exact helper or lifecycle owner responsible for cleanup
+     - the exact fail-fast condition for unsafe persisted test contexts
+     - the first shared helper/namespace chosen to converge app-runtime/bootstrap tests onto non-persisting defaults
+
+7. **Prove both sides of the contract**
+   - prove that ordinary temp-cwd/bootstrap tests do not allocate real persisted session artifacts
+   - prove that explicit persistence tests still work when pointed at an isolated temporary session root
+   - prove that explicit persistence tests can inspect files before helper-owned cleanup runs
+   - prove that isolated temporary session roots are cleaned up by the standardized helper/pattern
+   - prove that unsafe persisted test contexts targeting the real default session store fail fast
+
+## Risks
+
+- The leak may come from multiple test seams, not just one helper, so a too-local fix could leave residual writers behind.
+- Guardrails that are too broad could break legitimate persistence tests; they need an explicit isolated opt-in path.
+- Cleanup can become flaky if ownership is split across helpers and test bodies; prefer one obvious helper-owned lifecycle.
+- It is easy to broaden this into production persistence redesign; keep the slice strictly test-time and isolation-focused.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -44,3 +44,8 @@
   - [x] Tighten `psi.agent-session.test-support/create-test-session` so persisted test usage is guardrailed by code, not only by docstring guidance.
   - [x] Add or update focused proofs that the remaining app-runtime/rpc direct test seams do not persist into the real default session store unless given an explicit isolated `:session-root`.
   - [x] Re-run focused verification and confirm the review gaps are closed before marking the task ready to close.
+- [x] Close the remaining test-quality gaps found in test review.
+  - [x] Add a focused proof that `with-temp-session-root` removes the temporary session root after the helper-owned lifecycle completes.
+  - [x] Add a focused regression proof that persisted `create-test-session` use without explicit isolated `:session-root` fails fast.
+  - [x] Optionally strengthen the convenience bootstrap seam proof by covering intentional persisted test use with explicit `:session-root`, if that stays narrow and clearer than relying on implementation inspection alone.
+  - [x] Re-run focused verification for the added test coverage and confirm the remaining test-review gaps are closed.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -37,3 +37,10 @@
   - [x] Focused affected test namespaces are green.
   - [x] No incidental `--var-folders-*` or `--private-var-folders-*` directories are created under the real `~/.psi/agent/sessions/` during the focused test run.
   - [x] Explicit persistence coverage remains intact and isolated.
+- [x] Close the remaining shared-seam persistence gaps found in review.
+  - [x] Audit direct test call sites that use `psi.app-runtime/create-runtime-session-context` and classify each as non-persisting or explicit persistence.
+  - [x] Make non-persisting app-runtime test entrypoints explicit at the remaining direct call sites, or introduce a shared test-safe runtime helper if that is the clearer seam.
+  - [x] Cover the convenience `psi.app-runtime/bootstrap-runtime-session!` path so test use cannot silently fall through to the real default session store.
+  - [x] Tighten `psi.agent-session.test-support/create-test-session` so persisted test usage is guardrailed by code, not only by docstring guidance.
+  - [x] Add or update focused proofs that the remaining app-runtime/rpc direct test seams do not persist into the real default session store unless given an explicit isolated `:session-root`.
+  - [x] Re-run focused verification and confirm the review gaps are closed before marking the task ready to close.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -54,3 +54,5 @@
   - [x] Tighten local naming in the temp-root cleanup proof to reduce incidental ceremony while preserving post-lifecycle verification.
   - [x] Make the bootstrap root-forwarding proof emit clearer failure signal, e.g. by binding expected/actual names or adding explicit assertion messages around the isolated-root path check.
   - [x] Re-run the focused persistence test set and confirm the shaping changes preserve coverage and improve readability.
+- [x] Optional code-shaping polish if this seam grows further.
+  - [x] Consider adding a brief internal doc cue that `safe-context-opts` is the authoritative persisted-test guardrail seam, but only if more test-entry helpers or persisted-test patterns accumulate and the extra explanation earns its keep.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -33,7 +33,7 @@
   - [x] Add or update focused tests proving explicit persistence tests can inspect files before helper-owned cleanup runs when needed.
   - [x] Add or update focused tests proving the isolated temporary session roots are cleaned up by the standardized helper/pattern.
   - [x] Add or update focused tests proving persisted test contexts targeting the real default session store fail fast.
-- [ ] Verify the final state.
-  - [ ] Focused affected test namespaces are green.
-  - [ ] No incidental `--var-folders-*` or `--private-var-folders-*` directories are created under the real `~/.psi/agent/sessions/` during the focused test run.
-  - [ ] Explicit persistence coverage remains intact and isolated.
+- [x] Verify the final state.
+  - [x] Focused affected test namespaces are green.
+  - [x] No incidental `--var-folders-*` or `--private-var-folders-*` directories are created under the real `~/.psi/agent/sessions/` during the focused test run.
+  - [x] Explicit persistence coverage remains intact and isolated.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -49,3 +49,8 @@
   - [x] Add a focused regression proof that persisted `create-test-session` use without explicit isolated `:session-root` fails fast.
   - [x] Optionally strengthen the convenience bootstrap seam proof by covering intentional persisted test use with explicit `:session-root`, if that stays narrow and clearer than relying on implementation inspection alone.
   - [x] Re-run focused verification for the added test coverage and confirm the remaining test-review gaps are closed.
+- [x] Shape the newest persistence tests for clarity and signal.
+  - [x] Split the grouped helper/guardrail test in `session_lifecycle_test.clj` into separate single-contract `deftest`s.
+  - [x] Tighten local naming in the temp-root cleanup proof to reduce incidental ceremony while preserving post-lifecycle verification.
+  - [x] Make the bootstrap root-forwarding proof emit clearer failure signal, e.g. by binding expected/actual names or adding explicit assertion messages around the isolated-root path check.
+  - [x] Re-run the focused persistence test set and confirm the shaping changes preserve coverage and improve readability.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -1,38 +1,38 @@
 # Steps
 
-- [ ] Inventory the current test persistence leak paths before changing helpers.
-  - [ ] Identify non-persistence tests that still create real persisted sessions from temp cwd/worktree paths.
-  - [ ] Identify explicit persistence tests whose assertions intentionally require real session-file/journal behavior on disk.
-  - [ ] Confirm the main shared seam(s), especially app-runtime/runtime-bootstrap helper paths.
-- [ ] Converge non-persistence defaults for ordinary tests.
-  - [ ] Update shared runtime/bootstrap test helpers to pass `:persist? false` when persistence is not under test.
-  - [ ] Align app-runtime test helpers with the existing `psi.agent-session.test-support` non-persisting discipline.
-  - [ ] Patch any remaining direct non-helper test call sites only where a shared seam cannot cover them cleanly.
-- [ ] Standardize isolated temporary session root setup for explicit persistence tests.
-  - [ ] Introduce or refine a shared helper/pattern for tests that intentionally require persistence.
-  - [ ] Ensure the helper allocates an isolated temporary session root instead of using `~/.psi/agent/sessions/`.
-  - [ ] Prefer per-test helper-owned isolated temporary session roots unless broader fixture scope is justified.
-  - [ ] Keep explicit persistence tests clear at the call site about persistence being intentionally enabled.
-  - [ ] Ensure explicit persistence tests can inspect files in the isolated temporary session root before helper-owned cleanup runs when needed for assertions.
-- [ ] Add cleanup ownership for explicit persistence tests.
-  - [ ] Make the helper or standardized pattern clean up the isolated temporary session root after the test-owned lifecycle completes.
-  - [ ] Avoid leaving cleanup as an implicit manual responsibility in individual test bodies.
-  - [ ] Confirm the cleanup approach is robust for repeated local test runs and test failure paths.
-- [ ] Add guardrails for unsafe persisted test contexts.
-  - [ ] Fail fast when a test attempts persistence against the real default session store without an explicit isolated temporary session root.
-  - [ ] Preserve an explicit isolated opt-in path for true persistence tests.
-  - [ ] Keep the guardrail test-only so production runtime behavior is unchanged.
-- [ ] Record the explicit implementation decisions.
-  - [ ] Record the exact seam used to select an isolated temporary session root.
-  - [ ] Record the exact helper or lifecycle owner responsible for cleanup.
-  - [ ] Record the exact fail-fast condition for unsafe persisted test contexts.
-  - [ ] Record the first shared helper/namespace chosen to converge app-runtime/bootstrap tests onto non-persisting defaults.
-- [ ] Tighten focused proofs for both ordinary and explicit persistence cases.
-  - [ ] Add or update focused tests proving ordinary temp-cwd/bootstrap tests do not allocate persisted session artifacts in the real user session store.
-  - [ ] Add or update focused tests proving explicit persistence tests can still create session files under isolated temporary session roots.
-  - [ ] Add or update focused tests proving explicit persistence tests can inspect files before helper-owned cleanup runs when needed.
-  - [ ] Add or update focused tests proving the isolated temporary session roots are cleaned up by the standardized helper/pattern.
-  - [ ] Add or update focused tests proving persisted test contexts targeting the real default session store fail fast.
+- [x] Inventory the current test persistence leak paths before changing helpers.
+  - [x] Identify non-persistence tests that still create real persisted sessions from temp cwd/worktree paths.
+  - [x] Identify explicit persistence tests whose assertions intentionally require real session-file/journal behavior on disk.
+  - [x] Confirm the main shared seam(s), especially app-runtime/runtime-bootstrap helper paths.
+- [x] Converge non-persistence defaults for ordinary tests.
+  - [x] Update shared runtime/bootstrap test helpers to pass `:persist? false` when persistence is not under test.
+  - [x] Align app-runtime test helpers with the existing `psi.agent-session.test-support` non-persisting discipline.
+  - [x] Patch any remaining direct non-helper test call sites only where a shared seam cannot cover them cleanly.
+- [x] Standardize isolated temporary session root setup for explicit persistence tests.
+  - [x] Introduce or refine a shared helper/pattern for tests that intentionally require persistence.
+  - [x] Ensure the helper allocates an isolated temporary session root instead of using `~/.psi/agent/sessions/`.
+  - [x] Prefer per-test helper-owned isolated temporary session roots unless broader fixture scope is justified.
+  - [x] Keep explicit persistence tests clear at the call site about persistence being intentionally enabled.
+  - [x] Ensure explicit persistence tests can inspect files in the isolated temporary session root before helper-owned cleanup runs when needed for assertions.
+- [x] Add cleanup ownership for explicit persistence tests.
+  - [x] Make the helper or standardized pattern clean up the isolated temporary session root after the test-owned lifecycle completes.
+  - [x] Avoid leaving cleanup as an implicit manual responsibility in individual test bodies.
+  - [x] Confirm the cleanup approach is robust for repeated local test runs and test failure paths.
+- [x] Add guardrails for unsafe persisted test contexts.
+  - [x] Fail fast when a test attempts persistence against the real default session store without an explicit isolated temporary session root.
+  - [x] Preserve an explicit isolated opt-in path for true persistence tests.
+  - [x] Keep the guardrail test-only so production runtime behavior is unchanged.
+- [x] Record the explicit implementation decisions.
+  - [x] Record the exact seam used to select an isolated temporary session root.
+  - [x] Record the exact helper or lifecycle owner responsible for cleanup.
+  - [x] Record the exact fail-fast condition for unsafe persisted test contexts.
+  - [x] Record the first shared helper/namespace chosen to converge app-runtime/bootstrap tests onto non-persisting defaults.
+- [x] Tighten focused proofs for both ordinary and explicit persistence cases.
+  - [x] Add or update focused tests proving ordinary temp-cwd/bootstrap tests do not allocate persisted session artifacts in the real user session store.
+  - [x] Add or update focused tests proving explicit persistence tests can still create session files under isolated temporary session roots.
+  - [x] Add or update focused tests proving explicit persistence tests can inspect files before helper-owned cleanup runs when needed.
+  - [x] Add or update focused tests proving the isolated temporary session roots are cleaned up by the standardized helper/pattern.
+  - [x] Add or update focused tests proving persisted test contexts targeting the real default session store fail fast.
 - [ ] Verify the final state.
   - [ ] Focused affected test namespaces are green.
   - [ ] No incidental `--var-folders-*` or `--private-var-folders-*` directories are created under the real `~/.psi/agent/sessions/` during the focused test run.

--- a/munera/open/158-test-persistence-session-garbage/steps.md
+++ b/munera/open/158-test-persistence-session-garbage/steps.md
@@ -1,0 +1,39 @@
+# Steps
+
+- [ ] Inventory the current test persistence leak paths before changing helpers.
+  - [ ] Identify non-persistence tests that still create real persisted sessions from temp cwd/worktree paths.
+  - [ ] Identify explicit persistence tests whose assertions intentionally require real session-file/journal behavior on disk.
+  - [ ] Confirm the main shared seam(s), especially app-runtime/runtime-bootstrap helper paths.
+- [ ] Converge non-persistence defaults for ordinary tests.
+  - [ ] Update shared runtime/bootstrap test helpers to pass `:persist? false` when persistence is not under test.
+  - [ ] Align app-runtime test helpers with the existing `psi.agent-session.test-support` non-persisting discipline.
+  - [ ] Patch any remaining direct non-helper test call sites only where a shared seam cannot cover them cleanly.
+- [ ] Standardize isolated temporary session root setup for explicit persistence tests.
+  - [ ] Introduce or refine a shared helper/pattern for tests that intentionally require persistence.
+  - [ ] Ensure the helper allocates an isolated temporary session root instead of using `~/.psi/agent/sessions/`.
+  - [ ] Prefer per-test helper-owned isolated temporary session roots unless broader fixture scope is justified.
+  - [ ] Keep explicit persistence tests clear at the call site about persistence being intentionally enabled.
+  - [ ] Ensure explicit persistence tests can inspect files in the isolated temporary session root before helper-owned cleanup runs when needed for assertions.
+- [ ] Add cleanup ownership for explicit persistence tests.
+  - [ ] Make the helper or standardized pattern clean up the isolated temporary session root after the test-owned lifecycle completes.
+  - [ ] Avoid leaving cleanup as an implicit manual responsibility in individual test bodies.
+  - [ ] Confirm the cleanup approach is robust for repeated local test runs and test failure paths.
+- [ ] Add guardrails for unsafe persisted test contexts.
+  - [ ] Fail fast when a test attempts persistence against the real default session store without an explicit isolated temporary session root.
+  - [ ] Preserve an explicit isolated opt-in path for true persistence tests.
+  - [ ] Keep the guardrail test-only so production runtime behavior is unchanged.
+- [ ] Record the explicit implementation decisions.
+  - [ ] Record the exact seam used to select an isolated temporary session root.
+  - [ ] Record the exact helper or lifecycle owner responsible for cleanup.
+  - [ ] Record the exact fail-fast condition for unsafe persisted test contexts.
+  - [ ] Record the first shared helper/namespace chosen to converge app-runtime/bootstrap tests onto non-persisting defaults.
+- [ ] Tighten focused proofs for both ordinary and explicit persistence cases.
+  - [ ] Add or update focused tests proving ordinary temp-cwd/bootstrap tests do not allocate persisted session artifacts in the real user session store.
+  - [ ] Add or update focused tests proving explicit persistence tests can still create session files under isolated temporary session roots.
+  - [ ] Add or update focused tests proving explicit persistence tests can inspect files before helper-owned cleanup runs when needed.
+  - [ ] Add or update focused tests proving the isolated temporary session roots are cleaned up by the standardized helper/pattern.
+  - [ ] Add or update focused tests proving persisted test contexts targeting the real default session store fail fast.
+- [ ] Verify the final state.
+  - [ ] Focused affected test namespaces are green.
+  - [ ] No incidental `--var-folders-*` or `--private-var-folders-*` directories are created under the real `~/.psi/agent/sessions/` during the focused test run.
+  - [ ] Explicit persistence coverage remains intact and isolated.


### PR DESCRIPTION
## Summary
- enforce test-time persistence guardrails at shared session and app-runtime seams
- isolate explicit persistence tests with temporary session roots and helper-owned cleanup
- add focused regression proofs for non-persisting runtime seams, guardrails, cleanup, and isolated persisted bootstrap paths

## Testing
- clojure -M:test --focus psi.agent-session.session-lifecycle-test --focus psi.app-runtime-test --focus psi.rpc-real-delegate-command-test
- clj-kondo --lint components/agent-session/test/psi/agent_session/test_support.clj
- clj-kondo --lint components/agent-session/test/psi/agent_session/session_lifecycle_test.clj components/app-runtime/test/psi/app_runtime_test.clj
