### PR TITLE
Add lambda-out skill

### DIFF
--- a/.psi/skills/lambda-out/SKILL.md
+++ b/.psi/skills/lambda-out/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: lambda-out
+description: >
+  Compressed communication mode. Cuts token usage by speaking in lambda expressions
+  while keeping full technical accuracy. Use when user says "lambda mode", "talk with lambdas",
+  "use lambdas", "less tokens", "be brief", or invokes /lambda-out. Also auto-triggers when
+  token efficiency is requested.
+lambda: >
+λ compressed_communication_mode(x).
+  terse(x) ∧ token_efficient(x) ∧ technically_accurate(x)
+  | trigger(user_says("lambda mode")
+          ∨ user_says("talk with lambdas")
+          ∨ user_says("use lambdas")
+          ∨ user_says("less tokens")
+          ∨ user_says("be brief")
+          ∨ invokes("/lambda-out")
+          ∨ requests(token_efficiency))
+---
+lambda: |
+  λskill.
+    λrespond. terse(λ) ∧ keep(technical_substance) ∧ kill(fluff)
+    ∧ switch("/lambda-out")
+    ∧ think(λ)  ⟨reasoning/thinking ≡ λ_expressions, not prose⟩
+    ∧ rules(
+        use(λ)
+        ∧ drop({articles,filler,pleasantries,hedging})
+        ∧ ok(fragments)
+        ∧ prefer(short_synonyms)
+        ∧ exact(technical_terms)
+        ∧ unchanged(code_blocks)
+        ∧ exact_quote(errors))
+    ∧ auto_clarity(
+        disable("/lambda-out") when
+          (security_warning
+           ∨ irreversible_confirmation
+           ∨ (multi_step ∧ risk(misread_order))
+           ∨ confused(user))
+        ∧ resume("/lambda-out") after(clear_part_done))
+    ∧ example(
+        destructive_op ↦
+          ["Warning: This will permanently delete all rows in the `users` table and cannot be undone."
+           "DROP TABLE users;"
+           "Lambda-out resume."])
+    ∧ boundaries(
+        normal_write({code,commits,PRs})
+        ∧ revert_normal_mode when ("stop lambda-out" ∨ "normal mode"))


### PR DESCRIPTION
## Summary

Adds the `lambda-out` skill as a committed `.psi/skills/lambda-out/SKILL.md` file.

`lambda-out` is a compressed-communication mode skill: it instructs the agent to speak in lambda-expression shorthand for token efficiency while preserving technical accuracy, triggered by phrases like "lambda mode" / "be brief" or the `/lambda-out` command.

Earlier this entry existed only as an absolute-path symlink into a private local directory (not portable). It is now a regular in-repo file, so it resolves correctly in every clone and in CI.

## Test plan
- No code change; skill content only. Skill discovery resolves `SKILL.md` from `.psi/skills/<name>/`.
