### PR TITLE
Keep Emacs cursor in input after prompt completion

### DIFF
--- a/components/emacs-ui/psi-assistant-render.el
+++ b/components/emacs-ui/psi-assistant-render.el
@@ -671,7 +671,11 @@ from the next user prompt."
                  (input-end-after (psi-emacs--draft-end-position))
                  (restored (+ input-start-after (or input-offset 0))))
             (goto-char (max input-start-after (min restored input-end-after))))
-        (goto-char (psi-emacs--transcript-append-position))))))
+        ;; Default completion placement belongs in the editable input area, not
+        ;; at the transcript append boundary.  With a dedicated input separator,
+        ;; `psi-emacs--transcript-append-position' is the separator line start,
+        ;; which made point visibly jump to the divider after some completions.
+        (goto-char (psi-emacs--input-start-position))))))
 
 (defun psi-emacs--assistant-content-kind (value)
   "Return normalized kind/type token for VALUE, or nil."

--- a/components/emacs-ui/test/psi-streaming-transcript-test.el
+++ b/components/emacs-ui/test/psi-streaming-transcript-test.el
@@ -465,9 +465,22 @@ thinking prefix.
            '((:event . "assistant/message")
              (:data . ((:role . "assistant")
                        (:content . [((:type . :text) (:text . "move me"))])))))
-          (should (equal (point-max) (point))))
+          (should (= (psi-emacs--input-start-position) (point))))
       (when (process-live-p (psi-emacs-state-process psi-emacs--state))
         (delete-process (psi-emacs-state-process psi-emacs--state))))))
+
+(ert-deftest psi-assistant-finalize-fallback-does-not-place-point-on-input-separator ()
+  "Finalizing from transcript fallback enters input, not separator."
+  (with-temp-buffer
+    (psi-emacs-mode)
+    (setq-local psi-emacs--state (psi-emacs--initialize-state nil))
+    (psi-emacs--ensure-input-area)
+    (goto-char (point-min))
+    (psi-emacs--handle-rpc-event
+     '((:event . "assistant/message") (:data . ((:text . "done")))))
+    (should (psi-emacs--input-separator-marker-valid-p))
+    (should-not (= (psi-emacs--input-separator-position) (point)))
+    (should (= (psi-emacs--input-start-position) (point)))))
 
 (ert-deftest psi-tool-lifecycle-updates-single-inline-row-by-tool-id ()
   (with-temp-buffer

--- a/mementum/state.md
+++ b/mementum/state.md
@@ -15,6 +15,7 @@ Bootstrapped on 2026-04-02.
 
 ## Current work state
 
+- 2026-05-22: Fixed Emacs prompt-completion cursor fallback so finalization places point in the editable input area instead of the input divider line; added regression coverage; `bb emacs:test --focus psi-streaming-transcript-test` ran 308/308 green.
 - 2026-05-22: Executed task 166 code-shaper follow-up: extracted shared assistant streaming optimization instrumentation helper while preserving distinct behavior assertions; focused streaming suite 36/36 and `bb emacs:test` 307/307 green.
 - 2026-05-22: Executed task 166 test-shaper follow-up: split the combined assistant append optimization proof into separate incremental-delta, cumulative-snapshot, and divergent-merge tests; focused streaming suite 36/36 and `bb emacs:test` 307/307 green.
 - 2026-05-22: Executed task 166 repeated test-review follow-up after no-action review; no new unchecked steps existed, so only implementation.md was updated.


### PR DESCRIPTION
## Summary
- keep assistant finalization fallback point placement in the editable input area
- avoid placing point at the input divider/transcript append boundary
- add regression coverage for finalization from outside the input area

## Verification
- bb emacs:test --focus psi-streaming-transcript-test
