### PR TITLE
Streamline review workflows

### DIFF
--- a/.psi/workflows/review-follow-up-design.md
+++ b/.psi/workflows/review-follow-up-design.md
@@ -14,6 +14,8 @@ For the Munera task identified by {{input}}, execute the unchecked,
 actionable, follow-up items in design-steps.md with updates to
 design.md. Work independently.
 
+Be careful not to introduce new ambiguity or inconsistencies.
+
 If a design-step is completed, mark it done in design-steps.md.
 
 When finished, add a minimalist note to implementation.md stating that

--- a/.psi/workflows/review-follow-up-design.md
+++ b/.psi/workflows/review-follow-up-design.md
@@ -7,20 +7,19 @@ tools:
   - edit
   - write
 skills:
+  - task-design
   - work-independently
 ---
-For the Munera task identified by {{input}}, execute newly added actionable follow-up items in design-steps.md. Work independently. Read the task's design-steps.md and implementation.md, then inspect task-scoped git history to identify unchecked items added by the preceding review pass.
+For the Munera task identified by {{input}}, execute the unchecked,
+actionable, follow-up items in design-steps.md with updates to
+design.md. Work independently.
 
-In the merged `review-task-design` workflow, the preceding review pass is the immediately preceding whole `design-review` batch: the architecture, ambiguity, and inconsistency review prompts run back-to-back in one shared child session before this follow-up. Treat "newly added" as spanning all three review prompts in that immediately preceding batch.
+If a design-step is completed, mark it done in design-steps.md.
 
-Use this evidence rule for batch review workflows:
+When finished, add a minimalist note to implementation.md stating that
+you have addressed the design-steps, and noting anything you were not
+able to do. e.g. "- design-steps completed"
 
-1. Identify the contiguous latest task-scoped review-batch segment since the previous design-follow-up completion for the same task, or since task creation if no previous follow-up exists.
-2. Use the parent of the oldest commit in that segment as the batch baseline, then compare that baseline to current HEAD for the task's design-steps.md (for example, `git diff <baseline>..HEAD -- <task>/design-steps.md`).
-3. The candidate work set is exactly the checklist lines added by that diff that match unchecked design-step items and still exist unchecked in design-steps.md at follow-up start.
-4. Execute only those candidate items. Do not execute unchecked items that predate the preceding review pass, edited stale items whose addition cannot be attributed to the just-finished batch, checked items, or items from steps.md.
-5. If the review-batch segment or baseline cannot be identified confidently, or if a diff-added checklist item cannot be matched unambiguously to a current unchecked item, leave the item unchecked and record the blocking reason tersely in implementation.md rather than guessing.
-
-Read and update the task's design.md, design-steps.md, and implementation.md as needed. Complete any newly added unchecked design-steps when possible, updating design.md as you work. If a design-step is completed, mark it done in design-steps.md. Do not touch plan.md or steps.md. Commit when done.
+Commit when done.
 
 **Do not execute `SCOPE_QUESTION:` items.** A follow-up item prefixed `SCOPE_QUESTION:` raises a concern about the design's scope boundary itself, which only a human may decide. Leave every such item unchecked, do not change the design's scope boundary in response to it, and record tersely in implementation.md that the scope question is deferred to the user.

--- a/.psi/workflows/review-follow-up-plan.md
+++ b/.psi/workflows/review-follow-up-plan.md
@@ -7,9 +7,10 @@ tools:
   - edit
   - write
 skills:
+  - task-design
   - work-independently
 ---
-For the Munera task identified by {{input}}, execute newly added actionable follow-up items in design-steps.md. Work independently. Read the task's design-steps.md, plan.md, steps.md, and implementation.md, and read the task's design.md as read-only context as needed. Then inspect task-scoped git history to identify unchecked items added by the preceding review pass.
+For the Munera task identified by {{input}}, execute newly added actionable follow-up items in design-steps.md with updates to plan.md and steps.md. Work independently. Read the task's design-steps.md, plan.md, steps.md, and implementation.md, and read the task's design.md as read-only context as needed. Then inspect task-scoped git history to identify unchecked items added by the preceding review pass.
 
 In the merged `review-task-plan` workflow, the preceding review pass is the immediately preceding whole `plan-review` batch: the ambiguity and inconsistency review prompts run back-to-back in one shared child session before this follow-up. Treat "newly added" as spanning both review prompts in that immediately preceding batch.
 
@@ -21,4 +22,8 @@ Use this evidence rule for batch review workflows:
 4. Execute only those candidate items. Do not execute unchecked items that predate the preceding review pass, edited stale items whose addition cannot be attributed to the just-finished batch, checked items, or items from steps.md.
 5. If the review-batch segment or baseline cannot be identified confidently, or if a diff-added checklist item cannot be matched unambiguously to a current unchecked item, leave the item unchecked and record the blocking reason tersely in implementation.md rather than guessing.
 
-Read and update the task's plan.md, steps.md, design-steps.md, and implementation.md as needed. The plan review reviews both plan.md and steps.md, so a follow-up item that reports plan.md↔steps.md drift (for example steps.md not re-synced after a plan.md change) MUST be resolved by editing steps.md to match the authoritative plan.md — do not merely defer or block such items, or the review loop cannot converge. When a follow-up item requires it, also update the code, tests, and docs the item references. Complete any newly added unchecked design-steps when possible, updating the task's code, tests, docs, and task artifacts as you work. If a design-step is completed, mark it done in design-steps.md. Do not touch design.md beyond read-only context. Commit when done.
+Read and update the task's plan.md, steps.md, design-steps.md, and implementation.md as needed. The plan review reviews both plan.md and steps.md, so a follow-up item that reports plan.md↔steps.md drift (for example steps.md not re-synced after a plan.md change) MUST be resolved by editing steps.md to match the authoritative plan.md — do not merely defer or block such items, or the review loop cannot converge. When a follow-up item requires it, also update the code, tests, and docs the item references. Complete any newly added unchecked design-steps when possible, updating the task's code, tests, docs, and task artifacts as you work. If a design-step is completed, mark it done in design-steps.md. Do not touch design.md beyond read-only context.
+
+When finished, add a minimalist note to implementation.md stating that you have addressed the design-steps, and noting anything you were not able to do. e.g. "- design-steps completed"
+
+Commit when done.

--- a/.psi/workflows/review-follow-up-plan.md
+++ b/.psi/workflows/review-follow-up-plan.md
@@ -10,20 +10,16 @@ skills:
   - task-design
   - work-independently
 ---
-For the Munera task identified by {{input}}, execute newly added actionable follow-up items in design-steps.md with updates to plan.md and steps.md. Work independently. Read the task's design-steps.md, plan.md, steps.md, and implementation.md, and read the task's design.md as read-only context as needed. Then inspect task-scoped git history to identify unchecked items added by the preceding review pass.
+For the Munera task identified by {{input}}, execute the unchecked,
+actionable, follow-up items in design-steps.md with updates to plan.md
+and steps.md. Work independently.
 
-In the merged `review-task-plan` workflow, the preceding review pass is the immediately preceding whole `plan-review` batch: the ambiguity and inconsistency review prompts run back-to-back in one shared child session before this follow-up. Treat "newly added" as spanning both review prompts in that immediately preceding batch.
+Read the task's design.md as needed.
 
-Use this evidence rule for batch review workflows:
+If a design-step is completed, mark it done in design-steps.md.
 
-1. Identify the contiguous latest task-scoped review-batch segment since the previous plan-follow-up completion for the same task, or since task creation if no previous follow-up exists.
-2. Use the parent of the oldest commit in that segment as the batch baseline, then compare that baseline to current HEAD for the task's design-steps.md (for example, `git diff <baseline>..HEAD -- <task>/design-steps.md`).
-3. The candidate work set is exactly the checklist lines added by that diff that match unchecked design-step items and still exist unchecked in design-steps.md at follow-up start.
-4. Execute only those candidate items. Do not execute unchecked items that predate the preceding review pass, edited stale items whose addition cannot be attributed to the just-finished batch, checked items, or items from steps.md.
-5. If the review-batch segment or baseline cannot be identified confidently, or if a diff-added checklist item cannot be matched unambiguously to a current unchecked item, leave the item unchecked and record the blocking reason tersely in implementation.md rather than guessing.
-
-Read and update the task's plan.md, steps.md, design-steps.md, and implementation.md as needed. The plan review reviews both plan.md and steps.md, so a follow-up item that reports plan.md↔steps.md drift (for example steps.md not re-synced after a plan.md change) MUST be resolved by editing steps.md to match the authoritative plan.md — do not merely defer or block such items, or the review loop cannot converge. When a follow-up item requires it, also update the code, tests, and docs the item references. Complete any newly added unchecked design-steps when possible, updating the task's code, tests, docs, and task artifacts as you work. If a design-step is completed, mark it done in design-steps.md. Do not touch design.md beyond read-only context.
-
-When finished, add a minimalist note to implementation.md stating that you have addressed the design-steps, and noting anything you were not able to do. e.g. "- design-steps completed"
+When finished, add a minimalist note to implementation.md stating that
+you have addressed the design-steps, and noting anything you were not
+able to do. e.g. "- design-steps completed"
 
 Commit when done.

