### PR TITLE
feat(child-session): seed child journal at spawn via config.seed_entries.delegation

### DIFF
--- a/components/agent-session/src/psi/agent_session/child_session_state.clj
+++ b/components/agent-session/src/psi/agent_session/child_session_state.clj
@@ -99,10 +99,10 @@
 
 (defn initialize-child-session-state
   [state* parent-sd {:keys [child-session-id preloaded-messages] :as child-opts}]
-  (let [child-sd (child-session-base-state parent-sd child-opts)]
+  (let [child-sd (child-session-base-state parent-sd child-opts)
+        preloaded-journal (mapv persistence/message-entry (or preloaded-messages []))]
     (-> state*
         (assoc-in (state/session-data-path child-session-id) child-sd)
-        (assoc-in [:agent-session :sessions child-session-id :persistence]
-                  (persistence/persistence-state
-                   {:journal (mapv persistence/message-entry (or preloaded-messages []))}))
-        (init/initialize-session-slots child-session-id []))))
+        ;; initialize-session-slots overwrites :persistence :journal with its
+        ;; journal-entries arg — pass preloaded entries directly so they survive.
+        (init/initialize-session-slots child-session-id preloaded-journal))))

--- a/spec/session-management.allium
+++ b/spec/session-management.allium
@@ -138,6 +138,26 @@ rule SpawnedSessionInheritsThenDiverges {
     ensures: ParentAndChildConfigsCanDivergeAfterSpawn(parent.id, child.id)
 }
 
+rule SeedChildJournalAtSpawn {
+    when: CreateChildSession(context_id, parent_session_id, relation, config)
+    requires: config.preloaded_messages != null
+    requires: config.preloaded_messages.count > 0
+
+    ensures: child.journal = config.preloaded_messages
+    ensures: child.leaf_entry_id = LastEntryId(config.preloaded_messages)
+
+    @guidance
+        -- Callers supply preloaded_messages to pre-populate the child journal
+        -- before any user or assistant turns. This is the open extension point
+        -- for workflow step contributions: the workflow layer assembles prior
+        -- messages (DeltaMap, codebase structure, tier selection, etc.) as
+        -- SessionEntry values and passes them via config.preloaded_messages.
+        -- Parallel paths: SessionLoaded seeds from disk (resume),
+        -- ForkedSessionFileCreated seeds branch_entries (fork).
+        -- This rule covers the agent-spawn path.
+        -- preloaded_messages is optional — absence means empty journal (default behaviour).
+}
+
 rule WorkflowChildSessionPromptRebuiltFromStructuredState {
     when: CreateChildSession(context_id, parent_session_id, relation, config)
     requires: relation in {agent, automation}


### PR DESCRIPTION
Adds a generic extensibility mechanism so third-party extensions can load without requiring a hardcoded entry in psi-owned-extension-catalog:

- compute-install-state gains optional extra-deps param ({lib dep}) — merged as :extra scope, lower priority than user/project manifest entries.
- runtime-fns gains :contribute-manifest — extension init fns call this to queue {lib dep} entries contributed programmatically during the boot cycle.
- bootstrap-manifest-extensions-in! runs a second compute+activate pass when any extra deps were contributed, so contributed extensions load in the same boot cycle.

No behaviour change for existing psi-owned extensions. Any extension can now be distributed as a separate repo and loaded via inline :psi/init in the user or project extensions.edn without a catalog entry.