### PR TITLE
⚒ docs: improve README, CLI, and Emacs UI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,21 +113,6 @@ Frontend contributors: see
 For TUI login flow, in-session commands, and runtime behavior, see:
 - [`doc/tui.md`](doc/tui.md)
 
-### Workflows
-
-For user-facing workflow usage, workflow file location, `/delegate`, reload
-behavior, and workflow-run retention/cleanup behavior, see:
-- [`doc/workflows.md`](doc/workflows.md)
-
-Project workflows include autonomous simplification helpers: `/delegate
-reduce-incidental-complexity` for function/executable-unit incidental complexity
-and `/delegate reduce-architectural-complexity` for namespace/family/pair/community
-architecture targets selected by Gordian.
-
-Completed workflow runs are retained per originating session and older runs are
-cleaned up automatically; retention is configurable. See
-[`doc/workflows.md`](doc/workflows.md).
-
 ### Model controls
 
 Interactive sessions support `/speed` for provider throughput-tier selection and
@@ -144,10 +129,6 @@ reference, runtime scoped setters, outbound model API proxy environment variable
 - [`doc/configuration.md`](doc/configuration.md)
 - [`doc/custom-providers.md`](doc/custom-providers.md)
 
-## Developer documentation
-
-The sections below cover extending psi, runtime introspection, and internals.
-
 ### Built-in Tools
 
 `read` `bash` `edit` `write` `psi-tool`
@@ -161,11 +142,47 @@ The sections below cover extending psi, runtime introspection, and internals.
 - `scheduler` — delayed one-shot work via explicit `create|list|cancel`, including both delayed same-session prompts and delayed fresh top-level session creation
 - `operation` — list and invoke registered deterministic operations via explicit `list|invoke`
 
-See:
-- [`doc/psi-project-config.md`](doc/psi-project-config.md) for query/mutate/reload examples and worktree-authoritative reload targeting rules, including the recommended self-reload loop
-- [`doc/graph-surface.md`](doc/graph-surface.md) for graph discovery, root-queryable attrs, and session inventory discovery surfaces
-- [`doc/scheduler.md`](doc/scheduler.md) for scheduler kinds, session-config support, status semantics, and introspection attrs
-- [`doc/operations.md`](doc/operations.md) for the deterministic-operation `list`/`invoke` request shapes, params, all-key + 2000-char truncation rendering, and error surfacing (both the psi-tool action and the `/operations` / `/operation` commands)
+### Project nREPL
+
+For direct project-local REPL support distinct from psi's own runtime nREPL, see:
+- [`doc/project-nrepl.md`](doc/project-nrepl.md)
+
+### Workflows
+
+For user-facing workflow usage, workflow file location, `/delegate`, reload
+behavior, and workflow-run retention/cleanup behavior, see:
+- [`doc/workflows.md`](doc/workflows.md)
+
+Project workflows include autonomous simplification helpers: `/delegate
+reduce-incidental-complexity` for function/executable-unit incidental complexity
+and `/delegate reduce-architectural-complexity` for namespace/family/pair/community
+architecture targets selected by Gordian.
+
+Completed workflow runs are retained per originating session and older runs are
+cleaned up automatically; retention is configurable. See
+[`doc/workflows.md`](doc/workflows.md).
+
+## Extensions
+
+Extensions customise psi by adding tools, commands, event handlers, and UI.
+Built-in extensions that ship with this repo (activated via
+`.psi/extensions.edn`):
+
+- **mcp-tasks-run** — run mcp-tasks task/story workflows with sub-agent
+  execution per step (`/mcp-tasks-run`).
+- **commit-checks** — run project-local checks after a local commit and feed
+  failures back into the session.
+- **metrics** — accumulate persistent per-capability usage counters (`/metrics`).
+- **plan-state-learning** — update `munera/plan.md` and `mementum/state.md`
+  after non-PSL commits (`/psl`).
+- **hello-ext** — minimal example extension used in docs and tests (`/hello`).
+
+For the extension list, configuration, and authoring details, see:
+- [`doc/extensions.md`](doc/extensions.md)
+
+## Developer documentation
+
+The sections below cover extending psi, runtime introspection, and internals.
 
 ### Extension API
 
