### PR TITLE
Streamline review process prompts

### DIFF
--- a/.psi/workflows/review-task-design-ambiguity-review.md
+++ b/.psi/workflows/review-task-design-ambiguity-review.md
@@ -18,10 +18,9 @@ Review the task design for ambiguities. Do not review plan.md or steps.md.
 
 Then:
 
-1. append a terse review note on the outcome of the review to the task's implementation.md
-1a. Do not note compliance with these instructions; only note any non-compliance
-2. add unchecked follow-up items to design-steps.md for every new actionable ambiguity you found (create design-steps.md if it does not exist)
-3. avoid duplicating review notes or steps that already exist
+1. add unchecked follow-up items to design-steps.md for every new actionable ambiguity you found (create design-steps.md if it does not exist)
+2. append a minimalist review note on the outcome of the review to the task's implementation.md, e.g. "- no ambiguity review feedback" or "- ambiguity review added 2 new design steps"
+3. avoid duplicating review notes or design-steps that already exist
 4. commit
 5. if there is no new actionable ambiguity feedback, say so explicitly
 

--- a/.psi/workflows/review-task-design-architecture-review.md
+++ b/.psi/workflows/review-task-design-architecture-review.md
@@ -18,9 +18,9 @@ Review the task design for architectural fit with the project's architecture and
 
 Then:
 
-1. append a terse review note to the task's implementation.md
-2. add unchecked follow-up items to design-steps.md for every new actionable architectural misfit you found (create design-steps.md if it does not exist)
-3. avoid duplicating review notes or steps that already exist
+1. add unchecked follow-up items to design-steps.md for every new actionable architectural misfit you found (create design-steps.md if it does not exist)
+2. append a minimalist review note to the task's implementation.md, e.g. "- no architectural review feedback" or "- architectural review added 2 new design steps"
+3. avoid duplicating review notes or design-steps that already exist
 4. commit
 5. if there is no new actionable architectural-fit feedback, say so explicitly
 

--- a/.psi/workflows/review-task-design-inconsistency-review.md
+++ b/.psi/workflows/review-task-design-inconsistency-review.md
@@ -18,9 +18,8 @@ Review the task design for inconsistencies, focusing on internal inconsistency w
 
 Then:
 
-1. append a terse review note on the outcome of the review to the task's implementation.md
-1a. Do not note compliance with these instructions; only note any non-compliance
-2. add unchecked follow-up items to design-steps.md for every new actionable inconsistency you found (create design-steps.md if it does not exist)
+1. add unchecked follow-up items to design-steps.md for every new actionable inconsistency you found (create design-steps.md if it does not exist)
+2. append a minimalist review note on the outcome of the review to the task's implementation.md, e.g. "- no inconsistency review feedback" or "- inconsistency review added 2 new design steps"
 3. avoid duplicating review notes or steps that already exist
 4. commit
 5. if there is no new actionable inconsistency feedback, say so explicitly

--- a/.psi/workflows/review-task-plan-ambiguity-review.md
+++ b/.psi/workflows/review-task-plan-ambiguity-review.md
@@ -15,9 +15,7 @@ For the Munera task identified by {{input}}, run the ambiguity review as the fir
 Review the task plan and steps for ambiguities, treating steps.md as read-only task context. Then:
 
 1. add unchecked follow-up items to design-steps.md for every new actionable ambiguity you found (create design-steps.md if it does not exist)
-2. append a terse review note to the task's implementation.md
-   Do not note compliance with these instructions; only note any non-compliance.
-   Do not duplicate information that is already in the design-steps.
+2. append a minimalist review note on the outcome of the review to the task's implementation.md, e.g. "- no ambiguity review feedback" or "- ambiguity review added 2 new design steps"
 3. avoid duplicating review notes or design-steps that already exist
 4. commit
 5. if there is no new actionable ambiguity feedback, say so explicitly

--- a/.psi/workflows/review-task-plan-inconsistency-review.md
+++ b/.psi/workflows/review-task-plan-inconsistency-review.md
@@ -15,9 +15,7 @@ For the Munera task identified by {{input}}, run the inconsistency review as the
 Review the task plan and steps for inconsistencies, focusing on inconsistency across task files, treating steps.md as read-only task context. Then:
 
 1. add unchecked follow-up items to design-steps.md for every new actionable inconsistency you found (create design-steps.md if it does not exist)
-2. append a terse review note to the task's implementation.md
-   Do not note compliance with these instructions; only note any non-compliance.
-   Do not duplicate information that is already in the design-steps.
+2. append a minimalist review note on the outcome of the review to the task's implementation.md, e.g. "- no inconsistency review feedback" or "- inconsistency review added 2 new design steps"
 3. avoid duplicating review notes or design-steps that already exist
 4. commit
 5. if there is no new actionable inconsistency feedback, say so explicitly


### PR DESCRIPTION
## Summary
- Make design and plan review prompts add follow-up items before writing review notes
- Use minimalist review-note examples for no-feedback and added-step outcomes
- Remove extra compliance-note instructions from review prompts

## Testing
- Not run; prompt-only change