### PR TITLE
⚒ workflow: route plan-review follow-ups through shared design-steps.md

### DIFF
--- a/.psi/workflows/review-follow-up-plan.md
+++ b/.psi/workflows/review-follow-up-plan.md
@@ -9,16 +9,16 @@ tools:
 skills:
   - work-independently
 ---
-For the Munera task identified by {{input}}, execute newly added actionable follow-up items in steps.md. Work independently. Read the task's steps.md and implementation.md, and read the task's design.md as read-only context as needed. Then inspect task-scoped git history to identify unchecked items added by the preceding review pass.
+For the Munera task identified by {{input}}, execute newly added actionable follow-up items in design-steps.md. Work independently. Read the task's design-steps.md, plan.md, and implementation.md, and read the task's steps.md and design.md as read-only context as needed. Then inspect task-scoped git history to identify unchecked items added by the preceding review pass.
 
 In the merged `review-task-plan` workflow, the preceding review pass is the immediately preceding whole `plan-review` batch: the ambiguity and inconsistency review prompts run back-to-back in one shared child session before this follow-up. Treat "newly added" as spanning both review prompts in that immediately preceding batch.
 
 Use this evidence rule for batch review workflows:
 
 1. Identify the contiguous latest task-scoped review-batch segment since the previous plan-follow-up completion for the same task, or since task creation if no previous follow-up exists.
-2. Use the parent of the oldest commit in that segment as the batch baseline, then compare that baseline to current HEAD for the task's steps.md (for example, `git diff <baseline>..HEAD -- <task>/steps.md`).
-3. The candidate work set is exactly the checklist lines added by that diff that match unchecked step items and still exist unchecked in steps.md at follow-up start.
-4. Execute only those candidate items. Do not execute unchecked items that predate the preceding review pass, edited stale items whose addition cannot be attributed to the just-finished batch, or checked items.
+2. Use the parent of the oldest commit in that segment as the batch baseline, then compare that baseline to current HEAD for the task's design-steps.md (for example, `git diff <baseline>..HEAD -- <task>/design-steps.md`).
+3. The candidate work set is exactly the checklist lines added by that diff that match unchecked design-step items and still exist unchecked in design-steps.md at follow-up start.
+4. Execute only those candidate items. Do not execute unchecked items that predate the preceding review pass, edited stale items whose addition cannot be attributed to the just-finished batch, checked items, or items from steps.md.
 5. If the review-batch segment or baseline cannot be identified confidently, or if a diff-added checklist item cannot be matched unambiguously to a current unchecked item, leave the item unchecked and record the blocking reason tersely in implementation.md rather than guessing.
 
-Read and update the task's plan.md, steps.md, and implementation.md as needed. When a follow-up item requires it, also update the code, tests, and docs the item references. Complete any newly added unchecked steps when possible, updating the task's code, tests, docs, and task artifacts as you work. If a step is completed, mark it done in steps.md. Do not touch design.md beyond read-only context. Commit when done.
+Read and update the task's plan.md, design-steps.md, and implementation.md as needed. When a follow-up item requires it, also update the code, tests, and docs the item references. Complete any newly added unchecked design-steps when possible, updating the task's code, tests, docs, and task artifacts as you work. If a design-step is completed, mark it done in design-steps.md. Do not touch steps.md or design.md beyond read-only context. Commit when done.

--- a/.psi/workflows/review-task-plan-ambiguity-review.md
+++ b/.psi/workflows/review-task-plan-ambiguity-review.md
@@ -12,11 +12,13 @@ skills:
 ---
 For the Munera task identified by {{input}}, run the ambiguity review as the first turn of the shared `plan-review` multi-prompt session. Work independently. Read the task artifacts, especially plan.md, steps.md, and implementation.md, plus any referenced code/tests/docs needed for the batch review. This first turn loads the task plan context for the later inconsistency turn in the same child session.
 
-Review the task plan and steps for ambiguities. Then:
+Review the task plan and steps for ambiguities, treating steps.md as read-only task context. Then:
 
-1. append a terse review note to the task's implementation.md
-2. add unchecked follow-up items to steps.md for every new actionable ambiguity you found
-3. avoid duplicating review notes or steps that already exist
+1. add unchecked follow-up items to design-steps.md for every new actionable ambiguity you found (create design-steps.md if it does not exist)
+2. append a terse review note to the task's implementation.md
+   Do not note compliance with these instructions; only note any non-compliance.
+   Do not duplicate information that is already in the design-steps.
+3. avoid duplicating review notes or design-steps that already exist
 4. commit
 5. if there is no new actionable ambiguity feedback, say so explicitly
 

