### PR TITLE
Fix local/root extension startup and tool activation

### DIFF
--- a/bases/main/src/psi/launcher.clj
+++ b/bases/main/src/psi/launcher.clj
@@ -153,6 +153,32 @@
         (psi-self-basis-from-repo-config launcher-root policy)
         (update :deps assoc 'nrepl/nrepl {:mvn/version "1.5.1"}))))
 
+(defn- manifest-entry-base-dir
+  [{:keys [defaulted-fields]} launcher-root manifest-base-dir dep]
+  (cond
+    (and (contains? dep :local/root)
+         (not (some #{:local/root} defaulted-fields)))
+    manifest-base-dir
+
+    (some #{:local/root} defaulted-fields)
+    launcher-root
+
+    :else
+    nil))
+
+(defn- expand-manifest-for-source
+  [manifest {:keys [policy launcher-root manifest-base-dir]}]
+  (reduce-kv (fn [{:keys [deps reports]} lib dep]
+               (let [report (extensions/expand-entry-report lib dep {:policy policy})
+                     base-dir (manifest-entry-base-dir report launcher-root manifest-base-dir dep)
+                     expanded-dep (cond-> (:expanded report)
+                                    base-dir (#(absolutize-local-root base-dir %)))]
+                 {:deps (assoc deps lib expanded-dep)
+                  :reports (assoc reports lib (assoc report :expanded expanded-dep))}))
+             {:deps {}
+              :reports {}}
+             (:deps manifest)))
+
 (defn manifest-state
   [launcher-root cwd policy]
   (let [home               (System/getProperty "user.home")
@@ -160,15 +186,18 @@
         project-path       (project-manifest-path cwd)
         user-manifest      (extensions/read-manifest-file user-path)
         project-manifest   (extensions/read-manifest-file project-path)
+        user-base-dir      (.getParent (io/file user-path))
+        user-expanded      (expand-manifest-for-source user-manifest
+                                                       {:policy policy
+                                                        :launcher-root launcher-root
+                                                        :manifest-base-dir user-base-dir})
+        project-expanded   (expand-manifest-for-source project-manifest
+                                                       {:policy policy
+                                                        :launcher-root launcher-root
+                                                        :manifest-base-dir cwd})
         merged-manifest    (extensions/merge-manifests user-manifest project-manifest)
-        expansion-report   (extensions/manifest-expansion-report merged-manifest {:policy policy})
-        expanded-manifest0 (:expanded-manifest expansion-report)
-        expanded-manifest  (update expanded-manifest0 :deps
-                                   (fn [deps]
-                                     (into {}
-                                           (map (fn [[lib dep]]
-                                                  [lib (absolutize-local-root launcher-root dep)]))
-                                           deps)))]
+        expanded-manifest  {:deps (merge (:deps user-expanded) (:deps project-expanded))}
+        winning-reports    (merge (:reports user-expanded) (:reports project-expanded))]
     {:user-path          user-path
      :project-path       project-path
      :user-present?      (.exists (io/file user-path))
@@ -177,8 +206,16 @@
      :project-manifest   project-manifest
      :merged-manifest    merged-manifest
      :expanded-manifest  expanded-manifest
-     :defaulted-libs     (:defaulted-libs expansion-report)
-     :inferred-init-libs (:inferred-init-libs expansion-report)}))
+     :defaulted-libs     (->> winning-reports
+                              (keep (fn [[lib report]]
+                                      (when (:defaulted? report)
+                                        lib)))
+                              vec)
+     :inferred-init-libs (->> winning-reports
+                              (keep (fn [[lib report]]
+                                      (when (:inferred-init? report)
+                                        lib)))
+                              vec)}))
 
 (defn- absolutize-local-root-dep
   [base-dir dep]

--- a/bases/main/test/psi/launcher_test.clj
+++ b/bases/main/test/psi/launcher_test.clj
@@ -108,7 +108,30 @@
         (is (= ['psi/mementum]
                (:defaulted-libs (launcher/manifest-state "/repo/psi" "/repo/project" :installed))))
         (is (= ['psi/mementum]
-               (:inferred-init-libs (launcher/manifest-state "/repo/psi" "/repo/project" :installed))))))))
+               (:inferred-init-libs (launcher/manifest-state "/repo/psi" "/repo/project" :installed)))))))
+  (testing "project-local explicit local/root resolves against project cwd"
+    (let [project-manifest {:deps {'third-party/ext {:local/root "extensions/local-ext"
+                                                     :psi/init 'third.party.ext/init}}}
+          result (with-redefs [launcher/user-manifest-path (constantly "/tmp/user.edn")
+                               launcher/project-manifest-path (constantly "/tmp/project/.psi/extensions.edn")
+                               extensions/read-manifest-file (fn [path]
+                                                               (case path
+                                                                 "/tmp/user.edn" {:deps {}}
+                                                                 "/tmp/project/.psi/extensions.edn" project-manifest))]
+                   (launcher/manifest-state "/repo/psi" "/tmp/project" :installed))]
+      (is (= "/tmp/project/extensions/local-ext"
+             (get-in result [:expanded-manifest :deps 'third-party/ext :local/root])))))
+  (testing "psi-owned defaulted local/root resolves against launcher root"
+    (let [project-manifest {:deps {'psi/mementum {}}}
+          result (with-redefs [launcher/user-manifest-path (constantly "/tmp/user.edn")
+                               launcher/project-manifest-path (constantly "/tmp/project/.psi/extensions.edn")
+                               extensions/read-manifest-file (fn [path]
+                                                               (case path
+                                                                 "/tmp/user.edn" {:deps {}}
+                                                                 "/tmp/project/.psi/extensions.edn" project-manifest))]
+                   (launcher/manifest-state "/repo/psi" "/tmp/project" :installed))]
+      (is (= "/repo/psi/extensions/mementum"
+             (get-in result [:expanded-manifest :deps 'psi/mementum :local/root]))))))
 
 (deftest startup-basis-jar-policy-omits-psi-owned-extensions
   (testing "jar policy drops psi-owned extensions from basis — already bundled in org.hugoduncan/psi"

--- a/components/agent-session/src/psi/agent_session/extension_runtime.clj
+++ b/components/agent-session/src/psi/agent_session/extension_runtime.clj
@@ -13,13 +13,15 @@
    registration change."
   (:require
    [clojure.repl.deps :as repl.deps]
+   [psi.agent-core.core :as agent]
    [psi.agent-session.dispatch :as dispatch]
    [psi.agent-session.extension-installs :as installs]
    [psi.agent-session.extensions :as ext]
    [psi.agent-session.extensions.runtime-delivery :as runtime-delivery]
    [psi.agent-session.extensions.runtime-fns :as runtime-fns]
    [psi.agent-session.extensions.runtime-ui :as runtime-ui]
-   [psi.session-state.state :as ss]))
+   [psi.session-state.state :as ss]
+   [psi.tool-registry.registry :as tool-registry]))
 
 (defn load-extensions-in!
   "Discover and load all extensions into this session's registry.
@@ -107,6 +109,17 @@
       (update :errors into (:errors manifest-result))
       (merge (select-keys manifest-result [:deps-realized? :deps-restart-required? :deps-realize-error]))))
 
+(defn- refresh-active-tools-in!
+  [ctx session-id]
+  (let [agent-ctx     (ss/agent-ctx-in ctx session-id)
+        current-tools (or (:tools (agent/get-data-in agent-ctx)) [])
+        ext-tools     (tool-registry/all-tools-in (:extension-registry ctx))]
+    (dispatch/dispatch! ctx
+                        :session/set-active-tools
+                        {:session-id session-id
+                         :tool-maps  (into (vec current-tools) ext-tools)}
+                        {:origin :core})))
+
 (defn activate-manifest-extensions-in!
   "Activate manifest-aware extensions through one shared abstraction.
 
@@ -122,6 +135,8 @@
         activation-result (ext/activate-extensions-in! (:extension-registry ctx)
                                                        runtime-fns*
                                                        (activation-entries (assoc plan :deps-realized? (:deps-realized? deps-result))))]
+    (when (seq (:loaded activation-result))
+      (refresh-active-tools-in! ctx session-id))
     (merge-extension-results activation-result deps-result)))
 
 (defn bootstrap-manifest-extensions-in!

--- a/components/agent-session/test/psi/agent_session/extensions_io_test.clj
+++ b/components/agent-session/test/psi/agent_session/extensions_io_test.clj
@@ -8,7 +8,8 @@
    [psi.agent-session.extensions :as ext]
    [psi.tool-registry.registry :as tool-registry]
    [psi.agent-session.mutations :as mutations]
-   [psi.agent-session.test-support :as test-support]))
+   [psi.agent-session.test-support :as test-support]
+   [psi.session-state.state :as ss]))
 
 ;; ── Extension loading from file ─────────────────────────────────────────────
 
@@ -75,6 +76,37 @@
         (finally
           (.delete ext-file)
           (.delete tmp-dir))))))
+
+(deftest activate-manifest-extensions-refreshes-session-tool-defs-test
+  (testing "manifest activation refreshes session tool defs so newly registered tools become active"
+    (let [[ctx session-id] (test-support/create-test-session {:persist? false
+                                                              :cwd (test-support/temp-cwd)
+                                                              :mutations mutations/all-mutations})
+          reg (:extension-registry ctx)
+          ns-sym 'psi.test-extensions.runtime-manifest-ext]
+      (create-ns ns-sym)
+      (binding [*ns* (the-ns ns-sym)]
+        (clojure.core/refer 'clojure.core)
+        (intern *ns* 'init
+                (fn [api]
+                  ((:register-tool api) {:name "manifest-runtime-tool"
+                                         :label "Manifest Runtime Tool"
+                                         :description "Tool from manifest activation"
+                                         :format-request (fn [_] "manifest-runtime-tool")
+                                         :parameters {:type "object"}}))))
+      (let [result (ext-rt/activate-manifest-extensions-in!
+                    ctx
+                    session-id
+                    {:local-activation-entries []
+                     :entries-by-lib {'psi/test-manifest-ext {:dep {:mvn/version "1.0.0"
+                                                                    :psi/init 'psi.test-extensions.runtime-manifest-ext/init}
+                                                              :extension? true
+                                                              :enabled? true}}}
+                    {:deps-realized? true})
+            tool-names (set (map :name (:tool-defs (ss/get-session-data-in ctx session-id))))]
+        (is (= ["manifest:psi/test-manifest-ext"] (:loaded result)))
+        (is (contains? (tool-registry/tool-names-in reg) "manifest-runtime-tool"))
+        (is (contains? tool-names "manifest-runtime-tool"))))))
 
 (deftest load-extension-missing-file-test
   (testing "returns error for missing file"

--- a/components/app-runtime/test/psi/extension_install_startup_test.clj
+++ b/components/app-runtime/test/psi/extension_install_startup_test.clj
@@ -133,6 +133,22 @@
       (is (some #(re-find #"startup_ext.clj" %) (startup-registry-paths ctx)))
       (is (= :loaded (startup-entry-status ctx 'psi/test-startup-ext))))))
 
+(deftest startup-local-root-manifest-extension-tools-enter-session-tool-defs-test
+  (testing "bootstrap startup merges local-root manifest extension tools into session tool defs"
+    (let [ext-root (test-support/temp-cwd)
+          _        (write-local-extension! ext-root
+                                           'psi.test.startup-local-tool-ext
+                                           "(ns psi.test.startup-local-tool-ext)\n\n(defn init [api]\n  ((:register-tool api) {:name \"startup-local-tool\"\n                         :description \"tool from startup local-root manifest\"\n                         :format-request (fn [_] \"startup-local-tool\")\n                         :parameters {:type \"object\"}}))\n")
+          {:keys [result]} (bootstrap-with-manifest
+                            {:deps {'psi/test-startup-local-tool-ext {:local/root ext-root
+                                                                      :psi/init 'psi.test.startup-local-tool-ext/init}}}
+                            {})
+          {:keys [ctx summary]} result
+          session-id (-> (ss/list-context-sessions-in ctx) first :session-id)
+          tool-names (set (map :name (:tool-defs (ss/get-session-data-in ctx session-id))))]
+      (is (= 1 (:extension-loaded-count summary)))
+      (is (contains? tool-names "startup-local-tool")))))
+
 (deftest startup-loads-non-local-manifest-extension-via-init-var-test
   (testing "bootstrap startup loads non-local manifest extensions through :psi/init"
     (let [ns-sym 'psi.test.startup-remote-ext


### PR DESCRIPTION
## Summary
- resolve project-local relative `:local/root` extension entries against the project cwd in the launcher
- refresh active session tools after manifest extension activation so manifest-backed tools become usable immediately
- add regression coverage for launcher path resolution and manifest tool activation

## Testing
- `clojure -M:test --focus psi.launcher-test`
- `clojure -M:test --focus psi.extension-install-startup-test`
- `clojure -M:test --focus psi.agent-session.extensions-io-test`
- `clj-kondo --lint bases/main/src/psi/launcher.clj bases/main/test/psi/launcher_test.clj components/agent-session/src/psi/agent_session/extension_runtime.clj components/agent-session/test/psi/agent_session/extensions_io_test.clj components/app-runtime/test/psi/extension_install_startup_test.clj`