@@ -194,27 +211,40 @@ Project-local extension/config examples in this repo include:
 
 ### Architecture
 
-For architecture overview, components, EQL introspection guidance, and roadmap, see:
+For architecture overview, components, EQL introspection guidance, and
+roadmap, see:
 - [`doc/architecture.md`](doc/architecture.md)
 
 ### Graph discovery
 
-For the session-root graph discovery surface (`:psi.graph/*`), canonical discovery
-workflow, and graph semantics, see:
+For the session-root graph discovery surface (`:psi.graph/*`), canonical
+discovery workflow, and graph semantics, see:
 - [`doc/graph-surface.md`](doc/graph-surface.md)
 
-For prompt lifecycle introspection summaries and normalized prompt-turn attrs, see:
+For prompt lifecycle introspection summaries and normalized prompt-turn
+attrs, see:
 - [`doc/architecture.md`](doc/architecture.md)
 
 ### ψ Psi project config
 
-Project query/config tool details:
+Project query/config tool details, for query/mutate/reload examples and
+worktree-authoritative reload targeting rules, including the recommended
+self-reload loop:
 - [`doc/psi-project-config.md`](doc/psi-project-config.md)
 
-### Project nREPL
+### Scheduler
 
-For direct project-local REPL support distinct from psi's own runtime nREPL, see:
-- [`doc/project-nrepl.md`](doc/project-nrepl.md)
+For scheduler kinds, session-config support, status semantics, and
+introspection attrs:
+- [`doc/scheduler.md`](doc/scheduler.md)
+
+### Determinisitc Operations
+
+for the deterministic-operation `list`/`invoke` request shapes, params,
+all-key + 2000-char truncation rendering, and error surfacing (both the
+psi-tool action and the `/operations` / `/operation` commands)
+- [`doc/operations.md`](doc/operations.md)
+
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -168,14 +168,15 @@ Extensions customise psi by adding tools, commands, event handlers, and UI.
 Built-in extensions that ship with this repo (activated via
 `.psi/extensions.edn`):
 
-- **mcp-tasks-run** — run mcp-tasks task/story workflows with sub-agent
-  execution per step (`/mcp-tasks-run`).
 - **commit-checks** — run project-local checks after a local commit and feed
   failures back into the session.
+- **edit-clj** — structural Clojure/EDN editing tool that replaces whole forms
+  by structural equality (`edit-clj`).
+- **mementum** — git-based memory protocol: memories, knowledge, and
+  working-memory `state.md`.
 - **metrics** — accumulate persistent per-capability usage counters (`/metrics`).
-- **plan-state-learning** — update `munera/plan.md` and `mementum/state.md`
-  after non-PSL commits (`/psl`).
-- **hello-ext** — minimal example extension used in docs and tests (`/hello`).
+- **munera** — git-native Markdown task protocol (design → plan → implement →
+  review) under `munera/`.
 
 For the extension list, configuration, and authoring details, see:
 - [`doc/extensions.md`](doc/extensions.md)

--- a/README.md
+++ b/README.md
@@ -104,31 +104,14 @@ For CLI flags, launcher-only flags, environment variables, and switch behavior, 
 
 For keybindings, rendering behavior, and reconnect semantics, see:
 - [`doc/emacs-ui.md`](doc/emacs-ui.md)
-- [`doc/emacs-ui-development.md`](doc/emacs-ui-development.md) for frontend developer checks
+
+Frontend contributors: see
+[`doc/emacs-ui-development.md`](doc/emacs-ui-development.md).
 
 ### TUI usage
 
 For TUI login flow, in-session commands, and runtime behavior, see:
 - [`doc/tui.md`](doc/tui.md)