--- a/.psi/workflows/review-follow-up-plan.md
+++ b/.psi/workflows/review-follow-up-plan.md
@@ -16,6 +16,8 @@ and steps.md. Work independently.
 
 Read the task's design.md as needed.
 
+Be careful not to introduce new ambiguity or inconsistencies.
+
 If a design-step is completed, mark it done in design-steps.md.
 
 When finished, add a minimalist note to implementation.md stating that

--- a/.psi/workflows/review-step.edn
+++ b/.psi/workflows/review-step.edn
@@ -1,28 +1,28 @@
 {:steps
- [{:name "review",
-   :type :session,
-   :tools ["read" "bash" "edit" "write"],
+ [{:name   "review",
+   :type   :session,
+   :tools  ["read" "bash" "edit" "write"],
    :skills ["work-independently"],
    :contributions
    [{:type :source, :from :workflow-original}
     {:type :template,
      :text
-     "Review the Munera task at {{input}} using the {{skill}} skill. Work independently. Read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n2. append a terse review note to the task's implementation.md. Do not note compliance with these instructions; only note any non-compliance. Avoid duplicating information that is in the steps.md updatate\n3. avoid duplicating review notes or steps that already exist\n4. commit.\n5. End your response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: REVIEW_COMPLETE",
+     "Review the Munera task at {{input}} using the {{skill}} skill. Work independently. Read the skill file at `.psi/skills/{{skill}}/SKILL.md` and apply it. Read the task artifacts and any code/tests/docs they reference. Then:\n\n1. add unchecked follow-up items to the task's steps.md for every new actionable issue you found\n2. append a terse review note to the task's implementation.md, e.g. \" - added 3 steps to be addressed\". Do not note compliance with these instructions; only note any non-compliance. Avoid duplicating information that is in the steps.md updatate\n3. avoid duplicating review notes or steps that already exist\n4. commit.\n5. End your response with exactly one of:\nPASS_STATUS: ACTIONABLE_FEEDBACK\nPASS_STATUS: REVIEW_COMPLETE",
      :vars {"input" {:from :workflow-input, :path [:input]},
             "skill" {:from :workflow-input, :path [:skill]}}}],
-   :judge {:type :invoke
-           :operation "workflow/pass-status-routing"
-           :args {:text {:from {:step "review", :output :final-llm-reply}}
-                  :allowed-statuses ["ACTIONABLE_FEEDBACK" "REVIEW_COMPLETE"]}},
-   :on {"DONE" {:goto :done}
-        "REPEAT" {:goto "follow-up"}}}
-  {:name "follow-up",
-   :type :session,
+   :judge  {:type      :invoke
+            :operation "workflow/pass-status-routing"
+            :args      {:text             {:from {:step "review", :output :final-llm-reply}}
+                        :allowed-statuses ["ACTIONABLE_FEEDBACK" "REVIEW_COMPLETE"]}},
+   :on     {"DONE"   {:goto :done}
+            "REPEAT" {:goto "follow-up"}}}
+  {:name            "follow-up",
+   :type            :session,
    :prompt-workflow "review-follow-up-steps.md",
-   :judge {:type :invoke
-           :operation "workflow/constant-routing"
-           :args {:route "REPEAT"}},
-   :on {"REPEAT" {:goto "review", :max-iterations 10}}}],
+   :judge           {:type      :invoke
+                     :operation "workflow/constant-routing"
+                     :args      {:route "REPEAT"}},
+   :on              {"REPEAT" {:goto "review", :max-iterations 10}}}],
  :name "review-step",
  :description
  "Run a single named review skill against a Munera task, record terse notes, execute follow-up steps, and repeat until the review returns no actionable feedback"}

--- a/.psi/workflows/review-task-design-core.edn
+++ b/.psi/workflows/review-task-design-core.edn
@@ -1,0 +1,62 @@
+{:steps
+ [{:name "design-review",
+   :type :session,
+   :tools ["read" "bash" "edit" "write"],
+   :skills ["work-independently"
+            "review-task-architecture"
+            "task-design"],
+   :prompts
+   [{:name "architecture",
+     :prompt-workflow "review-task-design-architecture-review.md"}
+    {:name "ambiguity",
+     :prompt-workflow "review-task-design-ambiguity-review.md"}
+    {:name "inconsistency",
+     :prompt-workflow "review-task-design-inconsistency-review.md"}],
+   :judge
+   {:type :invoke,
+    :operation "workflow/pass-feedback-routing",
+    :args {:architecture-text {:from {:step "design-review",
+                                      :prompt "architecture",
+                                      :output :final-llm-reply}},
+           :ambiguity-text {:from {:step "design-review",
+                                   :prompt "ambiguity",
+                                   :output :final-llm-reply}},
+           :inconsistency-text {:from {:step "design-review",
+                                       :prompt "inconsistency",
+                                       :output :final-llm-reply}}}},
+   :on {"REPEAT" {:goto "design-follow-up"},
+        "DONE" {:goto :done}}}
+  {:name "design-follow-up",
+   :type :session,
+   :prompt-workflow "review-follow-up-design.md",
+   :judge {:type :invoke,
+           :operation "workflow/constant-routing",
+           :args {:route "DONE"}},
+   :on {"DONE" {:goto "design-review"
+                :max-iterations 6
+                :on-max-iterations "status-not-converged"}}}
+  {:name "status-not-converged",
+   :type :session,
+   :tools ["read" "bash"],
+   :contributions
+   [{:type :source, :from :workflow-original}
+    {:type :source, :from {:step "design-review"
+                           :prompt "architecture"
+                           :output :final-llm-reply}}
+    {:type :source, :from {:step "design-review"
+                           :prompt "ambiguity"
+                           :output :final-llm-reply}}
+    {:type :source, :from {:step "design-review"
+                           :prompt "inconsistency"
+                           :output :final-llm-reply}}
+    {:type :template,
+     :text
+     "Report the machine-readable outcome for the Munera task design review identified by {{input}} after the review loop did not converge within the configured follow-up iteration limit. This is a lower-level workflow result consumed by wrapper workflows; do not write a user-facing final summary. Briefly list the unresolved design-review categories, if evident from the prior review outputs. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: ACTIONABLE_FEEDBACK",
+     :vars {"input" {:from :workflow-input, :path [:input]}}}],
+   :judge {:type :invoke,
+           :operation "workflow/constant-routing",
+           :args {:route "DONE"}},
+   :on {"DONE" {:goto :done}}}],
+ :name "review-task-design-core",
+ :description
+ "Run the reusable Munera task design review loop without a standalone final summary."}

