### PR TITLE
⚒ Add looping implement-task workflows

### DIFF
--- a/.psi/workflows/gh-issue-implement.md
+++ b/.psi/workflows/gh-issue-implement.md
@@ -55,10 +55,9 @@ description: Find an implement-labeled PR, prepare its branch worktree, design a
                "DONE" {:goto :next}}}
          {:name "implement"
           :type :delegate
-          :target "builder"
-          :prompt-string {:type :template
-                          :text "Execute the Munera task described by {{design_report}}. Work independently. Use the `clojure-coding-standards` and `testing-without-mocks` skills.\n\nRequired procedure:\n1. Read the upstream handoff to identify the PR number, PR branch, worktree path, and Munera task path.\n2. In the worktree, execute the task autonomously using the refined design as authoritative guidance.\n3. Add or refine `plan.md` only after the design is complete and unambiguous.\n4. Implement in small, reviewable steps.\n5. Keep `design.md`, `plan.md`, `steps.md`, and `implementation.md` synchronized with what was learned and done.\n6. Run relevant verification for the affected area.\n7. Shape the implementation and tests to follow `clojure-coding-standards` and `testing-without-mocks`.\n8. Record any important deviations from the initial design in `implementation.md` so they can be summarized back onto the PR.\n9. At the end of the implementation pass, commit the implementation/task-artifact updates with an appropriate commit message if there are changes to record.\n\nOutput requirements:\n- Output a compact Markdown summary with these headings exactly:\n  - `## Implementation Outcome`\n  - `## Verification`\n  - `## Handoff Data`\n- Under `## Handoff Data`, include machine-friendly bullet lines for:\n  - `pr_number:`\n  - `pr_url:`\n  - `pr_branch:`\n  - `worktree_path:`\n  - `munera_task_path:`\n  - `deviation_summary:`"
-                          :vars {"design_report" {:from {:step "design" :yield :text}}}}
+          :target "implement-task-in-worktree"
+          :prompt-string {:type :map
+                          :fields {:input {:from {:step "design" :yield :text}}}}
           :context [{:type :source
                      :from :workflow-original}
                     {:type :source
@@ -96,4 +95,4 @@ description: Find an implement-labeled PR, prepare its branch worktree, design a
                       :add    ["review"]
                       :target "pr"}}]}
 
-Coordinate implementation work for an existing GitHub PR labeled `implement`: select the PR deterministically, prepare or reuse its branch-specific worktree, rebase the PR branch onto `origin/master`, create and refine a Munera task design with explicit implementation approach detail, implement the task, review and improve the task implementation through the `review-implementation` workflow, then push back to the PR branch, summarize any meaningful deviations from the initial design on the PR, remove the PR's `implement` label, and add the `review` label. All stages use the `work-independently` skill.
+Coordinate implementation work for an existing GitHub PR labeled `implement`: select the PR deterministically, prepare or reuse its branch-specific worktree, rebase the PR branch onto `origin/master`, create and refine a Munera task design with explicit implementation approach detail, implement the task through the looping `implement-task` workflow, review and improve the task implementation through the `review-implementation` workflow, then push back to the PR branch, summarize any meaningful deviations from the initial design on the PR, remove the PR's `implement` label, and add the `review` label. All stages use the `work-independently` skill.