-
-### Built-in Tools
-
-`read` `bash` `edit` `write` `psi-tool`
-
-`psi-tool` is the live runtime introspection/modification tool with canonical action-based requests:
-- `query` — EQL graph reads
-- `eval` — in-process ψ namespace-scoped Clojure eval
-- `mutate` — invoke registered runtime mutations with structured success/error reports
-- `reload-code` — explicit namespace/worktree code reload with distinct reload and graph-refresh reporting
-- `project-repl` — managed project REPL status/start/attach/stop/eval/interrupt operations with structured reports
-- `scheduler` — delayed one-shot work via explicit `create|list|cancel`, including both delayed same-session prompts and delayed fresh top-level session creation
-- `operation` — list and invoke registered deterministic operations via explicit `list|invoke`
-
-See:
-- [`doc/psi-project-config.md`](doc/psi-project-config.md) for query/mutate/reload examples and worktree-authoritative reload targeting rules, including the recommended self-reload loop
-- [`doc/graph-surface.md`](doc/graph-surface.md) for graph discovery, root-queryable attrs, and session inventory discovery surfaces
-- [`doc/scheduler.md`](doc/scheduler.md) for scheduler kinds, session-config support, status semantics, and introspection attrs
-- [`doc/operations.md`](doc/operations.md) for the deterministic-operation `list`/`invoke` request shapes, params, all-key + 2000-char truncation rendering, and error surfacing (both the psi-tool action and the `/operations` / `/operation` commands)
 
 ### Workflows
 
@@ -153,6 +136,36 @@ reusable model/thinking/speed/effort settings for interactive selection
 (`/session-profile`) and workflow steps (`:session-profile`); see
 [`doc/tui.md`](doc/tui.md), [`doc/configuration.md`](doc/configuration.md), and
 [`doc/workflows.md`](doc/workflows.md).
+
+## Configuration
+
+Config file locations, precedence (session > project-local > project-shared > user > system), settings
+reference, runtime scoped setters, outbound model API proxy environment variables, and custom provider setup:
+- [`doc/configuration.md`](doc/configuration.md)
+- [`doc/custom-providers.md`](doc/custom-providers.md)
+
+## Developer documentation
+
+The sections below cover extending psi, runtime introspection, and internals.
+
+### Built-in Tools
+
+`read` `bash` `edit` `write` `psi-tool`
+
+`psi-tool` is the live runtime introspection/modification tool with canonical action-based requests:
+- `query` — EQL graph reads
+- `eval` — in-process ψ namespace-scoped Clojure eval
+- `mutate` — invoke registered runtime mutations with structured success/error reports
+- `reload-code` — explicit namespace/worktree code reload with distinct reload and graph-refresh reporting
+- `project-repl` — managed project REPL status/start/attach/stop/eval/interrupt operations with structured reports
+- `scheduler` — delayed one-shot work via explicit `create|list|cancel`, including both delayed same-session prompts and delayed fresh top-level session creation
+- `operation` — list and invoke registered deterministic operations via explicit `list|invoke`
+
+See:
+- [`doc/psi-project-config.md`](doc/psi-project-config.md) for query/mutate/reload examples and worktree-authoritative reload targeting rules, including the recommended self-reload loop
+- [`doc/graph-surface.md`](doc/graph-surface.md) for graph discovery, root-queryable attrs, and session inventory discovery surfaces
+- [`doc/scheduler.md`](doc/scheduler.md) for scheduler kinds, session-config support, status semantics, and introspection attrs
+- [`doc/operations.md`](doc/operations.md) for the deterministic-operation `list`/`invoke` request shapes, params, all-key + 2000-char truncation rendering, and error surfacing (both the psi-tool action and the `/operations` / `/operation` commands)
 
 ### Extension API
 
@@ -179,12 +192,12 @@ Project-local extension/config examples in this repo include:
 - `bb commit-check:file-lengths`
 - `bb commit-check:dispatch-architecture`
 
-## Architecture
+### Architecture
 
 For architecture overview, components, EQL introspection guidance, and roadmap, see:
 - [`doc/architecture.md`](doc/architecture.md)
 
