### PR TITLE
⚒ Include base resources in base deps

### DIFF
--- a/bases/main/deps.edn
+++ b/bases/main/deps.edn
@@ -1,2 +1,3 @@
-{:deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        psi/app-runtime     {:local/root "../../components/app-runtime"}}}
+{:paths ["src" "resources"]
+ :deps  {org.clojure/clojure {:mvn/version "1.12.0"}
+         psi/app-runtime     {:local/root "../../components/app-runtime"}}}


### PR DESCRIPTION
## Summary
- Add `resources` to `bases/main/deps.edn` paths so base-local/resource-derived runtime launches include packaged resources.
- Ensures built-in packaged skills under `bases/main/resources/psi/skills` are visible when the base deps are used directly.

## Verification
- Commit hook ran `cljfmt fix` and `clj-kondo lint` successfully.