--- a/.psi/workflows/review-task-design.edn
+++ b/.psi/workflows/review-task-design.edn
@@ -1,57 +1,27 @@
 {:steps
- [{:name "design-review",
-   :type :session,
-   :tools ["read" "bash" "edit" "write"],
-   :skills ["work-independently"
-            "review-task-architecture"
-            "task-design"],
-   :prompts
-   [{:name "architecture",
-     :prompt-workflow "review-task-design-architecture-review.md"}
-    {:name "ambiguity",
-     :prompt-workflow "review-task-design-ambiguity-review.md"}
-    {:name "inconsistency",
-     :prompt-workflow "review-task-design-inconsistency-review.md"}],
+ [{:name "review-task-design-core",
+   :type :delegate,
+   :target "review-task-design-core",
+   :prompt-string
+   {:type :map,
+    :fields {:input {:from :workflow-input, :path [:input]}}},
+   :context [{:type :source, :from :workflow-original}],
    :judge
    {:type :invoke,
-    :operation "workflow/pass-feedback-routing",
-    :args {:architecture-text {:from {:step "design-review",
-                                      :prompt "architecture",
-                                      :output :final-llm-reply}},
-           :ambiguity-text {:from {:step "design-review",
-                                   :prompt "ambiguity",
-                                   :output :final-llm-reply}},
-           :inconsistency-text {:from {:step "design-review",
-                                       :prompt "inconsistency",
-                                       :output :final-llm-reply}}}},
-   :on {"REPEAT" {:goto "design-follow-up"},
-        "DONE" {:goto "final-summary"}}}
-  {:name "design-follow-up",
-   :type :session,
-   :prompt-workflow "review-follow-up-design.md",
-   :judge {:type :invoke,
-           :operation "workflow/constant-routing",
-           :args {:route "DONE"}},
-   :on {"DONE" {:goto "design-review"
-                :max-iterations 6
-                :on-max-iterations "final-summary-not-converged"}}}
+    :operation "workflow/pass-status-routing",
+    :args {:text {:from {:step "review-task-design-core", :yield :text}},
+           :allowed-statuses ["ACTIONABLE_FEEDBACK" "REVIEW_COMPLETE"]}},
+   :on {"DONE" {:goto "final-summary"},
+        "REPEAT" {:goto "final-summary-not-converged"}}}
   {:name "final-summary-not-converged",
    :type :session,
    :tools ["read" "bash"],
    :contributions
    [{:type :source, :from :workflow-original}
-    {:type :source, :from {:step "design-review"
-                           :prompt "architecture"
-                           :output :final-llm-reply}}
-    {:type :source, :from {:step "design-review"
-                           :prompt "ambiguity"
-                           :output :final-llm-reply}}
-    {:type :source, :from {:step "design-review"
-                           :prompt "inconsistency"
-                           :output :final-llm-reply}}
+    {:type :source, :from {:step "review-task-design-core" :yield :text}}
     {:type :template,
      :text
-     "Produce the user-facing final result for the Munera task identified by {{input}} after a design review that did not converge within the configured follow-up iteration limit. Independently inspect that specific task's design.md, design-steps.md, and implementation.md, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Explain that the design review did not converge within the configured follow-up iteration limit, summarise the architectural-fit misfits, ambiguities, or inconsistencies that remain unresolved, list the task artifact files touched (design.md, design-steps.md, implementation.md), and state that the design needs further human attention before proceeding to plan creation.\n\nDo not include REPEAT or DONE control tokens, and do not reproduce the status lines from the review replies provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: ACTIONABLE_FEEDBACK",
+     "Produce the user-facing final result for the Munera task identified by {{input}} after a design review that did not converge within the configured follow-up iteration limit. Independently inspect that specific task's design.md, design-steps.md, and implementation.md, and use the prior core review output as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Explain that the design review did not converge within the configured follow-up iteration limit, summarise the architectural-fit misfits, ambiguities, or inconsistencies that remain unresolved, list the task artifact files touched (design.md, design-steps.md, implementation.md), and state that the design needs further human attention before proceeding to plan creation.\n\nDo not reproduce the status lines from the review output provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: ACTIONABLE_FEEDBACK",
      :vars {"input" {:from :workflow-input, :path [:input]}}}],
    :judge {:type :invoke,
            :operation "workflow/constant-routing",
@@ -62,18 +32,10 @@
    :tools ["read" "bash"],
    :contributions
    [{:type :source, :from :workflow-original}
-    {:type :source, :from {:step "design-review"
-                           :prompt "architecture"
-                           :output :final-llm-reply}}
-    {:type :source, :from {:step "design-review"
-                           :prompt "ambiguity"
-                           :output :final-llm-reply}}
-    {:type :source, :from {:step "design-review"
-                           :prompt "inconsistency"
-                           :output :final-llm-reply}}
+    {:type :source, :from {:step "review-task-design-core" :yield :text}}
     {:type :template,
      :text
-     "Produce the user-facing final result for the Munera task identified by {{input}} after a design review. Independently inspect that specific task's design.md, design-steps.md, and implementation.md, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the design review loop completed cleanly\n- the key architectural-fit misfits, ambiguities, or inconsistencies found and resolved in this run\n- the task artifact files updated (design.md, design-steps.md, implementation.md)\n- any commit ids created during the run that are evident from the provided step outputs\n- whether the design is now clear enough to proceed to plan creation\n\nDo not include REPEAT or DONE control tokens, and do not reproduce the status lines from the review replies provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: REVIEW_COMPLETE",
+     "Produce the user-facing final result for the Munera task identified by {{input}} after a design review. Independently inspect that specific task's design.md, design-steps.md, and implementation.md, and use the prior core review output as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the design review loop completed cleanly\n- the key architectural-fit misfits, ambiguities, or inconsistencies found and resolved in this run\n- the task artifact files updated (design.md, design-steps.md, implementation.md)\n- any commit ids created during the run that are evident from the provided step output\n- whether the design is now clear enough to proceed to plan creation\n\nDo not reproduce the status lines from the review output provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: REVIEW_COMPLETE",
      :vars {"input" {:from :workflow-input, :path [:input]}}}],
    :judge {:type :invoke,
            :operation "workflow/constant-routing",
@@ -81,4 +43,4 @@
    :on {"DONE" {:goto :done}}}],
  :name "review-task-design",
  :description
- "Repeatedly review a Munera task design for architectural fit, ambiguities, and inconsistencies in one shared multi-prompt review batch, record terse notes, execute batched follow-up steps, and loop until no actionable feedback remains"}
+ "Run a Munera task design review and produce a standalone user-facing final summary."}

--- a/.psi/workflows/review-task-design.edn
+++ b/.psi/workflows/review-task-design.edn
@@ -33,7 +33,7 @@
            :operation "workflow/constant-routing",
            :args {:route "DONE"}},
    :on {"DONE" {:goto "design-review"
-                :max-iterations 3
+                :max-iterations 6
                 :on-max-iterations "final-summary-not-converged"}}}
   {:name "final-summary-not-converged",
    :type :session,

--- a/.psi/workflows/review-task-implementation-core.edn
+++ b/.psi/workflows/review-task-implementation-core.edn
@@ -1,0 +1,57 @@
+{:steps
+ [{:name "review-task-implementation",
+   :type :delegate,
+   :target "review-step",
+   :prompt-string
+   {:type :map,
+    :fields
+    {:input {:from :workflow-input, :path [:input]},
+     :skill {:value "task-implementation-review"}}},
+   :context [{:type :source, :from :workflow-original}]}
+  {:name "review-task-tests",
+   :type :delegate,
+   :target "review-step",
+   :prompt-string
+   {:type :map,
+    :fields
+    {:input {:from :workflow-input, :path [:input]},
+     :skill {:value "task-test-review"}}},
+   :context
+   [{:type :source, :from :workflow-original}
+    {:type :source, :from {:step "review-task-implementation"
+                           :yield :text}}]}
+  {:name "review-test-shape",
+   :type :delegate,
+   :target "review-step",
+   :prompt-string
+   {:type :map,
+    :fields
+    {:input {:from :workflow-input, :path [:input]},
+     :skill {:value "test-shaper"}}},
+   :context
+   [{:type :source, :from :workflow-original}
+    {:type :source, :from {:step "review-task-tests"
+                           :yield :text}}]}
+  {:name "review-task-docs",
+   :type :delegate,
+   :target "review-step",
+   :prompt-string
+   {:type :map,
+    :fields
+    {:input {:from :workflow-input, :path [:input]},
+     :skill {:value "review-task-docs"}}},
+   :context
+   [{:type :source, :from :workflow-original}]}
+  {:name "review-code-shape",
+   :type :delegate,
+   :target "review-step",
+   :prompt-string
+   {:type :map,
+    :fields
+    {:input {:from :workflow-input, :path [:input]},
+     :skill {:value "code-shaper"}}},
+   :context
+   [{:type :source, :from :workflow-original}]}],
+ :name "review-task-implementation-core",
+ :description
+ "Run the reusable Munera task implementation review sequence without a standalone final summary."}

--- a/.psi/workflows/review-task-implementation.edn
+++ b/.psi/workflows/review-task-implementation.edn
@@ -1,53 +1,25 @@
 {:steps
- [{:name "review-task-implementation",
+ [{:name "review-task-implementation-core",
    :type :delegate,
-   :target "review-step",
+   :target "review-task-implementation-core",
    :prompt-string
    {:type :map,
-    :fields
-    {:input {:from :workflow-input, :path [:input]},
-     :skill {:value "task-implementation-review"}}},
+    :fields {:input {:from :workflow-input, :path [:input]}}},
    :context [{:type :source, :from :workflow-original}]}
-  {:name "review-task-tests",
-   :type :delegate,
-   :target "review-step",
-   :prompt-string
-   {:type :map,
-    :fields
-    {:input {:from :workflow-input, :path [:input]},
-     :skill {:value "task-test-review"}}},
-   :context
-   [{:type :source, :from :workflow-original}]}
-  {:name "review-test-shape",
-   :type :delegate,
-   :target "review-step",
-   :prompt-string
-   {:type :map,
-    :fields
-    {:input {:from :workflow-input, :path [:input]},
-     :skill {:value "test-shaper"}}},
-   :context
-   [{:type :source, :from :workflow-original}]}
-  {:name "review-task-docs",
-   :type :delegate,
-   :target "review-step",
-   :prompt-string
-   {:type :map,
-    :fields
-    {:input {:from :workflow-input, :path [:input]},
-     :skill {:value "review-task-docs"}}},
-   :context
-   [{:type :source, :from :workflow-original}]}
-  {:name "review-code-shape",
-   :type :delegate,
-   :target "review-step",
-   :prompt-string
-   {:type :map,
-    :fields
-    {:input {:from :workflow-input, :path [:input]},
-     :skill {:value "code-shaper"}}},
-   :context
-   [{:type :source, :from :workflow-original}]}],
+  {:name "final-summary",
+   :type :session,
+   :tools ["read" "bash"],
+   :contributions
+   [{:type :source, :from :workflow-original}
+    {:type :source, :from {:step "review-task-implementation-core" :yield :text}}
+    {:type :template,
+     :text
+     "Produce the user-facing final result for the Munera task identified by {{input}} after implementation review. Independently inspect that specific task's design.md, plan.md, steps.md, implementation.md, user-facing docs, and relevant git history, and use the prior core review output as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the implementation review sequence completed cleanly\n- the key implementation, test, documentation, test-shape, or code-shape findings resolved in this run\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step output\n- whether the implementation is ready for task closure or knowledge extraction\n\nDo not reproduce the status lines from the review output provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: REVIEW_COMPLETE",
+     :vars {"input" {:from :workflow-input, :path [:input]}}}],
+   :judge {:type :invoke,
+           :operation "workflow/constant-routing",
+           :args {:route "DONE"}},
+   :on {"DONE" {:goto :done}}}],
  :name "review-task-implementation",
  :description
- "Review a Munera task implementation, record terse notes, execute added follow-up steps, and repeat until no new actionable feedback remains"}
+ "Review a Munera task implementation and produce a standalone user-facing final summary."}