-## Graph discovery
+### Graph discovery
 
 For the session-root graph discovery surface (`:psi.graph/*`), canonical discovery
 workflow, and graph semantics, see:
@@ -193,19 +206,12 @@ workflow, and graph semantics, see:
 For prompt lifecycle introspection summaries and normalized prompt-turn attrs, see:
 - [`doc/architecture.md`](doc/architecture.md)
 
-## Configuration
-
-Config file locations, precedence (session > project-local > project-shared > user > system), settings
-reference, runtime scoped setters, outbound model API proxy environment variables, and custom provider setup:
-- [`doc/configuration.md`](doc/configuration.md)
-- [`doc/custom-providers.md`](doc/custom-providers.md)
-
-## ψ Psi project config
+### ψ Psi project config
 
 Project query/config tool details:
 - [`doc/psi-project-config.md`](doc/psi-project-config.md)
 
-## Project nREPL
+### Project nREPL
 
 For direct project-local REPL support distinct from psi's own runtime nREPL, see:
 - [`doc/project-nrepl.md`](doc/project-nrepl.md)

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ For CLI flags, launcher-only flags, environment variables, and switch behavior, 
 
 ### Emacs UI usage
 
-For keybindings, rendering behavior, reconnect semantics, and developer checks, see:
+For keybindings, rendering behavior, and reconnect semantics, see:
 - [`doc/emacs-ui.md`](doc/emacs-ui.md)
+- [`doc/emacs-ui-development.md`](doc/emacs-ui-development.md) for frontend developer checks
 
 ### TUI usage
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Extensions customise psi by adding tools, commands, event handlers, and UI.
 Built-in extensions that ship with this repo (activated via
 `.psi/extensions.edn`):
 
+- **auto-session-name** — derive a session name automatically from early
+  conversation context.
 - **commit-checks** — run project-local checks after a local commit and feed
   failures back into the session.
 - **edit-clj** — structural Clojure/EDN editing tool that replaces whole forms

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,6 +1,7 @@
 # CLI Reference
 
-psi now has a launcher-owned canonical CLI surface.
+This reference covers the `psi` command-line surface for end users, with
+contributor-specific notes called out where they apply.
 
 ## Canonical usage
 
@@ -12,24 +13,24 @@ The launcher constructs startup basis data before `psi.main` starts.
 That means user/project extension manifests participate in classpath and
 extension availability before the JVM launches.
 
+## Launcher realization policy
+
+The realization policy controls how psi and psi-owned extensions are resolved
+at startup. The launcher selects a policy from the startup artifact layout:
+a packaged artifact (no source-tree resource root) selects `jar`, and a
+source/repo layout selects `installed`.
+
+| Policy | Selected when | How psi is resolved |
+|--------|---------------|---------------------|
+| `jar` | Running from a packaged artifact (released builds) | Single `org.hugoduncan/psi` Maven coordinate from Clojars |
+| `installed` | Running from a source/repo layout (unreleased/git installs) | Local paths relative to the launcher root (git checkout) |
+| `development` | Contributor/repo-local flows | Local paths relative to the launcher root (source tree) |
+
 Under `jar` policy, the launcher reads psi's shipped runtime dependency closure
 from jar-owned release metadata packaged inside `org.hugoduncan/psi`, rather
 than reconstructing psi's own runtime basis from repo-local component layout.
 Psi-owned runtime source/resource trees are packaged in the published jar, while
 user/project extension manifests layer additively on top.
-
-Launcher realization policy controls how psi and psi-owned extensions are
-resolved at startup. Three policies exist:
-
-| Policy | When used | How psi is resolved |
-|--------|-----------|---------------------|
-| `jar` | Default for released versions | Single `org.hugoduncan/psi` Maven coordinate from Clojars — fast, cached |
-| `installed` | Default for unreleased/git installs | Local paths relative to the launcher root (git checkout) |
-| `development` | Contributor/repo-local flows | Local paths relative to the launcher root (source tree) |
-
-Auto-detection: when running from a packaged artifact (no source-tree resource
-root), the launcher defaults to `:jar` policy. When running from source/repo
-layout, it defaults to `:installed`.
 
 Override with `PSI_LAUNCHER_POLICY`:
 
