### PR TITLE
Improve review steps

### DIFF
--- a/.psi/workflows/review-step.edn
+++ b/.psi/workflows/review-step.edn
@@ -7,7 +7,7 @@
    [{:type :source, :from :workflow-original}
     {:type :template,
      :text
-     "Review the Munera task at {{input}} using the {{skill}} skill. Work independently. Read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. append a terse review note to the task's implementation.md\n2. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n3. avoid duplicating review notes or steps that already exist\n4. commit\n5. end your response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: REVIEW_COMPLETE",
+     "Review the Munera task at {{input}} using the {{skill}} skill. Work independently. Read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n2. append a terse review note to the task's implementation.md. Do not note compliance with these instructions; only note any non-compliance. Avoid duplicating information that is in the steps.md updatate\n3. avoid duplicating review notes or steps that already exist\n4. commit.\n5. End your response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: REVIEW_COMPLETE",
      :vars {"input" {:from :workflow-input, :path [:input]},
             "skill" {:from :workflow-input, :path [:skill]}}}],
    :judge {:type :invoke

--- a/.psi/workflows/review-task-design-ambiguity-review.md
+++ b/.psi/workflows/review-task-design-ambiguity-review.md
@@ -14,7 +14,8 @@ For the Munera task identified by {{input}}, run the ambiguity review as the sec
 
 Review the task design for ambiguities. Do not review plan.md or steps.md. Then:
 
-1. append a terse review note to the task's implementation.md
+1. append a terse review note on the outcome of the review to the task's implementation.md
+1a. Do not note compliance with these instructions; only note any non-compliance
 2. add unchecked follow-up items to design-steps.md for every new actionable ambiguity you found (create design-steps.md if it does not exist)
 3. avoid duplicating review notes or steps that already exist
 4. commit

--- a/.psi/workflows/review-task-design-inconsistency-review.md
+++ b/.psi/workflows/review-task-design-inconsistency-review.md
@@ -14,7 +14,8 @@ For the Munera task identified by {{input}}, run the inconsistency review as the
 
 Review the task design for inconsistencies, focusing on internal inconsistency within design.md and between design.md and referenced artifacts. Do not review plan.md or steps.md. Then:
 
-1. append a terse review note to the task's implementation.md
+1. append a terse review note on the outcome of the review to the task's implementation.md
+1a. Do not note compliance with these instructions; only note any non-compliance
 2. add unchecked follow-up items to design-steps.md for every new actionable inconsistency you found (create design-steps.md if it does not exist)
 3. avoid duplicating review notes or steps that already exist
 4. commit


### PR DESCRIPTION
## Summary

Small wording/ordering improvements to the review workflow prompts:

- **`review-step.edn`** — reorder the review step's instructions so follow-up items are added to `steps.md` *before* the terse `implementation.md` note, and tighten the note guidance ("Do not note compliance with these instructions; only note any non-compliance"; avoid duplicating information already captured in the `steps.md` updates).
- **`review-task-design-ambiguity-review.md`** / **`review-task-design-inconsistency-review.md`** — clarify the review note is "on the outcome of the review", and add the same compliance-noting guidance (`1a. Do not note compliance with these instructions; only note any non-compliance`).

No behavioural/routing changes; prompt-body wording only.

## Test plan
- `clojure -M:test-paths -m scry.cli --ns psi.workflow-loader.workflow-definitions-test --ns psi.workflow-loader.workflow-review-prompt-contract-test` — 15 tests, 303 assertions pass (terminal `PASS_STATUS` menu contracts still hold).