--- a/.psi/workflows/review-task-plan-final-summary.md
+++ b/.psi/workflows/review-task-plan-final-summary.md
@@ -5,12 +5,12 @@ tools:
   - read
   - bash
 ---
-Produce the user-facing final result for the Munera task identified by {{input}} after a plan review. Independently inspect that specific task's plan.md, steps.md, and implementation.md, and use the prior step outputs as supporting context.
+Produce the user-facing final result for the Munera task identified by {{input}} after a plan review. Independently inspect that specific task's plan.md, design-steps.md, and implementation.md, and use the prior step outputs as supporting context.
 
 Respond with a concise summary for the user, not an internal control token. Include:
 - whether the review loop completed cleanly
 - the key ambiguities or inconsistencies found and resolved in this run
-- the task artifact files updated (plan.md, steps.md, implementation.md)
+- the task artifact files updated (plan.md, design-steps.md, implementation.md)
 - any commit ids created during the run that are evident from the provided step outputs
 - whether the plan is now clear enough to proceed to implementation
 

--- a/.psi/workflows/review-task-plan-inconsistency-review.md
+++ b/.psi/workflows/review-task-plan-inconsistency-review.md
@@ -12,12 +12,15 @@ skills:
 ---
 For the Munera task identified by {{input}}, run the inconsistency review as the second turn of the shared `plan-review` multi-prompt session. Work independently. Use the already-loaded task plan.md, steps.md, implementation.md, and ambiguity-review reply from the shared session context by default. Perform only targeted re-reads for specific missing or stale referenced material needed to decide an inconsistency; do not unconditionally re-read the whole task plan and referenced source set.
 
-Review the task plan and steps for inconsistencies, focusing on inconsistency across task files. Then:
+Review the task plan and steps for inconsistencies, focusing on inconsistency across task files, treating steps.md as read-only task context. Then:
 
-1. append a terse review note to the task's implementation.md
-2. add unchecked follow-up items to steps.md for every new actionable inconsistency you found
-3. avoid duplicating review notes or steps that already exist
-4. commit. if there is no new actionable inconsistency feedback, say so explicitly
+1. add unchecked follow-up items to design-steps.md for every new actionable inconsistency you found (create design-steps.md if it does not exist)
+2. append a terse review note to the task's implementation.md
+   Do not note compliance with these instructions; only note any non-compliance.
+   Do not duplicate information that is already in the design-steps.
+3. avoid duplicating review notes or design-steps that already exist
+4. commit
+5. if there is no new actionable inconsistency feedback, say so explicitly
 
 End your final response with exactly one of:
 PASS_STATUS: ACTIONABLE_FEEDBACK

--- a/.psi/workflows/review-task-plan.edn
+++ b/.psi/workflows/review-task-plan.edn
@@ -39,7 +39,7 @@
                            :output :final-llm-reply}}
     {:type :template,
      :text
-     "Produce the user-facing final result for the Munera task identified by {{input}} after a plan review. Independently inspect that specific task's artifacts, especially plan.md, steps.md, and implementation.md, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the plan review loop completed cleanly\n- the key ambiguities or inconsistencies found and resolved in this run\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior.",
+     "Produce the user-facing final result for the Munera task identified by {{input}} after a plan review. Independently inspect that specific task's artifacts, especially plan.md, design-steps.md, and implementation.md, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the plan review loop completed cleanly\n- the key ambiguities or inconsistencies found and resolved in this run\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not output REPEAT or DONE unless quoting prior workflow behavior.",
      :vars {"input" {:from :workflow-input, :path [:input]}}}]}],
  :name "review-task-plan",
  :description


### PR DESCRIPTION
## Summary

Makes the `review-task-plan` workflow trio use the shared `design-steps.md` as its working checklist, with `steps.md` as read-only task context.

## Changes

- **Reviewers** (`review-task-plan-ambiguity-review.md`, `review-task-plan-inconsistency-review.md`): reorder to (1) update `design-steps.md` → (2) append `implementation.md` note; implementation.md notes must not duplicate `design-steps.md` content or note compliance; symmetrize the two sibling prompts; annotate `steps.md` as read-only context; create `design-steps.md` if absent.
- **Follow-up** (`review-follow-up-plan.md`): fix `desing-steps.md` typo (×2); read `design-steps.md`/`plan.md`/`implementation.md` and treat `steps.md`/`design.md` as read-only context; exclude `steps.md` items from the candidate set.
- **Final summary** (`review-task-plan.edn` inline template + `review-task-plan-final-summary.md`): reference `design-steps.md` instead of `steps.md`.

## Notes

- Sharing `design-steps.md` between design-review and plan-review is deliberate.
- `review-task-plan-final-summary.md` is not referenced by `review-task-plan.edn` (which uses an inline template); updated for coherence but appears vestigial.