@@ -77,9 +78,12 @@ These are consumed by the launcher and are **not** forwarded to `psi.main`.
 
 - `--cwd <path>`
   - Override the working directory used for project manifest lookup and the launched psi process.
+  - Use this to run psi against a project directory other than the shell's current directory.
 - `--launcher-debug`
   - Print a pre-launch summary of cwd, manifest presence, merged manifest libs,
     psi-owned defaults, inferred `:psi/init` usage, and basis summary.
+  - Use this to troubleshoot startup, such as the selected realization policy,
+    a missing project manifest, or unexpected extension availability.
 
 ## Forwarded psi runtime flags
 
@@ -103,6 +107,7 @@ All other flags are forwarded unchanged to `psi.main`.
 
 - `--model <key>`
   - Select model key (same keys as `psi.ai.models/all-models`).
+  - In TUI mode, the `/model` command lists the available model keys.
   - Falls back to `PSI_MODEL` when not provided.
 - `--log-level <LEVEL>`
   - Set Timbre minimum level.
@@ -171,8 +176,8 @@ psi --nrepl 7888
 # TUI + nREPL
 psi --tui --nrepl
 
-# Pick model key
-psi --model sonnet-4.6
+# Pick model key (list available keys with /model in TUI mode)
+psi --model <model-key>
 
 # Memory retention
 psi --memory-store in-memory \

--- a/doc/emacs-ui-development.md
+++ b/doc/emacs-ui-development.md
@@ -1,0 +1,13 @@
+# Emacs UI development
+
+For contributors working on the Emacs frontend at `components/emacs-ui/`. For
+user-facing setup and usage, see [`emacs-ui.md`](emacs-ui.md).
+
+## Developer checks
+
+From repo root:
+
+- `bb emacs:test` (loads the split frontend suites, including `psi-buffer-lifecycle-test.el`, `psi-dispatch-test.el`, `psi-streaming-transcript-test.el`, `psi-tool-output-mode-test.el`, `psi-extension-ui-test.el`, `psi-capf-test.el`, and `psi-session-tree-test.el`)
+- `bb emacs:e2e` (live end-to-end harness against `psi --rpc-edn`)
+- `bb emacs:byte-compile`
+- `bb emacs:check`

--- a/doc/emacs-ui.md
+++ b/doc/emacs-ui.md
@@ -1,7 +1,13 @@
 # Emacs UI (rpc-edn)
 