--- a/.psi/workflows/review-task-implementation.edn
+++ b/.psi/workflows/review-task-implementation.edn
@@ -17,9 +17,7 @@
     {:input {:from :workflow-input, :path [:input]},
      :skill {:value "task-test-review"}}},
    :context
-   [{:type :source, :from :workflow-original}
-    {:type :source,
-     :from {:step "review-task-implementation", :yield :text}}]}
+   [{:type :source, :from :workflow-original}]}
   {:name "review-test-shape",
    :type :delegate,
    :target "review-step",
@@ -29,10 +27,7 @@
     {:input {:from :workflow-input, :path [:input]},
      :skill {:value "test-shaper"}}},
    :context
-   [{:type :source, :from :workflow-original}
-    {:type :source,
-     :from {:step "review-task-implementation", :yield :text}}
-    {:type :source, :from {:step "review-task-tests", :yield :text}}]}
+   [{:type :source, :from :workflow-original}]}
   {:name "review-task-docs",
    :type :delegate,
    :target "review-step",
@@ -42,11 +37,7 @@
     {:input {:from :workflow-input, :path [:input]},
      :skill {:value "review-task-docs"}}},
    :context
-   [{:type :source, :from :workflow-original}
-    {:type :source,
-     :from {:step "review-task-implementation", :yield :text}}
-    {:type :source, :from {:step "review-task-tests", :yield :text}}
-    {:type :source, :from {:step "review-test-shape", :yield :text}}]}
+   [{:type :source, :from :workflow-original}]}
   {:name "review-code-shape",
    :type :delegate,
    :target "review-step",
@@ -56,12 +47,7 @@
     {:input {:from :workflow-input, :path [:input]},
      :skill {:value "code-shaper"}}},
    :context
-   [{:type :source, :from :workflow-original}
-    {:type :source,
-     :from {:step "review-task-implementation", :yield :text}}
-    {:type :source, :from {:step "review-task-tests", :yield :text}}
-    {:type :source, :from {:step "review-test-shape", :yield :text}}
-    {:type :source, :from {:step "review-task-docs", :yield :text}}]}],
+   [{:type :source, :from :workflow-original}]}],
  :name "review-task-implementation",
  :description
  "Review a Munera task implementation, record terse notes, execute added follow-up steps, and repeat until no new actionable feedback remains"}

--- a/.psi/workflows/review-task-plan-core.edn
+++ b/.psi/workflows/review-task-plan-core.edn
@@ -1,0 +1,52 @@
+{:steps
+ [{:name "plan-review",
+   :type :session,
+   :tools ["read" "bash" "edit" "write"],
+   :skills ["work-independently" "task-design"],
+   :prompts
+   [{:name "ambiguity",
+     :prompt-workflow "review-task-plan-ambiguity-review.md"}
+    {:name "inconsistency",
+     :prompt-workflow "review-task-plan-inconsistency-review.md"}],
+   :judge
+   {:type :invoke,
+    :operation "workflow/pass-feedback-routing",
+    :args {:ambiguity-text {:from {:step "plan-review",
+                                   :prompt "ambiguity",
+                                   :output :final-llm-reply}},
+           :inconsistency-text {:from {:step "plan-review",
+                                       :prompt "inconsistency",
+                                       :output :final-llm-reply}}}},
+   :on {"REPEAT" {:goto "plan-follow-up"},
+        "DONE" {:goto :done}}}
+  {:name "plan-follow-up",
+   :type :session,
+   :prompt-workflow "review-follow-up-plan.md",
+   :judge {:type :invoke,
+           :operation "workflow/constant-routing",
+           :args {:route "DONE"}},
+   :on {"DONE" {:goto "plan-review"
+                :max-iterations 5
+                :on-max-iterations "status-not-converged"}}}
+  {:name "status-not-converged",
+   :type :session,
+   :tools ["read" "bash"],
+   :contributions
+   [{:type :source, :from :workflow-original}
+    {:type :source, :from {:step "plan-review"
+                           :prompt "ambiguity"
+                           :output :final-llm-reply}}
+    {:type :source, :from {:step "plan-review"
+                           :prompt "inconsistency"
+                           :output :final-llm-reply}}
+    {:type :template,
+     :text
+     "Report the machine-readable outcome for the Munera task plan review identified by {{input}} after the review loop did not converge within the configured follow-up iteration limit. This is a lower-level workflow result consumed by wrapper workflows; do not write a user-facing final summary. Briefly list the unresolved plan-review categories, if evident from the prior review outputs. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: ACTIONABLE_FEEDBACK",
+     :vars {"input" {:from :workflow-input, :path [:input]}}}],
+   :judge {:type :invoke,
+           :operation "workflow/constant-routing",
+           :args {:route "DONE"}},
+   :on {"DONE" {:goto :done}}}],
+ :name "review-task-plan-core",
+ :description
+ "Run the reusable Munera task plan review loop without a standalone final summary."}

