### PR TITLE
fix: catch InterruptedException in delayed scheduler thread

### DIFF
--- a/components/agent-session/src/psi/agent_session/context.clj
+++ b/components/agent-session/src/psi/agent_session/context.clj
@@ -219,8 +219,12 @@
    :scheduler-run-after-delay-fn (fn [ctx delay-ms f]
                                    ((:daemon-thread-fn ctx)
                                     (fn []
-                                      (Thread/sleep ^long delay-ms)
-                                      (f))))
+                                      (try
+                                        (Thread/sleep ^long delay-ms)
+                                        (f)
+                                        (catch InterruptedException _
+                                          ;; cancelled via scheduler-cancel-delay-fn — exit silently
+                                          nil)))))
    :scheduler-cancel-delay-fn (fn [_ctx handle]
                                 (when (instance? Thread handle)
                                   (.interrupt ^Thread handle)))

--- a/components/agent-session/test/psi/agent_session/scheduler_timer_seam_test.clj
+++ b/components/agent-session/test/psi/agent_session/scheduler_timer_seam_test.clj
@@ -58,3 +58,42 @@
                             {:origin :core})
       (is (= {:handle :fake} @cancelled*))
       (is (= :cancelled (get-in @(:state* ctx*) [:agent-session :sessions session-id :data :scheduler :schedules "sch-1" :status]))))))
+
+(deftest scheduler-cancelled-default-delay-thread-exits-without-uncaught-interrupted-exception-test
+  (testing "cancelling the default delayed scheduler thread interrupts sleep without leaking an uncaught exception"
+    (let [[ctx session-id] (create-session-context {:persist? false})
+          started-thread*  (atom nil)
+          uncaught*        (atom nil)
+          ctx*             (assoc ctx
+                                  :daemon-thread-fn
+                                  (fn [f]
+                                    (let [thread (Thread. ^Runnable f)]
+                                      (.setDaemon thread true)
+                                      (.setUncaughtExceptionHandler
+                                       thread
+                                       (reify Thread$UncaughtExceptionHandler
+                                         (uncaughtException [_ _ ex]
+                                           (reset! uncaught* ex))))
+                                      (reset! started-thread* thread)
+                                      (.start thread)
+                                      thread)))]
+      (session/dispatch-in! ctx* :scheduler/create
+                            {:session-id session-id
+                             :schedule-id "sch-1"
+                             :label "later"
+                             :message "later"
+                             :fire-at (.plusSeconds (java.time.Instant/now) 5)}
+                            {:origin :core})
+      (dotimes [_ 50]
+        (when-not @started-thread*
+          (Thread/sleep 10)))
+      (is (some? @started-thread*))
+      (session/dispatch-in! ctx* :scheduler/cancel
+                            {:session-id session-id
+                             :schedule-id "sch-1"}
+                            {:origin :core})
+      (.join ^Thread @started-thread* 500)
+      (is (false? (.isAlive ^Thread @started-thread*)))
+      (is (nil? @uncaught*))
+      (is (nil? (get @(:scheduler-timers* ctx*) "sch-1")))
+      (is (= :cancelled (get-in @(:state* ctx*) [:agent-session :sessions session-id :data :scheduler :schedules "sch-1" :status]))))))


### PR DESCRIPTION
## Summary
- catch `InterruptedException` in the default `:scheduler-run-after-delay-fn`
- treat thread interruption from `:scheduler-cancel-delay-fn` as expected cancellation
- avoid noisy background thread failures during delayed schedule cancellation

## Verification
- clojure -M:test -m kaocha --focus psi.agent-session.context-test