+This guide is for Emacs users who want to drive psi from within Emacs, and for
+contributors working on the frontend (see [Developer checks](#developer-checks)).
+
 The repository includes an Emacs frontend at `components/emacs-ui/` that runs
-psi in a dedicated process buffer over rpc-edn.
+psi in a dedicated process buffer over rpc-edn. Running psi as an owned
+subprocess per buffer keeps each session isolated, and rpc-edn gives the
+frontend a structured channel for streaming output and commands rather than
+raw terminal text.
 
 ## Install (straight.el)
 
@@ -25,7 +31,9 @@ This installs the Emacs frontend files from the repo and makes
 ## Start
 
 1. Install the canonical psi launcher so `psi` is available on `PATH`.
-2. In Emacs, add `components/emacs-ui` to `load-path` and load `psi.el`.
+2. Load the frontend. The [straight.el install](#install-straightel) above
+   handles `load-path` and `(require 'psi)` for you. Without straight.el, add
+   `components/emacs-ui` to `load-path` and load `psi.el` manually.
 3. Run one of:
    - `M-x psi-emacs-start` for the default/global buffer.
      - Use `C-u M-x psi-emacs-start` to force a fresh buffer name (`*psi*<2>`, etc.).
@@ -42,6 +50,40 @@ owned subprocess per dedicated buffer using:
 
 By default, the subprocess runs in the directory where `psi-emacs-start` is
 invoked. Override explicitly via `psi-emacs-working-directory` if needed.
+
+## Compose and keybindings
+
+In `psi-emacs-mode`:
+
+- `RET` inserts newline (never sends)
+- `C-c RET` send prompt
+  - slash-prefixed input always uses backend `command`
+  - while streaming, non-slash input uses steer (`prompt_while_streaming` with `behavior=steer`)
+- `C-u C-c RET` queue override for non-slash streaming input
+- `C-c C-q` queue while streaming for non-slash input; slash-prefixed input still uses backend `command`; fallback to normal send when idle
+- `M-p` navigate to older input history entry
+- `M-n` navigate to newer input history entry (or recover stash after `M-p`)
+- `M-r` search input history via completing-read (`M-x psi-emacs-search-input-history`);
+  selecting an entry stashes the current draft and populates the input area;
+  `C-g` or empty-string cancels without changing input or navigation state
+- `C-c C-k` abort active streaming (`abort`)
+- `C-c C-r` reconnect (prompts before clearing edited buffer)
+- `C-c C-t` toggle tool-output view mode (collapsed ↔ expanded); also available as `M-x psi-emacs-toggle-tool-output-view`
+- `C-c C-e` move point to the end of the current psi prompt entry area (`M-x psi-emacs-move-point-to-prompt-end`)
+- `C-c m m` set model (`M-x psi-emacs-set-model`)
+- `C-c m n` cycle model next (`M-x psi-emacs-cycle-model-next`)
+- `C-c m p` cycle model previous (`M-x psi-emacs-cycle-model-prev`)
+- `C-c m t` set thinking level (`M-x psi-emacs-set-thinking-level`)
+- `C-c m c` cycle thinking level (`M-x psi-emacs-cycle-thinking-level`)
+
+Compose source rules determine which buffer text psi sends. Because the
+transcript and the input share one buffer, a draft anchor marks where the
+current input begins so earlier transcript text is not resent by accident:
+
+- Active region sends region text (for both `C-c RET` and `C-c C-q`).
+- Without a region, psi sends the tail draft block from the draft anchor marker to end-of-buffer.
+- Normal editing keeps the anchor at the start of the current draft tail, so transcript text above the anchor is not resent unless you explicitly select it as a region.
+- Reconnect clear (`C-c C-r` after confirmation) resets the buffer and repositions the draft anchor at the new buffer end; after reconnect, sends come only from text typed after that reset point.
 
 ## Customizing `psi-emacs-command`
 
@@ -75,42 +117,9 @@ Customize `psi-emacs-stream-timeout-seconds` to change the frontend watchdog.
 
 ## Developer checks
 
-From repo root:
+For contributors working on the frontend. From repo root:
 
 - `bb emacs:test` (loads the split frontend suites, including `psi-buffer-lifecycle-test.el`, `psi-dispatch-test.el`, `psi-streaming-transcript-test.el`, `psi-tool-output-mode-test.el`, `psi-extension-ui-test.el`, `psi-capf-test.el`, and `psi-session-tree-test.el`)
 - `bb emacs:e2e` (live end-to-end harness against `psi --rpc-edn`)
 - `bb emacs:byte-compile`
 - `bb emacs:check`
-
-## Compose and keybindings
-
-In `psi-emacs-mode`:
-
-- `RET` inserts newline (never sends)
-- `C-c RET` send prompt
-  - slash-prefixed input always uses backend `command`
-  - while streaming, non-slash input uses steer (`prompt_while_streaming` with `behavior=steer`)
-- `C-u C-c RET` queue override for non-slash streaming input
-- `C-c C-q` queue while streaming for non-slash input; slash-prefixed input still uses backend `command`; fallback to normal send when idle
-- `M-p` navigate to older input history entry
-- `M-n` navigate to newer input history entry (or recover stash after `M-p`)
-- `M-r` search input history via completing-read (`M-x psi-emacs-search-input-history`);
-  selecting an entry stashes the current draft and populates the input area;
-  `C-g` or empty-string cancels without changing input or navigation state
-- `C-c C-k` abort active streaming (`abort`)
-- `C-c C-r` reconnect (prompts before clearing edited buffer)
-- `C-c C-t` toggle tool-output view mode (collapsed ↔ expanded); also available as `M-x psi-emacs-toggle-tool-output-view`
-- `C-c C-e` move point to the end of the current psi prompt entry area (`M-x psi-emacs-move-point-to-prompt-end`)
-- `C-c m m` set model (`M-x psi-emacs-set-model`)
-- `C-c m n` cycle model next (`M-x psi-emacs-cycle-model-next`)
-- `C-c m p` cycle model previous (`M-x psi-emacs-cycle-model-prev`)
-- `C-c m t` set thinking level (`M-x psi-emacs-set-thinking-level`)
-- `C-c m c` cycle thinking level (`M-x psi-emacs-cycle-thinking-level`)
-- `M-x psi-emacs-move-point-to-prompt-end` move point to the end of the current psi prompt entry area
-
-Compose source rules:
-
-- Active region sends region text (for both `C-c RET` and `C-c C-q`).
-- Without a region, psi sends the tail draft block from the draft anchor marker to end-of-buffer.
-- Normal editing keeps the anchor at the start of the current draft tail, so transcript text above the anchor is not resent unless you explicitly select it as a region.
-- Reconnect clear (`C-c C-r` after confirmation) resets the buffer and repositions the draft anchor at the new buffer end; after reconnect, sends come only from text typed after that reset point.

--- a/doc/emacs-ui.md
+++ b/doc/emacs-ui.md
@@ -1,7 +1,8 @@
 # Emacs UI (rpc-edn)
 
-This guide is for Emacs users who want to drive psi from within Emacs, and for
-contributors working on the frontend (see [Developer checks](#developer-checks)).
+This guide is for Emacs users who want to drive psi from within Emacs.
+Contributors working on the frontend should see
+[`emacs-ui-development.md`](emacs-ui-development.md).
 
 The repository includes an Emacs frontend at `components/emacs-ui/` that runs
 psi in a dedicated process buffer over rpc-edn. Running psi as an owned
@@ -115,11 +116,7 @@ Requirement: command must launch psi in rpc-edn mode (include `--rpc-edn`).
 Streaming stall detection defaults to 600 seconds (10 minutes) in Emacs.
 Customize `psi-emacs-stream-timeout-seconds` to change the frontend watchdog.
 
-## Developer checks
+## Contributing
 
-For contributors working on the frontend. From repo root:
-
-- `bb emacs:test` (loads the split frontend suites, including `psi-buffer-lifecycle-test.el`, `psi-dispatch-test.el`, `psi-streaming-transcript-test.el`, `psi-tool-output-mode-test.el`, `psi-extension-ui-test.el`, `psi-capf-test.el`, and `psi-session-tree-test.el`)
-- `bb emacs:e2e` (live end-to-end harness against `psi --rpc-edn`)
-- `bb emacs:byte-compile`
-- `bb emacs:check`
+For frontend developer checks (test suites, byte-compile, e2e harness), see
+[`emacs-ui-development.md`](emacs-ui-development.md).


### PR DESCRIPTION
## Summary

Documentation-only improvements across README and `doc/`.

- **README**: reorder so user docs precede developer docs; add a `## Extensions`
  section listing built-in extensions (auto-session-name, commit-checks,
  edit-clj, mementum, metrics, munera) with a link to `doc/extensions.md`.
- **Emacs UI**: declare audience, add the *why* to user sections, fix an
  Install↔Start `load-path` contradiction, remove a duplicate keybinding,
  reorder (Compose → Customizing → Contributing), and split frontend developer
  checks into new `doc/emacs-ui-development.md`.
- **CLI**: clarify launcher policy ordering and flag rationale, state audience,
  remove superlative.

## Scope

Docs only — no code or behaviour changes. Rebased on latest `master`.

🤖 Authored with psi