--- a/.psi/workflows/implement-task-in-worktree.md
+++ b/.psi/workflows/implement-task-in-worktree.md
@@ -1,0 +1,39 @@
+---
+name: implement-task-in-worktree
+description: Resolve worktree from a structured handoff, then implement a Munera task via the implement-task workflow
+---
+{:terminal-contract {:handoff {:type :markdown-handoff-data}}
+ :steps [{:name "resolve-worktree"
+          :type :session
+          :tools ["read" "bash" "work-on"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :template
+                           :text "Extract the worktree path and Munera task path from the following handoff data. Call `work-on` with the extracted worktree path to set the session worktree. Then respond with ONLY the Munera task path (e.g. `munera/open/003-foo`) on a single line — nothing else.\n\nHandoff data:\n{{input}}"
+                           :vars {"input" {:from :workflow-input
+                                           :path [:input]}}}]}
+         {:name "implement"
+          :type :delegate
+          :target "implement-task"
+          :prompt-string {:type :map
+                          :fields {:input {:from {:step "resolve-worktree" :yield :text}}}}
+          :context [{:type :source
+                     :from :workflow-original}]}
+         {:name "summary"
+          :type :session
+          :tools ["read" "bash"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :source
+                           :from {:step "implement" :yield :text}}
+                          {:type :template
+                           :text "Produce the user-facing final result for the Munera task. Independently inspect that specific task's artifacts, especially `design.md`, `plan.md`, `steps.md`, and `implementation.md`, and use the prior step outputs as supporting context.\n\nOutput requirements:\n- Output a compact Markdown summary with these headings exactly:\n  - `## Implementation Outcome`\n  - `## Verification`\n  - `## Handoff Data`\n- Under `## Implementation Outcome`, summarize:\n  - whether the implementation loop completed cleanly\n  - the main implementation work completed in this run\n  - the task artifact files updated\n  - any remaining notes or risks explicitly recorded in the task artifacts\n  - any commit ids created during the run that are evident from the provided step outputs\n- Under `## Verification`, summarize the verification performed in this run.\n- Under `## Handoff Data`, include machine-friendly bullet lines for every field you can determine from the provided context and inspected task artifacts. Include these when available:\n  - `pr_number:`\n  - `pr_url:`\n  - `pr_branch:`\n  - `worktree_path:`\n  - `munera_task_path:`\n  - `deviation_summary:`\n\nIf a field is not available, omit it rather than inventing it."
+                           :vars {}}]}]}
+
+Wraps `implement-task` for pipeline use where the input is a structured handoff blob containing `worktree_path:` and `munera_task_path:` fields.
+
+Step 1 extracts the worktree path, calls `work-on` to set the session worktree, and emits the plain task path. Step 2 delegates to `implement-task` which inherits the resolved worktree. Step 3 produces a user-facing summary.
+
+Input shape: `{:input "structured-handoff-text-containing-worktree_path-and-munera_task_path"}`
+
+For interactive use where you're already in the right worktree, use `implement-task` directly.