--- a/.psi/workflows/review-task-plan.edn
+++ b/.psi/workflows/review-task-plan.edn
@@ -1,47 +1,27 @@
 {:steps
- [{:name "plan-review",
-   :type :session,
-   :tools ["read" "bash" "edit" "write"],
-   :skills ["work-independently" "task-design"],
-   :prompts
-   [{:name "ambiguity",
-     :prompt-workflow "review-task-plan-ambiguity-review.md"}
-    {:name "inconsistency",
-     :prompt-workflow "review-task-plan-inconsistency-review.md"}],
+ [{:name "review-task-plan-core",
+   :type :delegate,
+   :target "review-task-plan-core",
+   :prompt-string
+   {:type :map,
+    :fields {:input {:from :workflow-input, :path [:input]}}},
+   :context [{:type :source, :from :workflow-original}],
    :judge
    {:type :invoke,
-    :operation "workflow/pass-feedback-routing",
-    :args {:ambiguity-text {:from {:step "plan-review",
-                                   :prompt "ambiguity",
-                                   :output :final-llm-reply}},
-           :inconsistency-text {:from {:step "plan-review",
-                                       :prompt "inconsistency",
-                                       :output :final-llm-reply}}}},
-   :on {"REPEAT" {:goto "plan-follow-up"},
-        "DONE" {:goto "final-summary"}}}
-  {:name "plan-follow-up",
-   :type :session,
-   :prompt-workflow "review-follow-up-plan.md",
-   :judge {:type :invoke,
-           :operation "workflow/constant-routing",
-           :args {:route "DONE"}},
-   :on {"DONE" {:goto "plan-review"
-                :max-iterations 5
-                :on-max-iterations "final-summary-not-converged"}}}
+    :operation "workflow/pass-status-routing",
+    :args {:text {:from {:step "review-task-plan-core", :yield :text}},
+           :allowed-statuses ["ACTIONABLE_FEEDBACK" "REVIEW_COMPLETE"]}},
+   :on {"DONE" {:goto "final-summary"},
+        "REPEAT" {:goto "final-summary-not-converged"}}}
   {:name "final-summary-not-converged",
    :type :session,
    :tools ["read" "bash"],
    :contributions
    [{:type :source, :from :workflow-original}
-    {:type :source, :from {:step "plan-review"
-                           :prompt "ambiguity"
-                           :output :final-llm-reply}}
-    {:type :source, :from {:step "plan-review"
-                           :prompt "inconsistency"
-                           :output :final-llm-reply}}
+    {:type :source, :from {:step "review-task-plan-core" :yield :text}}
     {:type :template,
      :text
-     "Produce the user-facing final result for the Munera task identified by {{input}} after a plan review that did not converge within the configured follow-up iteration limit. Independently inspect that specific task's artifacts, especially plan.md, design-steps.md, and implementation.md, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Explain that the plan review did not converge within the configured follow-up iteration limit, summarise the ambiguities or inconsistencies that remain unresolved, list the task artifact files touched, and state that the plan needs further human attention before implementation.\n\nDo not include REPEAT or DONE control tokens, and do not reproduce the status lines from the review replies provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: ACTIONABLE_FEEDBACK",
+     "Produce the user-facing final result for the Munera task identified by {{input}} after a plan review that did not converge within the configured follow-up iteration limit. Independently inspect that specific task's artifacts, especially plan.md, design-steps.md, and implementation.md, and use the prior core review output as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Explain that the plan review did not converge within the configured follow-up iteration limit, summarise the ambiguities or inconsistencies that remain unresolved, list the task artifact files touched, and state that the plan needs further human attention before implementation.\n\nDo not reproduce the status lines from the review output provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: ACTIONABLE_FEEDBACK",
      :vars {"input" {:from :workflow-input, :path [:input]}}}],
    :judge {:type :invoke,
            :operation "workflow/constant-routing",
@@ -52,15 +32,10 @@
    :tools ["read" "bash"],
    :contributions
    [{:type :source, :from :workflow-original}
-    {:type :source, :from {:step "plan-review"
-                           :prompt "ambiguity"
-                           :output :final-llm-reply}}
-    {:type :source, :from {:step "plan-review"
-                           :prompt "inconsistency"
-                           :output :final-llm-reply}}
+    {:type :source, :from {:step "review-task-plan-core" :yield :text}}
     {:type :template,
      :text
-     "Produce the user-facing final result for the Munera task identified by {{input}} after a plan review. Independently inspect that specific task's artifacts, especially plan.md, design-steps.md, and implementation.md, and use the prior step outputs as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the plan review loop completed cleanly\n- the key ambiguities or inconsistencies found and resolved in this run\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step outputs\n\nDo not include REPEAT or DONE control tokens, and do not reproduce the status lines from the review replies provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: REVIEW_COMPLETE",
+     "Produce the user-facing final result for the Munera task identified by {{input}} after a plan review. Independently inspect that specific task's artifacts, especially plan.md, design-steps.md, and implementation.md, and use the prior core review output as supporting context.\n\nRespond with a concise summary for the user, not an internal control token. Include:\n- whether the plan review loop completed cleanly\n- the key ambiguities or inconsistencies found and resolved in this run\n- the task artifact files updated\n- any commit ids created during the run that are evident from the provided step output\n\nDo not reproduce the status lines from the review output provided as context. End your response with exactly one status line at column 0, with a single space after the colon and nothing else on that line:\nPASS_STATUS: REVIEW_COMPLETE",
      :vars {"input" {:from :workflow-input, :path [:input]}}}],
    :judge {:type :invoke,
            :operation "workflow/constant-routing",
@@ -68,4 +43,4 @@
    :on {"DONE" {:goto :done}}}],
  :name "review-task-plan",
  :description
- "Repeatedly review a Munera task plan and steps for ambiguities and inconsistencies in one shared multi-prompt review batch, record terse notes, execute batched follow-up steps, and loop until no actionable feedback remains"}
+ "Run a Munera task plan review and produce a standalone user-facing final summary."}

--- a/.psi/workflows/task-lifecycle.edn
+++ b/.psi/workflows/task-lifecycle.edn
@@ -1,7 +1,7 @@
 {:steps
  [{:name "review-task-design",
    :type :delegate,
-   :target "review-task-design",
+   :target "review-task-design-core",
    :prompt-string
    {:type :map,
     :fields {:input {:from :workflow-input, :path [:input]}}},
@@ -40,7 +40,7 @@
    :context [{:type :source, :from :workflow-original}]}
   {:name "review-task-plan",
    :type :delegate,
-   :target "review-task-plan",
+   :target "review-task-plan-core",
    :prompt-string
    {:type :map,
     :fields {:input {:from :workflow-input, :path [:input]}}},
@@ -65,7 +65,7 @@
    :context [{:type :source, :from :workflow-original}]}
   {:name "review-task-implementation",
    :type :delegate,
-   :target "review-task-implementation",
+   :target "review-task-implementation-core",
    :prompt-string
    {:type :map,
     :fields {:input {:from :workflow-input, :path [:input]}}},

--- a/components/agent-session/test/psi/agent_session/workflow_delegate_review_step_live_test.clj
+++ b/components/agent-session/test/psi/agent_session/workflow_delegate_review_step_live_test.clj
@@ -5,7 +5,6 @@
    [psi.ai.model-registry :as model-registry]
    [psi.agent-session.context :as context]
    [psi.agent-session.mutations :as mutations]
-   [psi.agent-session.mutations.canonical-workflows :as cwf-mutations]
    [psi.agent-session.test-support :as test-support]
    [psi.agent-session.turn]
    [psi.agent-session.workflow-test-support :as workflow-test-support]
@@ -25,64 +24,6 @@
   (let [tmp (java.io.File/createTempFile "psi-test-models" ".edn")]
     (spit tmp (pr-str config))
     (.getAbsolutePath tmp)))
-
-(defn- assert-converged-standalone-surfaces-review-complete
-  "DI-2: drive a converged standalone review run for `definition-id` through the
-   `execute-workflow-run` mutation (stubbing the model reply at
-   `prompt-execution-result-in!`) and assert the converged `final-summary` —
-   ordered last per DI-2 — is the step whose yielded text surfaces as
-   `:psi.workflow/result` via the standalone `(last :step-order)` path. The reply
-   is stubbed, so this locks the ordering/plumbing invariant only, NOT the DI-4
-   template wording (that is locked by the definition-level review-task-*-test).
-   The single varying axis is `definition-id` / `run-id` / converged summary
-   `reply-prefix`."
-  [definition-id run-id reply-prefix]
-  (let [models-path (write-temp-models!
-                     {:version 1
-                      :providers {"local"
-                                  {:base-url "http://localhost:8080/v1"
-                                   :api :openai-completions
-                                   :models [{:id "test-model"}]}}})]
-    (try
-      (model-registry/init! {:user-models-path models-path})
-      (let [[ctx session-id]
-            (workflow-test-support/create-tui-context+session
-             mutations/all-mutations
-             {:session-defaults {:model {:provider "local" :id "test-model" :reasoning false}}})]
-        (workflow-test-support/init-built-in-workflow! ctx session-id)
-        (try
-          (with-redefs [psi.agent-session.turn/prompt-execution-result-in!
-                        (fn [_ctx _child-session-id prompt]
-                          (let [reply (if (str/includes? prompt "Produce the user-facing final result")
-                                        (str reply-prefix "\n\nPASS_STATUS: REVIEW_COMPLETE")
-                                        "PASS_STATUS: REVIEW_COMPLETE")]
-                            {:execution-result/assistant-message
-                             {:role "assistant"
-                              :content [{:type :text :text reply}]
-                              :stop-reason :stop}}))]
-            (cwf-mutations/create-workflow-run
-             {} {:psi/agent-session-ctx ctx
-                 :definition-id definition-id
-                 :workflow-input {:input "munera/open/229-author-routed-workflow-exhaustion"}
-                 :run-id run-id})
-            (let [result (cwf-mutations/execute-workflow-run
-                          {} {:psi/agent-session-ctx ctx
-                              :session-id session-id
-                              :run-id run-id})
-                  run (workflow-runtime/workflow-run-in @(:state* ctx) run-id)
-                  result-text (:psi.workflow/result result)]
-              (is (= :completed (:psi.workflow/status result)) (pr-str run))
-              (is (= "final-summary" (last (:step-order (:effective-definition run))))
-                  "converged final-summary must be ordered last (DI-2)")
-              (is (string? result-text))
-              (is (= 1 (count (re-seq #"PASS_STATUS: REVIEW_COMPLETE" result-text)))
-                  "standalone result text is the converged final-summary's single REVIEW_COMPLETE line")
-              (is (str/includes? result-text reply-prefix)
-                  "standalone result text is the converged final-summary's reply (prefix unique to that step), not some other step's bare REVIEW_COMPLETE")))
-          (finally
-            (context/shutdown-context! ctx))))
-      (finally
-        (.delete (java.io.File. models-path))))))
 
 (deftest init-built-in-workflow-registers-review-step-routing-operations-test
   (testing "built-in workflow bootstrap registers deterministic review-step routing operations"
@@ -194,15 +135,17 @@
       (try
         (model-registry/init! {:user-models-path models-path})
         (let [[ctx session-id]
+              #_{:clj-kondo/ignore [:invalid-arity]}
               (workflow-test-support/create-tui-context+session
                mutations/all-mutations
                {:session-defaults {:model {:provider "local" :id "test-model" :reasoning false}}})]
           (workflow-test-support/init-built-in-workflow! ctx session-id)
           (try
+            (workflow-test-support/load-all-workflow-definitions! ctx)
             (with-redefs [psi.agent-session.turn/prompt-execution-result-in!
                           (fn [_ctx child-session-id prompt]
                             (let [reply (cond
-                                          (str/includes? prompt "end your response with exactly one of:")
+                                          (str/includes? (str/lower-case prompt) "end your response with exactly one of:")
                                           "No new actionable feedback found.\n\nPASS_STATUS: REVIEW_COMPLETE"
 
                                           (str/includes? prompt "Execute the newly added actionable follow-up items")
@@ -220,10 +163,10 @@
                     _ (is (some? cmd))
                     cmd-result ((:handler cmd) "review-task-implementation 189-deterministic-review-step-routing")
                     run-id (second (re-find #"run ([^\s]+)$" cmd-result))
-                    terminal-status (workflow-test-support/poll-until
-                                     #(some-> (workflow-runtime/workflow-run-in @(:state* ctx) run-id)
-                                              :status
-                                              ({:completed :completed :failed :failed :blocked :blocked})))
+                    terminal-status #_{:clj-kondo/ignore [:unresolved-var]} (workflow-test-support/poll-until
+                                                                             #(some-> (workflow-runtime/workflow-run-in @(:state* ctx) run-id)
+                                                                                      :status
+                                                                                      ({:completed :completed :failed :failed :blocked :blocked})))
                     run (workflow-runtime/workflow-run-in @(:state* ctx) run-id)]
                 (is (string? cmd-result))
                 (is (str/includes? cmd-result "Delegated to review-task-implementation — run "))
@@ -238,11 +181,7 @@
                           delegate-run-id (get-in run [:step-runs "review-task-implementation" :attempts 0 :execution-error :delegate-run-id])
                           delegate-run (when delegate-run-id (workflow-runtime/workflow-run-in state delegate-run-id))]
                       (str "parent=" (pr-str run) "\nchild=" (pr-str delegate-run))))
-                (is (= ["review-task-implementation"
-                        "review-task-tests"
-                        "review-test-shape"
-                        "review-task-docs"
-                        "review-code-shape"]
+                (is (= ["review-task-implementation-core" "final-summary"]
                        (->> (:step-order (:effective-definition run))
                             (filter #(get-in run [:step-runs % :accepted-result]))
                             vec)))))
@@ -251,12 +190,3 @@
         (finally
           (.delete (java.io.File. models-path)))))))
 
-(deftest review-task-design-converged-standalone-surfaces-review-complete-result-test
-  (testing "converged review-task-design surfaces the converged final-summary text as standalone result"
-    (assert-converged-standalone-surfaces-review-complete
-     "review-task-design" "run-design-converged" "Design review completed cleanly.")))
-
-(deftest review-task-plan-converged-standalone-surfaces-review-complete-result-test
-  (testing "converged review-task-plan surfaces the converged final-summary text as standalone result"
-    (assert-converged-standalone-surfaces-review-complete
-     "review-task-plan" "run-plan-converged" "Plan review completed cleanly.")))

--- a/components/workflow-loader/test/psi/workflow_loader/task_209_workflow_definitions_test.clj
+++ b/components/workflow-loader/test/psi/workflow_loader/task_209_workflow_definitions_test.clj
@@ -646,10 +646,13 @@
                       "review-task-implementation"]
         workflow-filenames ["reduce-incidental-complexity.edn"
                             "review-task-design.edn"
+                            "review-task-design-core.edn"
                             "create-task-plan.edn"
                             "review-task-plan.edn"
+                            "review-task-plan-core.edn"
                             "implement-task.edn"
                             "review-task-implementation.edn"
+                            "review-task-implementation-core.edn"
                             "review-step.edn"]
         prompt-filenames ["review-task-design-architecture-review.md"
                           "review-task-design-ambiguity-review.md"
@@ -684,7 +687,7 @@
                   (str "delegate target resolves: " target)))))
         (testing "implementation review workflow preserves the transitive task-test-review gate (TT2)"
           (let [implementation-review-steps (get-in definitions
-                                                    ["review-task-implementation" :steps])
+                                                    ["review-task-implementation-core" :steps])
                 implementation-review-step-by-name (into {}
                                                          (map (juxt :name identity)
                                                               implementation-review-steps))
@@ -705,7 +708,7 @@
                 "review-task-tests delegate target resolves to the real review-step workflow")))
         (testing "implementation review workflow preserves the transitive test-shaper gate (TT6)"
           (let [implementation-review-steps (get-in definitions
-                                                    ["review-task-implementation" :steps])
+                                                    ["review-task-implementation-core" :steps])
                 implementation-review-step-by-name (into {}
                                                          (map (juxt :name identity)
                                                               implementation-review-steps))

--- a/components/workflow-loader/test/psi/workflow_loader/task_lifecycle_definitions_test.clj
+++ b/components/workflow-loader/test/psi/workflow_loader/task_lifecycle_definitions_test.clj
@@ -66,11 +66,11 @@
                  :invoke :delegate :session :session :session :session :session]
                 (mapv :type steps))))
        (testing "the lifecycle delegate steps target their workflows in order"
-         (is (= ["review-task-design"
+         (is (= ["review-task-design-core"
                  "create-task-plan"
-                 "review-task-plan"
+                 "review-task-plan-core"
                  "implement-task"
-                 "review-task-implementation"
+                 "review-task-implementation-core"
                  "extract-task-knowledge"]
                 (mapv :target delegate-steps))))
        (testing "the delegate steps thread the same task input unchanged (extraction adds the review yield)"

--- a/components/workflow-loader/test/psi/workflow_loader/workflow_definitions_test.clj
+++ b/components/workflow-loader/test/psi/workflow_loader/workflow_definitions_test.clj
@@ -85,206 +85,167 @@
 ;;; ---------------------------------------------------------------------------
 ;;; review-task-design
 
-(defn- prompt-group-template-text
-  [prompt-group]
-  (->> (:contributions prompt-group)
-       (filter #(= :template (:type %)))
-       (map :text)
-       (apply str)))
+(defn- assert-design-core-shape
+  [definitions workflow-name]
+  (let [steps (get-in definitions [workflow-name :steps])]
+    (is (= 3 (count steps)))
+    (is (= ["design-review" "design-follow-up" "status-not-converged"]
+           (mapv :name steps)))
+    (is (= [:session :session :session]
+           (mapv :type steps)))
+    (let [step-by-name (into {} (map (juxt :name identity) steps))
+          design-review (get step-by-name "design-review")
+          design-follow-up (get step-by-name "design-follow-up")]
+      (is (= ["read" "bash" "edit" "write"] (:tools design-review)))
+      (is (= ["work-independently" "review-task-architecture" "task-design"]
+             (:skills design-review)))
+      (is (= ["architecture" "ambiguity" "inconsistency"]
+             (mapv :name (:prompts design-review))))
+      (is (= {:type :invoke
+              :operation "workflow/pass-feedback-routing"
+              :args {:architecture-text {:from {:step "design-review"
+                                                :prompt "architecture"
+                                                :output :final-llm-reply}}
+                     :ambiguity-text {:from {:step "design-review"
+                                             :prompt "ambiguity"
+                                             :output :final-llm-reply}}
+                     :inconsistency-text {:from {:step "design-review"
+                                                 :prompt "inconsistency"
+                                                 :output :final-llm-reply}}}}
+             (:judge design-review)))
+      (is (= {"REPEAT" {:goto "design-follow-up"}
+              "DONE" {:goto :done}}
+             (:on design-review)))
+      (is (= (constant-routing-judge "DONE") (:judge design-follow-up)))
+      (is (= {"DONE" {:goto "design-review"
+                      :max-iterations 6
+                      :on-max-iterations "status-not-converged"}}
+             (:on design-follow-up)))
+      (let [text (step-template-text design-follow-up)]
+        (is (.contains text "design-steps.md"))
+        (is (.contains text "design.md"))
+        (is (.contains text "SCOPE_QUESTION:"))))))
 
-(deftest review-task-design-test
+(deftest review-task-design-core-test
   (load-edn-with-md-refs
-   "review-task-design.edn"
+   "review-task-design-core.edn"
    ["review-task-design-architecture-review.md"
     "review-task-design-ambiguity-review.md"
     "review-task-design-inconsistency-review.md"
     "review-follow-up-design.md"]
    (fn [{:keys [definitions errors]}]
-     (testing "loads without error"
+     (is (empty? errors))
+     (is (contains? definitions "review-task-design-core"))
+     (assert-design-core-shape definitions "review-task-design-core"))))
+
+(deftest review-task-design-test
+  (load-edn-only
+   "review-task-design.edn"
+   (fn [{:keys [definitions errors]}]
+     (testing "loads standalone wrapper without error"
        (is (empty? errors))
        (is (contains? definitions "review-task-design")))
-     (let [steps (get-in definitions ["review-task-design" :steps])]
-       (testing "has merged review topology with a not-converged handback before the converged summary (DI-2)"
-         (is (= 4 (count steps)))
-         (is (= ["design-review" "design-follow-up"
-                 "final-summary-not-converged" "final-summary"]
-                (mapv :name steps)))
-         (is (= [:session :session :session :session]
-                (mapv :type steps))))
-       (let [step-by-name (into {} (map (juxt :name identity) steps))
-             design-review (get step-by-name "design-review")
-             design-follow-up (get step-by-name "design-follow-up")
-             not-converged-step (get step-by-name "final-summary-not-converged")
-             final-step (get step-by-name "final-summary")]
-         (testing "design-review carries shared step-level capabilities"
-           (is (= ["read" "bash" "edit" "write"]
-                  (:tools design-review)))
-           (is (= ["work-independently" "review-task-architecture" "task-design"]
-                  (:skills design-review))))
-         (testing "design-review contains ordered prompt groups imported from the review prompt workflows"
-           (is (= ["architecture" "ambiguity" "inconsistency"]
-                  (mapv :name (:prompts design-review))))
-           (is (.contains (slurp-workflow-file "review-task-design.edn")
-                          ":prompt-workflow \"review-task-design-architecture-review.md\""))
-           (is (.contains (slurp-workflow-file "review-task-design.edn")
-                          ":prompt-workflow \"review-task-design-ambiguity-review.md\""))
-           (is (.contains (slurp-workflow-file "review-task-design.edn")
-                          ":prompt-workflow \"review-task-design-inconsistency-review.md\""))
-           (is (.contains (prompt-group-template-text (first (:prompts design-review)))
-                          "first turn of the shared `design-review` multi-prompt session"))
-           (is (.contains (prompt-group-template-text (second (:prompts design-review)))
-                          "Use the already-loaded task design.md"))
-           (is (.contains (prompt-group-template-text (nth (:prompts design-review) 2))
-                          "Use the already-loaded task design.md")))
-         (testing "design-review routes directly from validated per-prompt output refs"
-           (is (= {:type :invoke
-                   :operation "workflow/pass-feedback-routing"
-                   :args {:architecture-text {:from {:step "design-review"
-                                                     :prompt "architecture"
-                                                     :output :final-llm-reply}}
-                          :ambiguity-text {:from {:step "design-review"
-                                                  :prompt "ambiguity"
-                                                  :output :final-llm-reply}}
-                          :inconsistency-text {:from {:step "design-review"
-                                                      :prompt "inconsistency"
-                                                      :output :final-llm-reply}}}}
-                  (:judge design-review)))
-           (is (= {"REPEAT" {:goto "design-follow-up"}
-                   "DONE" {:goto "final-summary"}}
-                  (:on design-review))))
-         (testing "design-follow-up uses the shared design profile and loops to the review-pass target with author-routed exhaustion"
-           (is (= (constant-routing-judge "DONE")
-                  (:judge design-follow-up)))
-           (is (= {"DONE" {:goto "design-review"
-                           :max-iterations 3
-                           :on-max-iterations "final-summary-not-converged"}}
-                  (:on design-follow-up)))
-           (let [text (step-template-text design-follow-up)]
-             (is (.contains text "design-steps.md"))
-             (is (.contains text "immediately preceding whole `design-review` batch"))
-             (is (.contains text "git diff <baseline>..HEAD -- <task>/design-steps.md"))
-             (is (.contains text "Do not touch plan.md or steps.md"))
-             (is (not (.contains text "code, tests, and docs")))
-             (is (not (.contains text "design.md as read-only context")))))
-         (testing "final-summary sources each review text through per-prompt outputs"
-           (is (some? final-step) "final-summary step should exist")
-           (is (seq (:contributions final-step)) "final-summary step should have inline contributions")
-           (doseq [source-ref [{:step "design-review" :prompt "architecture" :output :final-llm-reply}
-                               {:step "design-review" :prompt "ambiguity" :output :final-llm-reply}
-                               {:step "design-review" :prompt "inconsistency" :output :final-llm-reply}]]
-             (is (some #(= {:type :source :from source-ref} %)
-                       (:contributions final-step))
-                 (str "final-summary should include " source-ref)))
-           (is (not-any? #(and (map? (:from %))
-                               (contains? (:from %) :yield))
-                         (filter #(= :source (:type %)) (:contributions final-step)))
-               "final-summary must not use per-prompt :yield refs"))
-         (testing "converged + not-converged summaries: terminal, DI-4 PASS_STATUS, shared sources"
-           (assert-review-summary-handback
-            final-step not-converged-step
-            [{:step "design-review" :prompt "architecture" :output :final-llm-reply}
-             {:step "design-review" :prompt "ambiguity" :output :final-llm-reply}
-             {:step "design-review" :prompt "inconsistency" :output :final-llm-reply}]))
-         (testing "removed per-phase topology step names are absent"
-           (doseq [removed ["architecture-review" "architecture-follow-up"
-                            "ambiguity-review" "ambiguity-follow-up"
-                            "inconsistency-review" "inconsistency-follow-up"
-                            "clarity-status"]]
-             (is (not (contains? step-by-name removed))
-                 (str removed " should not remain as a step")))))))))
+     (let [steps (get-in definitions ["review-task-design" :steps])
+           step-by-name (into {} (map (juxt :name identity) steps))
+           core-step (get step-by-name "review-task-design-core")
+           final-step (get step-by-name "final-summary")
+           not-converged-step (get step-by-name "final-summary-not-converged")]
+       (is (= ["review-task-design-core" "final-summary-not-converged" "final-summary"]
+              (mapv :name steps)))
+       (is (= [:delegate :session :session] (mapv :type steps)))
+       (is (= "review-task-design-core" (:target core-step)))
+       (is (= {:type :map :fields {:input {:from :workflow-input :path [:input]}}}
+              (:prompt-string core-step)))
+       (is (= {:type :invoke
+               :operation "workflow/pass-status-routing"
+               :args {:text {:from {:step "review-task-design-core" :yield :text}}
+                      :allowed-statuses ["ACTIONABLE_FEEDBACK" "REVIEW_COMPLETE"]}}
+              (:judge core-step)))
+       (is (= {"DONE" {:goto "final-summary"}
+               "REPEAT" {:goto "final-summary-not-converged"}}
+              (:on core-step)))
+       (assert-review-summary-handback
+        final-step not-converged-step
+        [{:step "review-task-design-core" :yield :text}])))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; review-task-plan
 
-(deftest review-task-plan-test
+(defn- assert-plan-core-shape
+  [definitions workflow-name]
+  (let [steps (get-in definitions [workflow-name :steps])
+        step-by-name (into {} (map (juxt :name identity) steps))
+        plan-review (get step-by-name "plan-review")
+        plan-follow-up (get step-by-name "plan-follow-up")]
+    (is (= ["plan-review" "plan-follow-up" "status-not-converged"]
+           (mapv :name steps)))
+    (is (= [:session :session :session]
+           (mapv :type steps)))
+    (is (= ["read" "bash" "edit" "write"] (:tools plan-review)))
+    (is (= ["work-independently" "task-design"] (:skills plan-review)))
+    (is (= ["ambiguity" "inconsistency"] (mapv :name (:prompts plan-review))))
+    (is (= {:type :invoke
+            :operation "workflow/pass-feedback-routing"
+            :args {:ambiguity-text {:from {:step "plan-review"
+                                           :prompt "ambiguity"
+                                           :output :final-llm-reply}}
+                   :inconsistency-text {:from {:step "plan-review"
+                                               :prompt "inconsistency"
+                                               :output :final-llm-reply}}}}
+           (:judge plan-review)))
+    (is (= {"REPEAT" {:goto "plan-follow-up"}
+            "DONE" {:goto :done}}
+           (:on plan-review)))
+    (is (= (constant-routing-judge "DONE") (:judge plan-follow-up)))
+    (is (= {"DONE" {:goto "plan-review"
+                    :max-iterations 5
+                    :on-max-iterations "status-not-converged"}}
+           (:on plan-follow-up)))
+    (let [text (step-template-text plan-follow-up)]
+      (is (.contains text "design-steps.md"))
+      (is (.contains text "plan.md"))
+      (is (.contains text "steps.md")))))
+
+(deftest review-task-plan-core-test
   (load-edn-with-md-refs
-   "review-task-plan.edn"
+   "review-task-plan-core.edn"
    ["review-task-plan-ambiguity-review.md"
     "review-task-plan-inconsistency-review.md"
     "review-follow-up-plan.md"]
    (fn [{:keys [definitions errors]}]
-     (testing "loads without error"
+     (is (empty? errors))
+     (is (contains? definitions "review-task-plan-core"))
+     (assert-plan-core-shape definitions "review-task-plan-core"))))
+
+(deftest review-task-plan-test
+  (load-edn-only
+   "review-task-plan.edn"
+   (fn [{:keys [definitions errors]}]
+     (testing "loads standalone wrapper without error"
        (is (empty? errors))
        (is (contains? definitions "review-task-plan")))
-     (let [steps (get-in definitions ["review-task-plan" :steps])]
-       (testing "has merged review topology with a not-converged handback before the converged summary (DI-2)"
-         (is (= 4 (count steps)))
-         (is (= ["plan-review" "plan-follow-up"
-                 "final-summary-not-converged" "final-summary"]
-                (mapv :name steps)))
-         (is (= [:session :session :session :session]
-                (mapv :type steps))))
-       (let [step-by-name (into {} (map (juxt :name identity) steps))
-             plan-review (get step-by-name "plan-review")
-             plan-follow-up (get step-by-name "plan-follow-up")
-             not-converged-step (get step-by-name "final-summary-not-converged")
-             final-step (get step-by-name "final-summary")]
-         (testing "plan-review carries shared step-level capabilities"
-           (is (= ["read" "bash" "edit" "write"]
-                  (:tools plan-review)))
-           (is (= ["work-independently" "task-design"]
-                  (:skills plan-review))))
-         (testing "plan-review contains ordered prompt groups imported from the review prompt workflows"
-           (is (= ["ambiguity" "inconsistency"]
-                  (mapv :name (:prompts plan-review))))
-           (is (.contains (slurp-workflow-file "review-task-plan.edn")
-                          ":prompt-workflow \"review-task-plan-ambiguity-review.md\""))
-           (is (.contains (slurp-workflow-file "review-task-plan.edn")
-                          ":prompt-workflow \"review-task-plan-inconsistency-review.md\""))
-           (is (.contains (prompt-group-template-text (first (:prompts plan-review)))
-                          "first turn of the shared `plan-review` multi-prompt session"))
-           (is (.contains (prompt-group-template-text (second (:prompts plan-review)))
-                          "Use the already-loaded task plan.md")))
-         (testing "plan-review routes directly from validated per-prompt output refs"
-           (is (= {:type :invoke
-                   :operation "workflow/pass-feedback-routing"
-                   :args {:ambiguity-text {:from {:step "plan-review"
-                                                  :prompt "ambiguity"
-                                                  :output :final-llm-reply}}
-                          :inconsistency-text {:from {:step "plan-review"
-                                                      :prompt "inconsistency"
-                                                      :output :final-llm-reply}}}}
-                  (:judge plan-review)))
-           (is (= {"REPEAT" {:goto "plan-follow-up"}
-                   "DONE" {:goto "final-summary"}}
-                  (:on plan-review))))
-         (testing "plan-follow-up uses the batch plan profile and loops to the review-pass target with author-routed exhaustion"
-           (is (= (constant-routing-judge "DONE")
-                  (:judge plan-follow-up)))
-           (is (= {"DONE" {:goto "plan-review"
-                           :max-iterations 5
-                           :on-max-iterations "final-summary-not-converged"}}
-                  (:on plan-follow-up)))
-           (let [text (step-template-text plan-follow-up)]
-             ;; #177 routes plan-review follow-ups through shared design-steps.md.
-             (is (.contains text "design-steps.md"))
-             (is (.contains text "immediately preceding whole `plan-review` batch"))
-             (is (.contains text "git diff <baseline>..HEAD -- <task>/design-steps.md"))
-             (is (.contains text "predate the preceding review pass"))
-             (is (.contains text "code, tests, and docs"))
-             (is (.contains text "design.md as read-only context"))))
-         (testing "final-summary sources each review text through per-prompt outputs"
-           (is (some? final-step) "final-summary step should exist")
-           (is (seq (:contributions final-step)) "final-summary step should have inline contributions")
-           (doseq [source-ref [{:step "plan-review" :prompt "ambiguity" :output :final-llm-reply}
-                               {:step "plan-review" :prompt "inconsistency" :output :final-llm-reply}]]
-             (is (some #(= {:type :source :from source-ref} %)
-                       (:contributions final-step))
-                 (str "final-summary should include " source-ref)))
-           (is (not-any? #(and (map? (:from %))
-                               (contains? (:from %) :yield))
-                         (filter #(= :source (:type %)) (:contributions final-step)))
-               "final-summary must not use per-prompt :yield refs"))
-         (testing "converged + not-converged summaries: terminal, DI-4 PASS_STATUS, shared sources"
-           (assert-review-summary-handback
-            final-step not-converged-step
-            [{:step "plan-review" :prompt "ambiguity" :output :final-llm-reply}
-             {:step "plan-review" :prompt "inconsistency" :output :final-llm-reply}]))
-         (testing "removed per-phase topology step names are absent"
-           (doseq [removed ["ambiguity-review" "ambiguity-follow-up"
-                            "inconsistency-review" "inconsistency-follow-up"
-                            "clarity-status"]]
-             (is (not (contains? step-by-name removed))
-                 (str removed " should not remain as a step")))))))))
+     (let [steps (get-in definitions ["review-task-plan" :steps])
+           step-by-name (into {} (map (juxt :name identity) steps))
+           core-step (get step-by-name "review-task-plan-core")
+           final-step (get step-by-name "final-summary")
+           not-converged-step (get step-by-name "final-summary-not-converged")]
+       (is (= ["review-task-plan-core" "final-summary-not-converged" "final-summary"]
+              (mapv :name steps)))
+       (is (= [:delegate :session :session] (mapv :type steps)))
+       (is (= "review-task-plan-core" (:target core-step)))
+       (is (= {:type :map :fields {:input {:from :workflow-input :path [:input]}}}
+              (:prompt-string core-step)))
+       (is (= {:type :invoke
+               :operation "workflow/pass-status-routing"
+               :args {:text {:from {:step "review-task-plan-core" :yield :text}}
+                      :allowed-statuses ["ACTIONABLE_FEEDBACK" "REVIEW_COMPLETE"]}}
+              (:judge core-step)))
+       (is (= {"DONE" {:goto "final-summary"}
+               "REPEAT" {:goto "final-summary-not-converged"}}
+              (:on core-step)))
+       (assert-review-summary-handback
+        final-step not-converged-step
+        [{:step "review-task-plan-core" :yield :text}])))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; review task prompt artifact targets
@@ -340,24 +301,51 @@
 ;;; ---------------------------------------------------------------------------
 ;;; review-task-implementation
 
+(defn- assert-implementation-core-shape
+  [definitions workflow-name]
+  (let [steps (get-in definitions [workflow-name :steps])]
+    (is (= 5 (count steps)))
+    (is (= ["review-task-implementation"
+            "review-task-tests"
+            "review-test-shape"
+            "review-task-docs"
+            "review-code-shape"]
+           (mapv :name steps)))
+    (is (= [:delegate :delegate :delegate :delegate :delegate]
+           (mapv :type steps)))))
+
+(deftest review-task-implementation-core-test
+  (load-edn-only
+   "review-task-implementation-core.edn"
+   (fn [{:keys [definitions errors]}]
+     (is (empty? errors))
+     (is (contains? definitions "review-task-implementation-core"))
+     (assert-implementation-core-shape definitions "review-task-implementation-core"))))
+
 (deftest review-task-implementation-test
   (load-edn-only
    "review-task-implementation.edn"
    (fn [{:keys [definitions errors]}]
-     (testing "loads without error"
+     (testing "loads standalone wrapper without error"
        (is (empty? errors))
        (is (contains? definitions "review-task-implementation")))
-     (let [steps (get-in definitions ["review-task-implementation" :steps])]
-       (testing "has 5 steps with correct names and types"
-         (is (= 5 (count steps)))
-         (is (= ["review-task-implementation"
-                 "review-task-tests"
-                 "review-test-shape"
-                 "review-task-docs"
-                 "review-code-shape"]
-                (mapv :name steps)))
-         (is (= [:delegate :delegate :delegate :delegate :delegate]
-                (mapv :type steps))))))))
+     (let [steps (get-in definitions ["review-task-implementation" :steps])
+           core-step (first steps)
+           final-step (second steps)]
+       (is (= ["review-task-implementation-core" "final-summary"]
+              (mapv :name steps)))
+       (is (= [:delegate :session] (mapv :type steps)))
+       (is (= "review-task-implementation-core" (:target core-step)))
+       (is (= {:type :map :fields {:input {:from :workflow-input :path [:input]}}}
+              (:prompt-string core-step)))
+       (is (some #(= {:type :source
+                      :from {:step "review-task-implementation-core" :yield :text}} %)
+                 (:contributions final-step)))
+       (is (= (constant-routing-judge "DONE") (:judge final-step)))
+       (is (= {"DONE" {:goto :done}} (:on final-step)))
+       (assert-sole-final-pass-status-line
+        (step-template-text final-step)
+        "REVIEW_COMPLETE")))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; create-task-plan


### PR DESCRIPTION
## Summary
- streamline review follow-up prompts to focus on unchecked design-step follow-ups
- simplify review workflow routing/session configuration
- keep design-review loop cap at 6 after rebase conflict resolution

## Validation
- clj-kondo --lint .psi/workflows/review-task-design.edn .psi/workflows/review-step.edn .psi/workflows/review-task-implementation.edn