--- a/.psi/workflows/implement-task.md
+++ b/.psi/workflows/implement-task.md
@@ -1,0 +1,97 @@
+---
+name: implement-task
+description: Repeatedly implement a Munera task in autonomous passes until no concrete implementation work remains
+---
+{:terminal-contract {:handoff {:type :markdown-handoff-data}}
+ :steps [{:name "implement-pass"
+          :type :session
+          :tools ["read" "bash" "edit" "write"]
+          :skills ["work-independently" "clojure-coding-standards" "testing-without-mocks"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :template
+                           :text "Implement the specific Munera task described by {{input}}. Work independently. Read `.psi/skills/work-independently/SKILL.md` and apply it. Also apply `clojure-coding-standards` and `testing-without-mocks` as relevant.
+
+Use the actor-step context to identify the specific task and, when present, the associated `munera_task_path`, `worktree_path`, PR metadata, and other handoff data. Focus only on that task.
+
+Required procedure:
+1. Read the task artifacts, especially `design.md`, `steps.md`, and `implementation.md`, plus `plan.md` when present.
+2. If `plan.md` is missing and the design is complete and unambiguous, create or refine `plan.md` before implementation.
+3. Execute the next concrete implementation slice for the task.
+4. Keep `design.md`, `plan.md`, `steps.md`, and `implementation.md` synchronized with what you learned and changed.
+5. Add or refine tests as required by the task design.
+6. Run relevant verification for the affected area.
+7. Mark completed checklist items done in `steps.md`; add new implementation follow-up items when discovered.
+8. Record important deviations from the initial design tersely in `implementation.md`.
+9. Commit any changes made during this pass with an appropriate commit message.
+10. If the task is already complete or no further concrete implementation work is available, say so explicitly.
+
+End your final response with exactly one of:
+PASS_STATUS: MORE_WORK_REMAINS
+PASS_STATUS: IMPLEMENTATION_COMPLETE"
+                           :vars {"input" {:from :workflow-input}}}]}
+         {:name "implementation-status"
+          :type :session
+          :tools ["read" "bash"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :source
+                           :from {:step "implement-pass" :yield :text}}
+                          {:type :template
+                           :text "Review the specific Munera task described by {{input}} and decide whether implementation work still remains. Independently inspect that task's artifacts, especially `design.md`, `plan.md`, `steps.md`, and `implementation.md`, and use the prior implementation-pass output as supporting context.
+
+Respond with exactly one word: REPEAT or DONE.
+
+Return REPEAT if the task still has remaining unchecked implementation work, unmet acceptance criteria, missing verification, or newly discovered follow-up work that should be executed in another implementation pass.
+
+Return DONE only if the task implementation is complete enough for handoff: the implementation work is done, relevant verification has been run, and the task artifacts do not indicate remaining implementation work.
+
+Do not review the repository generically. Judge only the specific named task from the actor-step context."
+                           :vars {"input" {:from :workflow-input}}}]
+          :judge {:type :llm
+                  :contributions [{:type :template
+                                   :text "Respond exactly with one word: REPEAT or DONE."
+                                   :vars {}}]}
+          :on {"REPEAT" {:goto "implement-pass"
+                          :max-iterations 8}
+               "DONE"   {:goto "final-summary"}}}
+         {:name "final-summary"
+          :type :session
+          :tools ["read" "bash"]
+          :contributions [{:type :source
+                           :from :workflow-original}
+                          {:type :source
+                           :from {:step "implement-pass" :yield :text}}
+                          {:type :template
+                           :text "Produce the user-facing final result for the specific Munera task described by {{input}}. Independently inspect that task's artifacts, especially `design.md`, `plan.md`, `steps.md`, and `implementation.md`, and use the prior implementation-pass output as supporting context.
+
+Output requirements:
+- Output a compact Markdown summary with these headings exactly:
+  - `## Implementation Outcome`
+  - `## Verification`
+  - `## Handoff Data`
+- Under `## Implementation Outcome`, summarize:
+  - whether the implementation loop completed cleanly
+  - the main implementation work completed in this run
+  - the task artifact files updated
+  - any remaining notes or risks explicitly recorded in the task artifacts
+  - any commit ids created during the run that are evident from the provided step outputs
+- Under `## Verification`, summarize the verification performed in this run.
+- Under `## Handoff Data`, include machine-friendly bullet lines for every field you can determine from the actor-step context and inspected task artifacts. Include these when available:
+  - `pr_number:`
+  - `pr_url:`
+  - `pr_branch:`
+  - `worktree_path:`
+  - `munera_task_path:`
+  - `deviation_summary:`
+
+If a field is not available, omit it rather than inventing it."
+                           :vars {"input" {:from :workflow-input}}}]}]}
+
+Repeatedly executes autonomous implementation passes against a specific Munera task until the task appears complete. Each pass performs concrete implementation work, updates task artifacts, runs relevant verification, and commits changes. A control step judges REPEAT or DONE based on the current state of that specific task.
+
+Input shapes:
+- `{:input "munera/open/003-foo"}` for direct use
+- `{:input "structured-handoff-text-containing-munera_task_path-and-optional-worktree/PR-fields"}` for pipeline use
+
+Child sessions inherit the invoking session's worktree — no worktree setup is needed when already in the correct worktree.


### PR DESCRIPTION
## Summary
- add a looping `implement-task` workflow for repeated autonomous Munera task implementation passes
- add `implement-task-in-worktree` for structured worktree handoff symmetry with review workflows
- update `gh-issue-implement` to use the new worktree-aware looping implementation workflow

## Testing
- not run (workflow content only)